### PR TITLE
feat: 건물 등록 CRUD 기초 기능 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/saferoute/domain/building/controller/BuildingController.java
@@ -1,0 +1,69 @@
+package com.saferoute.domain.building.controller;
+
+import com.saferoute.domain.building.dto.response.BuildingResponse;
+import com.saferoute.domain.building.dto.request.CreateBuildingRequest;
+import com.saferoute.domain.building.dto.request.UpdateBuildingRequest;
+import com.saferoute.domain.building.service.BuildingService;
+import com.saferoute.global.response.ApiResponse;
+import jakarta.validation.Valid;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/buildings")
+@RequiredArgsConstructor
+public class BuildingController {
+
+    private final BuildingService buildingService;
+
+    // 건물 등록
+    @PostMapping
+    public ResponseEntity<ApiResponse<BuildingResponse>> createBuilding(
+            @Valid @RequestBody CreateBuildingRequest request) {
+        BuildingResponse response = buildingService.createBuilding(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("건물 등록에 성공했습니다.", response));
+    }
+
+    // 건물 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<BuildingResponse>>> getBuildings() {
+        return ResponseEntity.ok(ApiResponse.success(buildingService.getBuildings()));
+    }
+
+    // 건물 상세 조회
+    @GetMapping("/{buildingId}")
+    public ResponseEntity<ApiResponse<BuildingResponse>> getBuilding(@PathVariable UUID buildingId) {
+        return ResponseEntity.ok(ApiResponse.success(buildingService.getBuilding(buildingId)));
+    }
+
+    // 건물 정보 수정
+    @PutMapping("/{buildingId}")
+    public ResponseEntity<ApiResponse<BuildingResponse>> updateBuilding(
+            @PathVariable UUID buildingId,
+            @Valid @RequestBody UpdateBuildingRequest request
+    ) {
+        BuildingResponse response = buildingService.updateBuilding(buildingId, request);
+        return ResponseEntity.ok(ApiResponse.success("건물 정보 수정에 성공했습니다.", response));
+    }
+
+    // 건물 비활성화 (삭제 대신 비활성 처리)
+    @PatchMapping("/{buildingId}/deactivate")
+    public ResponseEntity<ApiResponse<Void>> deactivateBuilding(@PathVariable UUID buildingId) {
+        buildingService.deactivateBuilding(buildingId);
+        return ResponseEntity.ok(ApiResponse.success("건물이 비활성화되었습니다.", null));
+    }
+
+    // 건물 삭제
+    @DeleteMapping("/{buildingId}")
+    public ResponseEntity<ApiResponse<Void>> deleteBuilding(@PathVariable UUID buildingId) {
+        buildingService.deleteBuilding(buildingId);
+        return ResponseEntity.ok(ApiResponse.success("건물이 삭제되었습니다.", null));
+    }
+}

--- a/src/main/java/com/saferoute/domain/building/dto/CreateBuildingRequest.java
+++ b/src/main/java/com/saferoute/domain/building/dto/CreateBuildingRequest.java
@@ -1,0 +1,14 @@
+package com.saferoute.domain.building.dto;
+
+import com.saferoute.domain.building.entity.BuildingType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+// 건물 등록 요청
+public record CreateBuildingRequest(
+        @NotBlank @Size(min = 2, max = 20) String name,
+        @NotBlank @Size(min = 8, max = 100) String address,
+        @NotNull Integer totalFloors,
+        @NotNull BuildingType buildingType
+) {}

--- a/src/main/java/com/saferoute/domain/building/dto/request/CreateBuildingRequest.java
+++ b/src/main/java/com/saferoute/domain/building/dto/request/CreateBuildingRequest.java
@@ -1,4 +1,4 @@
-package com.saferoute.domain.building.dto;
+package com.saferoute.domain.building.dto.request;
 
 import com.saferoute.domain.building.entity.BuildingType;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/saferoute/domain/building/dto/request/UpdateBuildingRequest.java
