### PR TITLE
feat: 도면 관리 CRUD 기초 기능 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/saferoute/domain/building/controller/BuildingController.java
@@ -1,0 +1,69 @@
+package com.saferoute.domain.building.controller;
+
+import com.saferoute.domain.building.dto.response.BuildingResponse;
+import com.saferoute.domain.building.dto.request.CreateBuildingRequest;
+import com.saferoute.domain.building.dto.request.UpdateBuildingRequest;
+import com.saferoute.domain.building.service.BuildingService;
+import com.saferoute.global.response.ApiResponse;
+import jakarta.validation.Valid;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/buildings")
+@RequiredArgsConstructor
+public class BuildingController {
+
+    private final BuildingService buildingService;
+
+    // 건물 등록
+    @PostMapping
+    public ResponseEntity<ApiResponse<BuildingResponse>> createBuilding(
+            @Valid @RequestBody CreateBuildingRequest request) {
+        BuildingResponse response = buildingService.createBuilding(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("건물 등록에 성공했습니다.", response));
+    }
+
+    // 건물 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<BuildingResponse>>> getBuildings() {
+        return ResponseEntity.ok(ApiResponse.success(buildingService.getBuildings()));
+    }
+
+    // 건물 상세 조회
+    @GetMapping("/{buildingId}")
+    public ResponseEntity<ApiResponse<BuildingResponse>> getBuilding(@PathVariable UUID buildingId) {
+        return ResponseEntity.ok(ApiResponse.success(buildingService.getBuilding(buildingId)));
+    }
+
+    // 건물 정보 수정
+    @PutMapping("/{buildingId}")
+    public ResponseEntity<ApiResponse<BuildingResponse>> updateBuilding(
+            @PathVariable UUID buildingId,
+            @Valid @RequestBody UpdateBuildingRequest request
+    ) {
+        BuildingResponse response = buildingService.updateBuilding(buildingId, request);
+        return ResponseEntity.ok(ApiResponse.success("건물 정보 수정에 성공했습니다.", response));
+    }
+
+    // 건물 비활성화 (삭제 대신 비활성 처리)
+    @PatchMapping("/{buildingId}/deactivate")
+    public ResponseEntity<ApiResponse<Void>> deactivateBuilding(@PathVariable UUID buildingId) {
+        buildingService.deactivateBuilding(buildingId);
+        return ResponseEntity.ok(ApiResponse.success("건물이 비활성화되었습니다.", null));
+    }
+
+    // 건물 삭제
+    @DeleteMapping("/{buildingId}")
+    public ResponseEntity<ApiResponse<Void>> deleteBuilding(@PathVariable UUID buildingId) {
+        buildingService.deleteBuilding(buildingId);
+        return ResponseEntity.ok(ApiResponse.success("건물이 삭제되었습니다.", null));
+    }
+}

--- a/src/main/java/com/saferoute/domain/building/dto/CreateBuildingRequest.java
+++ b/src/main/java/com/saferoute/domain/building/dto/CreateBuildingRequest.java
@@ -1,0 +1,14 @@
+package com.saferoute.domain.building.dto;
+
+import com.saferoute.domain.building.entity.BuildingType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+// 건물 등록 요청
+public record CreateBuildingRequest(
+        @NotBlank @Size(min = 2, max = 20) String name,
+        @NotBlank @Size(min = 8, max = 100) String address,
+        @NotNull Integer totalFloors,
+        @NotNull BuildingType buildingType
+) {}

--- a/src/main/java/com/saferoute/domain/building/dto/request/CreateBuildingRequest.java
+++ b/src/main/java/com/saferoute/domain/building/dto/request/CreateBuildingRequest.java
@@ -1,4 +1,4 @@
-package com.saferoute.domain.building.dto;
+package com.saferoute.domain.building.dto.request;
 
 import com.saferoute.domain.building.entity.BuildingType;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/saferoute/domain/building/dto/request/UpdateBuildingRequest.java
