### PR TITLE
feat: 그래프 노드/엣지 JPA 엔티티·Repository 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapEdge.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapEdge.java
@@ -1,0 +1,68 @@
+package com.saferoute.domain.evacuation.graph.entity;
+
+import com.saferoute.domain.floor.entity.Floor;
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Table(name = "map_edges")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MapEdge {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "distance", nullable = false)
+    private double distance;
+
+    // 화재구역 통제 시 true로 전환 (Dijkstra 계산에서 이 엣지 제외)
+    @Column(name = "blocked", nullable = false)
+    private boolean blocked;
+
+    // IoT 유도등 디바이스 ID (IoT 디바이스 엔티티 생기면 FK 관계로 교체 예정) (미정)
+    @Column(name = "guide_light_id")
+    private UUID guideLightId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_id", nullable = false)
+    private Floor floor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_node_id", nullable = false)
+    private MapNode fromNode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_node_id", nullable = false)
+    private MapNode toNode;
+
+    private MapEdge(Floor floor, MapNode fromNode, MapNode toNode, double distance) {
+        this.floor = floor;
+        this.fromNode = fromNode;
+        this.toNode = toNode;
+        this.distance = distance;
+        this.blocked = false;
+    }
+
+    // 그래프 엣지(통로) 등록용 정적 팩토리 메서드
+    public static MapEdge create(Floor floor, MapNode fromNode, MapNode toNode, double distance) {
+        return new MapEdge(floor, fromNode, toNode, distance);
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapNode.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapNode.java
@@ -1,0 +1,79 @@
+package com.saferoute.domain.evacuation.graph.entity;
+
+import com.saferoute.domain.floor.entity.Floor;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Table(name = "map_nodes")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MapNode {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    // 도면상 식별 코드 (예: "STAIR_A", "325") - AI 세그멘테이션 결과와 매칭용
+    @NotBlank
+    @Column(name = "code", nullable = false, length = 50)
+    private String code;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private NodeType type;
+
+    @NotBlank
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "pos_x", nullable = false)
+    private double x;
+
+    @Column(name = "pos_y", nullable = false)
+    private double y;
+
+    // Dijkstra 경로 계산 시 목적지 후보로 삼을 노드인지 여부
+    @Column(name = "is_exit_target", nullable = false)
+    private boolean isExitTarget;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_id", nullable = false)
+    private Floor floor;
+
+    private MapNode(Floor floor, String code, NodeType type, String name,
+            double x, double y, boolean isExitTarget) {
+        this.floor = floor;
+        this.code = code;
+        this.type = type;
+        this.name = name;
+        this.x = x;
+        this.y = y;
+        this.isExitTarget = isExitTarget;
+    }
+
+    // 그래프 노드 등록용 정적 팩토리 메서드
+    public static MapNode create(Floor floor, String code, NodeType type, String name,
+            double x, double y, boolean isExitTarget) {
+        return new MapNode(floor, code, type, name, x, y, isExitTarget);
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/entity/NodeType.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/entity/NodeType.java
@@ -1,0 +1,9 @@
+package com.saferoute.domain.evacuation.graph.entity;
+
+public enum NodeType {
+    STAIR,
+    ROOM,
+    HALLWAY,
+    DOOR,
+    CUSTOM
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapEdgeJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapEdgeJpaRepository.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.evacuation.graph.repository;
+
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MapEdgeJpaRepository extends JpaRepository<MapEdge, UUID> {
+
+    List<MapEdge> findByFloorId(UUID floorId);
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
@@ -1,0 +1,24 @@
+package com.saferoute.domain.evacuation.graph.repository;
+
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.floor.entity.Floor;
+import java.util.List;
+import java.util.UUID;
+
+public interface MapGraphRepository {
+
+    // 노드 추가
+    MapNode addNode(Floor floor, String code, NodeType type, String name,
+            double x, double y, boolean isExitTarget);
+
+    // 엣지 추가 (계단/방 사이 통로)
+    MapEdge addEdge(Floor floor, MapNode fromNode, MapNode toNode, double distance);
+
+    // 특정 층의 노드 전체 조회
+    List<MapNode> findNodesByFloor(UUID floorId);
+
+    // 특정 층의 엣지 전체 조회
+    List<MapEdge> findEdgesByFloor(UUID floorId);
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.saferoute.domain.evacuation.graph.repository;
+
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.floor.entity.Floor;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MapGraphRepositoryImpl implements MapGraphRepository {
+
+    private final MapNodeJpaRepository mapNodeJpaRepository;
+    private final MapEdgeJpaRepository mapEdgeJpaRepository;
+
+    @Override
+    public MapNode addNode(Floor floor, String code, NodeType type, String name,
+            double x, double y, boolean isExitTarget) {
+        MapNode node = MapNode.create(floor, code, type, name, x, y, isExitTarget);
+        return mapNodeJpaRepository.save(node);
+    }
+
+    @Override
+    public MapEdge addEdge(Floor floor, MapNode fromNode, MapNode toNode, double distance) {
+        MapEdge edge = MapEdge.create(floor, fromNode, toNode, distance);
+        return mapEdgeJpaRepository.save(edge);
+    }
+
+    @Override
+    public List<MapNode> findNodesByFloor(UUID floorId) {
+        return mapNodeJpaRepository.findByFloorId(floorId);
+    }
+
+    @Override
+    public List<MapEdge> findEdgesByFloor(UUID floorId) {
+        return mapEdgeJpaRepository.findByFloorId(floorId);
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapNodeJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapNodeJpaRepository.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.evacuation.graph.repository;
+
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MapNodeJpaRepository extends JpaRepository<MapNode, UUID> {
+
+    List<MapNode> findByFloorId(UUID floorId);
+}

--- a/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
@@ -1,0 +1,89 @@
+package com.saferoute.domain.evacuation.graph.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.floor.entity.Floor;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MapGraphRepositoryImplTest {
+
+    @InjectMocks
+    private MapGraphRepositoryImpl mapGraphRepository;
+
+    @Mock
+    private MapNodeJpaRepository mapNodeJpaRepository;
+
+    @Mock
+    private MapEdgeJpaRepository mapEdgeJpaRepository;
+
+    private final UUID floorId = UUID.randomUUID();
+
+    @Test
+    @DisplayName("노드를 추가하면 저장된다")
+    void addNode_success() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode savedNode = MapNode.create(floor, "STAIR_B", NodeType.STAIR, "계단B", 0, 0, true);
+        given(mapNodeJpaRepository.save(any(MapNode.class))).willReturn(savedNode);
+
+        // when
+        MapNode result = mapGraphRepository.addNode(floor, "STAIR_B", NodeType.STAIR, "계단B", 0, 0, true);
+
+        // then
+        assertThat(result.getCode()).isEqualTo("STAIR_B");
+        assertThat(result.isExitTarget()).isTrue();
+        verify(mapNodeJpaRepository).save(any(MapNode.class));
+    }
+
+    @Test
+    @DisplayName("두 노드를 엣지로 연결하면 거리 속성이 저장된다")
+    void addEdge_success() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode from = mock(MapNode.class);
+        MapNode to = mock(MapNode.class);
+        MapEdge savedEdge = MapEdge.create(floor, from, to, 8.0);
+        given(mapEdgeJpaRepository.save(any(MapEdge.class))).willReturn(savedEdge);
+
+        // when
+        MapEdge result = mapGraphRepository.addEdge(floor, from, to, 8.0);
+
+        // then
+        assertThat(result.getDistance()).isEqualTo(8.0);
+        assertThat(result.isBlocked()).isFalse();
+        verify(mapEdgeJpaRepository).save(any(MapEdge.class));
+    }
+
+    @Test
+    @DisplayName("층별로 노드와 엣지를 조회할 수 있다")
+    void findByFloor_success() {
+        // given
+        MapNode node = mock(MapNode.class);
+        MapEdge edge = mock(MapEdge.class);
+        given(mapNodeJpaRepository.findByFloorId(floorId)).willReturn(List.of(node));
+        given(mapEdgeJpaRepository.findByFloorId(floorId)).willReturn(List.of(edge));
+
+        // when
+        List<MapNode> nodes = mapGraphRepository.findNodesByFloor(floorId);
+        List<MapEdge> edges = mapGraphRepository.findEdgesByFloor(floorId);
+
+        // then
+        assertThat(nodes).hasSize(1);
+        assertThat(edges).hasSize(1);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
closes #15

## 📋 작업 내용
- Neptune 사용 불가로 PostgreSQL 인접 테이블 방식으로 전환
- MapNode, MapEdge JPA 엔티티 설계 (Floor.java 컨벤션 적용)
- MapNodeJpaRepository, MapEdgeJpaRepository (Spring Data JPA)
- MapGraphRepository 인터페이스 + Impl (서비스 레이어에 그래프 CRUD 노출)
- NodeType enum: STAIR/ROOM/HALLWAY/DOOR/CUSTOM ← POI 대신 이 구성으로 수정

## 🧪 테스트 결과
- MapGraphRepositoryImplTest 3건 통과 (Mockito 기반)

## ✅ 체크리스트
- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] 테스트 통과
- [x] ./gradlew build 성공