### PR TITLE
fix(scenario): EntityManager 대신 Repository로 존재 검증 추가 - #13

### DIFF
--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -67,43 +67,44 @@ public class TrainingScenario {
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 
-  @LastModifiedDate
-  @Column(name = "updated_at", nullable = false)
-  private Instant updatedAt;
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
 
-  public static TrainingScenario create(String name,
-      Integer expectedParticipants,
-      Instant scheduledAt,
-      Boolean isTemplate,
-      Building building,
-      User admin) {
-    TrainingScenario scenario = new TrainingScenario();
-    scenario.name = name;
-    scenario.expectedParticipants = expectedParticipants;
-    scenario.scheduledAt = scheduledAt;
-    scenario.isTemplate = isTemplate != null ? isTemplate : false;
-    scenario.building = building;
-    scenario.admin = admin;
-    return scenario;
-  }
+    @OneToMany(mappedBy = "scenario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TrainingSession> trainingSessions = new ArrayList<>();
 
-  public void update(String name,
-      Integer expectedParticipants,
-      Instant scheduledAt,
-      Boolean isTemplate) {
-    if (name != null) this.name = name;
-    if (expectedParticipants != null) this.expectedParticipants = expectedParticipants;
-    if (scheduledAt != null) this.scheduledAt = scheduledAt;
-    if (isTemplate != null) this.isTemplate = isTemplate;
-  }
+    public static TrainingScenario create(String name,
+            Integer expectedParticipants,
+            Instant scheduledAt,
+            Boolean isTemplate,
+            Building building,
+            User admin) {
+        TrainingScenario scenario = new TrainingScenario();
+        scenario.name = name;
+        scenario.expectedParticipants = expectedParticipants;
+        scenario.scheduledAt = scheduledAt;
+        scenario.isTemplate = isTemplate != null ? isTemplate : false;
+        scenario.building = building;
+        scenario.admin = admin;
+        return scenario;
+    }
+
+    public void update(String name,
+            Integer expectedParticipants,
+            Instant scheduledAt,
+            Boolean isTemplate) {
+        if (name != null) this.name = name;
+        if (expectedParticipants != null) this.expectedParticipants = expectedParticipants;
+        if (scheduledAt != null) this.scheduledAt = scheduledAt;
+        if (isTemplate != null) this.isTemplate = isTemplate;
+    }
 
     // 응답용 getter
     public UUID getBuildingId() {
         return building != null ? building.getId() : null;
     }
 
-  @OneToMany(mappedBy = "scenario", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<TrainingSession> trainingSessions = new ArrayList<>();
     public UUID getAdminId() {
         return admin != null ? admin.getId() : null;
     }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -1,13 +1,14 @@
 package com.saferoute.domain.training.service;
 
 import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
 import com.saferoute.domain.user.entity.User;
-import jakarta.persistence.EntityManager;
+import com.saferoute.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -21,7 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrainingScenarioService {
 
     private final TrainingScenarioRepository scenarioRepository;
-    private final EntityManager entityManager;
+    private final BuildingRepository buildingRepository;
+    private final UserRepository userRepository;
 
     // 목록 조회
     public List<ScenarioResponse> getScenarios() {
@@ -38,12 +40,10 @@ public class TrainingScenarioService {
     // 생성
     @Transactional
     public ScenarioResponse createScenario(CreateScenarioRequest request) {
-        // TODO: BuildingRepository, UserRepository 구현 후 findById()로 교체
-        // 현재는 Repository 미구현으로 getReference() 임시 사용 (DB 조회 없이 FK만 세팅)
-        Building building = entityManager.getReference(
-                Building.class, request.getBuildingId());
-        User admin = entityManager.getReference(
-                User.class, request.getAdminId());
+        Building building = buildingRepository.findById(request.getBuildingId())
+                .orElseThrow(() -> new RuntimeException("건물을 찾을 수 없습니다."));
+        User admin = userRepository.findById(request.getAdminId())
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
 
         TrainingScenario scenario = TrainingScenario.create(
                 request.getName(),

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -1,6 +1,6 @@
 package com.saferoute.domain.training.service;
 
-import com.saferoute.domain.building.Building;
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
 import com.saferoute.domain.training.dto.RunningSessionResponse;
 import com.saferoute.domain.training.dto.ScheduledSessionResponse;

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -1,13 +1,14 @@
 package com.saferoute.domain.training.service;
 
 import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
 import com.saferoute.domain.user.entity.User;
-import jakarta.persistence.EntityManager;
+import com.saferoute.domain.user.repository.UserRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -37,7 +37,10 @@ class TrainingScenarioServiceTest {
     private TrainingScenarioRepository scenarioRepository;
 
     @Mock
-    private EntityManager entityManager;
+    private BuildingRepository buildingRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     private final UUID scenarioId = UUID.randomUUID();
     private final UUID buildingId = UUID.randomUUID();
@@ -114,11 +117,8 @@ class TrainingScenarioServiceTest {
         given(building.getId()).willReturn(buildingId);
         given(admin.getId()).willReturn(adminId);
 
-        // EntityManager.getReference() 가 mock 객체 반환하도록 설정
-        given(entityManager.getReference(eq(Building.class), eq(buildingId)))
-                .willReturn(building);
-        given(entityManager.getReference(eq(User.class), eq(adminId)))
-                .willReturn(admin);
+        given(buildingRepository.findById(buildingId)).willReturn(Optional.of(building));
+        given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
 
         TrainingScenario savedScenario = TrainingScenario.create(
                 "새시나리오", 30, scheduledAt, false, building, admin);
@@ -131,6 +131,37 @@ class TrainingScenarioServiceTest {
         assertThat(result.getName()).isEqualTo("새시나리오");
         assertThat(result.getBuildingId()).isEqualTo(buildingId);
         verify(scenarioRepository).save(any(TrainingScenario.class));
+    }
+
+    @Test
+    @DisplayName("시나리오 생성 - 건물이 없으면 예외 발생")
+    void createScenario_buildingNotFound() {
+        // given
+        CreateScenarioRequest request = new CreateScenarioRequest(
+                "새시나리오", buildingId, 30, scheduledAt, false, adminId);
+        given(buildingRepository.findById(buildingId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> scenarioService.createScenario(request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("건물을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("시나리오 생성 - 유저가 없으면 예외 발생")
+    void createScenario_userNotFound() {
+        // given
+        CreateScenarioRequest request = new CreateScenarioRequest(
+                "새시나리오", buildingId, 30, scheduledAt, false, adminId);
+
+        Building building = mock(Building.class);
+        given(buildingRepository.findById(buildingId)).willReturn(Optional.of(building));
+        given(userRepository.findById(adminId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> scenarioService.createScenario(request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("유저를 찾을 수 없습니다.");
     }
 
     @Test


### PR DESCRIPTION
## 🔗 관련 이슈

closes #13

## 📋 작업 내용

- 시나리오 생성 시 buildingId, adminId 유효성 검증 추가
- EntityManager.getReference() → BuildingRepository.findById(),
  UserRepository.findById()로 교체
- 존재하지 않는 buildingId/adminId로 요청 시 즉시 예외 발생
  ("건물을 찾을 수 없습니다." / "유저를 찾을 수 없습니다.")
- TrainingScenario 코드 정렬 정리

## 📄 API 변경사항

POST /api/v1/scenarios
- buildingId, adminId가 존재하지 않을 경우
  → 기존: 생성 시점에는 에러 없이 통과 (이후 조회 시 오류 발생 가능)
  → 변경: 즉시 RuntimeException 발생

## 🧪 테스트 결과

- TrainingScenarioServiceTest 전체 통과
- 신규 테스트 2개 추가
  - createScenario_buildingNotFound (건물 없을 때 예외)
  - createScenario_userNotFound (유저 없을 때 예외)
- Postman으로 실제 API 동작 확인
  (존재하지 않는 buildingId/adminId 요청 시 에러 응답 확인)

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] 테스트 통과
- [x] ./gradlew build 성공