+++ b/src/main/java/com/saferoute/domain/building/dto/request/UpdateBuildingRequest.java
@@ -1,0 +1,14 @@
+package com.saferoute.domain.building.dto.request;
+
+import com.saferoute.domain.building.entity.BuildingType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+// 건물 정보 수정 요청
+public record UpdateBuildingRequest(
+        @NotBlank @Size(min = 2, max = 20) String name,
+        @NotBlank @Size(min = 8, max = 100) String address,
+        @NotNull Integer totalFloors,
+        @NotNull BuildingType buildingType
+) {}

--- a/src/main/java/com/saferoute/domain/building/dto/response/BuildingResponse.java
+++ b/src/main/java/com/saferoute/domain/building/dto/response/BuildingResponse.java
@@ -1,0 +1,32 @@
+package com.saferoute.domain.building.dto.response;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record BuildingResponse(
+        UUID id,
+        String name,
+        String address,
+        Integer totalFloors,
+        BuildingType buildingType,
+        Boolean isActive,
+        Instant lastTrainedAt,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static BuildingResponse from(Building building) {
+        return new BuildingResponse(
+                building.getId(),
+                building.getName(),
+                building.getAddress(),
+                building.getTotalFloors(),
+                building.getBuildingType(),
+                building.getIsActive(),
+                building.getLastTrainedAt(),
+                building.getCreatedAt(),
+                building.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/building/entity/Building.java
+++ b/src/main/java/com/saferoute/domain/building/entity/Building.java
@@ -1,4 +1,4 @@
-package com.saferoute.domain.building;
+package com.saferoute.domain.building.entity;
 
 import com.saferoute.domain.training.entity.TrainingScenario;
 import jakarta.persistence.CascadeType;

--- a/src/main/java/com/saferoute/domain/building/entity/BuildingType.java
+++ b/src/main/java/com/saferoute/domain/building/entity/BuildingType.java
@@ -1,4 +1,4 @@
-package com.saferoute.domain.building;
+package com.saferoute.domain.building.entity;
 
 public enum BuildingType {
     CLASSROOM,

--- a/src/main/java/com/saferoute/domain/building/exception/BuildingNotFoundException.java
+++ b/src/main/java/com/saferoute/domain/building/exception/BuildingNotFoundException.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.building.exception;
+
+import com.saferoute.global.exception.BusinessException;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class BuildingNotFoundException extends BusinessException {
+    public BuildingNotFoundException(UUID buildingId) {
+        super(HttpStatus.NOT_FOUND, "건물을 찾을 수 없습니다: " + buildingId);
+    }
+}

--- a/src/main/java/com/saferoute/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/saferoute/domain/building/repository/BuildingRepository.java
@@ -1,0 +1,9 @@
+package com.saferoute.domain.building.repository;
+
+import com.saferoute.domain.building.entity.Building;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BuildingRepository
+        extends JpaRepository<Building, UUID> {
+}

--- a/src/main/java/com/saferoute/domain/building/service/BuildingService.java
+++ b/src/main/java/com/saferoute/domain/building/service/BuildingService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class BuildingService {
 
     private final BuildingRepository buildingRepository;

--- a/src/main/java/com/saferoute/domain/building/service/BuildingService.java
+++ b/src/main/java/com/saferoute/domain/building/service/BuildingService.java
@@ -1,0 +1,64 @@
+package com.saferoute.domain.building.service;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.dto.response.BuildingResponse;
+import com.saferoute.domain.building.dto.request.CreateBuildingRequest;
+import com.saferoute.domain.building.dto.request.UpdateBuildingRequest;
+import com.saferoute.domain.building.exception.BuildingNotFoundException;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BuildingService {
+
+    private final BuildingRepository buildingRepository;
+
+    @Transactional
+    public BuildingResponse createBuilding(CreateBuildingRequest request) {
+        Building building = Building.create(
+                request.name(),
+                request.address(),
+                request.totalFloors(),
+                request.buildingType()
+        );
+        return BuildingResponse.from(buildingRepository.save(building));
+    }
+
+    public List<BuildingResponse> getBuildings() {
+        return buildingRepository.findAll().stream()
+                .map(BuildingResponse::from)
+                .toList();
+    }
+
+    public BuildingResponse getBuilding(UUID buildingId) {
+        return BuildingResponse.from(findBuildingById(buildingId));
+    }
+
+    @Transactional
+    public BuildingResponse updateBuilding(UUID buildingId, UpdateBuildingRequest request) {
+        Building building = findBuildingById(buildingId);
+        building.update(request.name(), request.address(), request.totalFloors(), request.buildingType());
+        return BuildingResponse.from(building);
+    }
+
+    @Transactional
+    public void deactivateBuilding(UUID buildingId) {
+        findBuildingById(buildingId).deactivate();
+    }
+
+    @Transactional
+    public void deleteBuilding(UUID buildingId) {
+        buildingRepository.delete(findBuildingById(buildingId));
+    }
+
+    private Building findBuildingById(UUID buildingId) {
+        return buildingRepository.findById(buildingId)
+                .orElseThrow(() -> new BuildingNotFoundException(buildingId));
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -1,6 +1,6 @@
 package com.saferoute.domain.training.entity;
 
-import com.saferoute.domain.building.Building;
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.user.entity.User;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -1,6 +1,6 @@
 package com.saferoute.domain.training.service;
 
-import com.saferoute.domain.building.Building;
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -15,10 +15,14 @@ public class SecurityConfig {
 
         http
                 .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.disable())
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**"
+                                "/v3/api-docs/**",
+                                "/h2-console/**"
                         ).permitAll()
                         .anyRequest().permitAll()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
   h2:
     console:
       enabled: true
+      path: /h2-console
 
   jpa:
     hibernate:

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -1,6 +1,6 @@
 package com.saferoute.domain.training.service;
 
-import com.saferoute.domain.building.Building;
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;


### PR DESCRIPTION
📌 Issue
Resolves #5 

## 작업 내용

- 건물 목록 조회(`GET /api/v1/buildings`): 등록된 전체 건물 목록 반환
- 건물 상세 조회(`GET /api/v1/buildings/{buildingId}`): 건물 ID로 단건 조회
- 건물 등록(`POST /api/v1/buildings`): 건물명/주소/층수/건물타입 입력 후 저장
- 건물 수정(`PUT /api/v1/buildings/{buildingId}`): 건물 기본 정보 수정
- 건물 비활성화(`PATCH /api/v1/buildings/{buildingId}/deactivate`): 삭제 없이 `isActive=false` 처리
- 건물 삭제(`DELETE /api/v1/buildings/{buildingId}`): 건물 및 연관 데이터 하드 삭제
- `BuildingNotFoundException`(404) 추가
- `buildingType` 값: `CLASSROOM` / `CAFETERIA` / `LIBRARY` / `DORMITORY` / `GYM`

## 테스트 방법
```bash
# 건물 등록
curl -X POST http://localhost:8080/api/v1/buildings 
-H "Content-Type: application/json" 
-d '{"name":"A동 본관","address":"서울특별시 강남구 테헤란로 152","totalFloors":5,"buildingType":"CLASSROOM"}'

# 건물 목록 조회
curl -X GET http://localhost:8080/api/v1/buildings

#건물 상세 조회
curl -X GET http://localhost:8080/api/v1/buildings/{buildingId}

# 건물 수정
curl -X PUT http://localhost:8080/api/v1/buildings/{buildingId}
-H "Content-Type: application/json" 
-d '{"name":"A동 본관","address":"서울특별시 강남구 테헤란로 152","totalFloors":6,"buildingType":"CLASSROOM"}'

# 건물 비활성화
curl -X PATCH http://localhost:8080/api/v1/buildings/{buildingId}/deactivate

# 건물 삭제
curl -X DELETE http://localhost:8080/api/v1/buildings/{buildingId}