+++ b/src/main/java/com/saferoute/domain/building/dto/request/UpdateBuildingRequest.java
@@ -1,0 +1,14 @@
+package com.saferoute.domain.building.dto.request;
+
+import com.saferoute.domain.building.entity.BuildingType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+// 건물 정보 수정 요청
+public record UpdateBuildingRequest(
+        @NotBlank @Size(min = 2, max = 20) String name,
+        @NotBlank @Size(min = 8, max = 100) String address,
+        @NotNull Integer totalFloors,
+        @NotNull BuildingType buildingType
+) {}

--- a/src/main/java/com/saferoute/domain/building/dto/response/BuildingResponse.java
+++ b/src/main/java/com/saferoute/domain/building/dto/response/BuildingResponse.java
@@ -1,0 +1,32 @@
+package com.saferoute.domain.building.dto.response;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record BuildingResponse(
+        UUID id,
+        String name,
+        String address,
+        Integer totalFloors,
+        BuildingType buildingType,
+        Boolean isActive,
+        Instant lastTrainedAt,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static BuildingResponse from(Building building) {
+        return new BuildingResponse(
+                building.getId(),
+                building.getName(),
+                building.getAddress(),
+                building.getTotalFloors(),
+                building.getBuildingType(),
+                building.getIsActive(),
+                building.getLastTrainedAt(),
+                building.getCreatedAt(),
+                building.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/building/entity/Building.java
+++ b/src/main/java/com/saferoute/domain/building/entity/Building.java
@@ -1,4 +1,4 @@
-package com.saferoute.domain.building;
+package com.saferoute.domain.building.entity;
 
 import com.saferoute.domain.training.entity.TrainingScenario;
 import jakarta.persistence.CascadeType;

--- a/src/main/java/com/saferoute/domain/building/entity/Building.java
+++ b/src/main/java/com/saferoute/domain/building/entity/Building.java
@@ -1,5 +1,6 @@
 package com.saferoute.domain.building.entity;
 
+import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -72,6 +73,9 @@ public class Building {
 
     @OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TrainingScenario> trainingScenarios = new ArrayList<>();
+
+    @OneToMany(mappedBy = "building", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Floor> floors = new ArrayList<>();
 
     private Building(String name, String address, Integer totalFloors, BuildingType buildingType) {
         this.name = name;

--- a/src/main/java/com/saferoute/domain/building/entity/BuildingType.java
+++ b/src/main/java/com/saferoute/domain/building/entity/BuildingType.java
@@ -1,4 +1,4 @@
-package com.saferoute.domain.building;
+package com.saferoute.domain.building.entity;
 
 public enum BuildingType {
     CLASSROOM,

--- a/src/main/java/com/saferoute/domain/building/exception/BuildingNotFoundException.java
+++ b/src/main/java/com/saferoute/domain/building/exception/BuildingNotFoundException.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.building.exception;
+
+import com.saferoute.global.exception.BusinessException;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class BuildingNotFoundException extends BusinessException {
+    public BuildingNotFoundException(UUID buildingId) {
+        super(HttpStatus.NOT_FOUND, "건물을 찾을 수 없습니다: " + buildingId);
+    }
+}

--- a/src/main/java/com/saferoute/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/saferoute/domain/building/repository/BuildingRepository.java
@@ -1,0 +1,9 @@
+package com.saferoute.domain.building.repository;
+
+import com.saferoute.domain.building.entity.Building;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BuildingRepository
+        extends JpaRepository<Building, UUID> {
+}

--- a/src/main/java/com/saferoute/domain/building/service/BuildingService.java
+++ b/src/main/java/com/saferoute/domain/building/service/BuildingService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class BuildingService {
 
     private final BuildingRepository buildingRepository;

--- a/src/main/java/com/saferoute/domain/building/service/BuildingService.java
+++ b/src/main/java/com/saferoute/domain/building/service/BuildingService.java
@@ -1,0 +1,64 @@
+package com.saferoute.domain.building.service;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.dto.response.BuildingResponse;
+import com.saferoute.domain.building.dto.request.CreateBuildingRequest;
+import com.saferoute.domain.building.dto.request.UpdateBuildingRequest;
+import com.saferoute.domain.building.exception.BuildingNotFoundException;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BuildingService {
+
+    private final BuildingRepository buildingRepository;
+
+    @Transactional
+    public BuildingResponse createBuilding(CreateBuildingRequest request) {
+        Building building = Building.create(
+                request.name(),
+                request.address(),
+                request.totalFloors(),
+                request.buildingType()
+        );
+        return BuildingResponse.from(buildingRepository.save(building));
+    }
+
+    public List<BuildingResponse> getBuildings() {
+        return buildingRepository.findAll().stream()
+                .map(BuildingResponse::from)
+                .toList();
+    }
+
+    public BuildingResponse getBuilding(UUID buildingId) {
+        return BuildingResponse.from(findBuildingById(buildingId));
+    }
+
+    @Transactional
+    public BuildingResponse updateBuilding(UUID buildingId, UpdateBuildingRequest request) {
+        Building building = findBuildingById(buildingId);
+        building.update(request.name(), request.address(), request.totalFloors(), request.buildingType());
+        return BuildingResponse.from(building);
+    }
+
+    @Transactional
+    public void deactivateBuilding(UUID buildingId) {
+        findBuildingById(buildingId).deactivate();
+    }
+
+    @Transactional
+    public void deleteBuilding(UUID buildingId) {
+        buildingRepository.delete(findBuildingById(buildingId));
+    }
+
+    private Building findBuildingById(UUID buildingId) {
+        return buildingRepository.findById(buildingId)
+                .orElseThrow(() -> new BuildingNotFoundException(buildingId));
+    }
+}

--- a/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
+++ b/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
@@ -1,0 +1,57 @@
+package com.saferoute.domain.floor.controller;
+
+import com.saferoute.domain.floor.dto.request.CreateFloorRequest;
+import com.saferoute.domain.floor.dto.response.FloorResponse;
+import com.saferoute.domain.floor.service.FloorService;
+import com.saferoute.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/buildings/{buildingId}/floors")
+@RequiredArgsConstructor
+public class FloorController {
+
+    private final FloorService floorService;
+
+    // 건물별 도면 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<FloorResponse>>> getFloors(@PathVariable UUID buildingId) {
+        return ResponseEntity.ok(ApiResponse.success(floorService.getFloors(buildingId)));
+    }
+
+    // 도면(층) 등록
+    @PostMapping
+    public ResponseEntity<ApiResponse<FloorResponse>> createFloor(
+            @PathVariable UUID buildingId,
+            @Valid @RequestBody CreateFloorRequest request
+    ) {
+        FloorResponse response = floorService.createFloor(buildingId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("도면 등록에 성공했습니다.", response));
+    }
+
+    // 도면 상세 조회
+    @GetMapping("/{floorId}")
+    public ResponseEntity<ApiResponse<FloorResponse>> getFloor(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID floorId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(floorService.getFloor(buildingId, floorId)));
+    }
+
+    // 도면 삭제
+    @DeleteMapping("/{floorId}")
+    public ResponseEntity<ApiResponse<Void>> deleteFloor(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID floorId
+    ) {
+        floorService.deleteFloor(buildingId, floorId);
+        return ResponseEntity.ok(ApiResponse.success("도면이 삭제되었습니다.", null));
+    }
+}

--- a/src/main/java/com/saferoute/domain/floor/dto/request/CreateFloorRequest.java
+++ b/src/main/java/com/saferoute/domain/floor/dto/request/CreateFloorRequest.java
@@ -1,0 +1,9 @@
+package com.saferoute.domain.floor.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateFloorRequest(
+        // 도면 이미지 없이 층만 먼저 등록 가능
+        @NotNull Integer floorNum,
+        String mapImageUrl
+) {}

--- a/src/main/java/com/saferoute/domain/floor/dto/response/FloorResponse.java
+++ b/src/main/java/com/saferoute/domain/floor/dto/response/FloorResponse.java
@@ -1,0 +1,28 @@
+package com.saferoute.domain.floor.dto.response;
+
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FloorResponse(
+        UUID id,
+        Integer floorNum,
+        String mapImageUrl,
+        SegmentationStatus segmentationStatus,
+        Instant processedAt,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static FloorResponse from(Floor floor) {
+        return new FloorResponse(
+                floor.getId(),
+                floor.getFloorNum(),
+                floor.getMapImageUrl(),
+                floor.getSegmentationStatus(),
+                floor.getProcessedAt(),
+                floor.getCreatedAt(),
+                floor.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/floor/entity/Floor.java
+++ b/src/main/java/com/saferoute/domain/floor/entity/Floor.java
@@ -1,0 +1,69 @@
+package com.saferoute.domain.floor.entity;
+
+import com.saferoute.domain.building.entity.Building;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Table(name = "floors")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Floor {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @NotNull
+    @Column(name = "floor_num", nullable = false)
+    private Integer floorNum;
+
+    @NotBlank
+    @Size(max = 1000)
+    @Column(name = "map_image_url", length = 1000)
+    private String mapImageUrl;
+
+    //세그멘테이션 처리 상태 (PENDING, PROCESSING, DONE, FAILED)
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "segmentation_status", nullable = false, length = 20)
+    private SegmentationStatus segmentationStatus;
+
+    @Column(name = "processed_at")
+    private Instant processedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    private Floor(Building building, Integer floorNum, String mapImageUrl) {
+        this.building = building;
+        this.floorNum = floorNum;
+        this.mapImageUrl = mapImageUrl;
+        this.segmentationStatus = SegmentationStatus.PENDING;
+    }
+
+    // 도면(층) 등록용 정적 팩토리 메서드
+    public static Floor create(Building building, Integer floorNum, String mapImageUrl) {
+        return new Floor(building, floorNum, mapImageUrl);
+    }
+}

--- a/src/main/java/com/saferoute/domain/floor/entity/SegmentationStatus.java
+++ b/src/main/java/com/saferoute/domain/floor/entity/SegmentationStatus.java
@@ -1,0 +1,8 @@
+package com.saferoute.domain.floor.entity;
+
+public enum SegmentationStatus {
+    PENDING,
+    PROCESSING,
+    DONE,
+    FAILED
+}

--- a/src/main/java/com/saferoute/domain/floor/exception/FloorNotFoundException.java
+++ b/src/main/java/com/saferoute/domain/floor/exception/FloorNotFoundException.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.floor.exception;
+
+import com.saferoute.global.exception.BusinessException;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class FloorNotFoundException extends BusinessException {
+    public FloorNotFoundException(UUID floorId) {
+        super(HttpStatus.NOT_FOUND, "도면을 찾을 수 없습니다: " + floorId);
+    }
+}

--- a/src/main/java/com/saferoute/domain/floor/repository/FloorRepository.java
+++ b/src/main/java/com/saferoute/domain/floor/repository/FloorRepository.java
@@ -1,0 +1,12 @@
+package com.saferoute.domain.floor.repository;
+
+import com.saferoute.domain.floor.entity.Floor;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FloorRepository extends JpaRepository<Floor, UUID> {
+    List<Floor> findByBuilding_IdOrderByFloorNumAsc(UUID buildingId);
+    Optional<Floor> findByIdAndBuilding_Id(UUID id, UUID buildingId);
+}

--- a/src/main/java/com/saferoute/domain/floor/service/FloorService.java
+++ b/src/main/java/com/saferoute/domain/floor/service/FloorService.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class FloorService {
 
     private final FloorRepository floorRepository;

--- a/src/main/java/com/saferoute/domain/floor/service/FloorService.java
+++ b/src/main/java/com/saferoute/domain/floor/service/FloorService.java
@@ -1,0 +1,60 @@
+package com.saferoute.domain.floor.service;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.exception.BuildingNotFoundException;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.floor.dto.request.CreateFloorRequest;
+import com.saferoute.domain.floor.dto.response.FloorResponse;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.exception.FloorNotFoundException;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FloorService {
+
+    private final FloorRepository floorRepository;
+    private final BuildingRepository buildingRepository;
+
+    public List<FloorResponse> getFloors(UUID buildingId) {
+        validateBuildingExists(buildingId);
+        return floorRepository.findByBuilding_IdOrderByFloorNumAsc(buildingId).stream()
+                .map(FloorResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public FloorResponse createFloor(UUID buildingId, CreateFloorRequest request) {
+        Building building = buildingRepository.findById(buildingId)
+                .orElseThrow(() -> new BuildingNotFoundException(buildingId));
+
+        Floor floor = Floor.create(building, request.floorNum(), request.mapImageUrl());
+        return FloorResponse.from(floorRepository.save(floor));
+    }
+
+    public FloorResponse getFloor(UUID buildingId, UUID floorId) {
+        return FloorResponse.from(findFloor(buildingId, floorId));
+    }
+
+    @Transactional
+    public void deleteFloor(UUID buildingId, UUID floorId) {
+        floorRepository.delete(findFloor(buildingId, floorId));
+    }
+
+    private void validateBuildingExists(UUID buildingId) {
+        if (!buildingRepository.existsById(buildingId)) {
+            throw new BuildingNotFoundException(buildingId);
+        }
+    }
+
+    private Floor findFloor(UUID buildingId, UUID floorId) {
+        return floorRepository.findByIdAndBuilding_Id(floorId, buildingId)
+                .orElseThrow(() -> new FloorNotFoundException(floorId));
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -1,6 +1,6 @@
 package com.saferoute.domain.training.entity;
 
-import com.saferoute.domain.building.Building;
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.user.entity.User;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -1,6 +1,6 @@
 package com.saferoute.domain.training.service;
 
-import com.saferoute.domain.building.Building;
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -15,10 +15,14 @@ public class SecurityConfig {
 
         http
                 .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.disable())
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**"
+                                "/v3/api-docs/**",
+                                "/h2-console/**"
                         ).permitAll()
                         .anyRequest().permitAll()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
   h2:
     console:
       enabled: true
+      path: /h2-console
 
   jpa:
     hibernate:

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -1,6 +1,6 @@
 package com.saferoute.domain.training.service;
 
-import com.saferoute.domain.building.Building;
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;


### PR DESCRIPTION
📌 Issue
Resolves #10 

## 작업 내용

- 건물별 도면 목록 조회(`GET /api/v1/buildings/{buildingId}/floors`): 층 번호 오름차순 반환
- 도면 등록(`POST /api/v1/buildings/{buildingId}/floors`): 층 번호 + 이미지 URL 입력 후 저장, `segmentationStatus` 는 `PENDING` 고정
- 도면 상세 조회(`GET /api/v1/buildings/{buildingId}/floors/{floorId}`): 도면 ID로 단건 조회
- 도면 삭제(`DELETE /api/v1/buildings/{buildingId}/floors/{floorId}`): 도면 하드 삭제
- `SegmentationStatus` enum 추가: `PENDING` / `PROCESSING` / `DONE` / `FAILED`
- `Floor` 엔티티 추가
- `FloorNotFoundException`(404) 추가

## 테스트 방법
```bash
# 도면 등록
curl -X POST http://localhost:8080/api/v1/buildings/{buildingId}/floors
-H "Content-Type: application/json" 
-d '{"floorNum":1,"mapImageUrl":"[https://example.com/floor1.png"}]

# 도면 목록 조회
curl -X GET http://localhost:8080/api/v1/buildings/{buildingId}/floors

# 도면 상세 조회
curl -X GET http://localhost:8080/api/v1/buildings/{buildingId}/floors/{floorId}

# 도면 삭제
curl -X DELETE http://localhost:8080/api/v1/buildings/{buildingId}/floors/{floorId}
```