### PR TITLE
feat: 노드/엣지 커스텀 편집 API 구현

### DIFF
--- a/src/main/java/com/saferoute/SafeRouteApplication.java
+++ b/src/main/java/com/saferoute/SafeRouteApplication.java
@@ -2,9 +2,7 @@ package com.saferoute;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class SafeRouteApplication {
 

--- a/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphController.java
@@ -1,0 +1,26 @@
+package com.saferoute.domain.evacuation.controller;
+
+import com.saferoute.domain.evacuation.graph.dto.response.FloorGraphResponse;
+import com.saferoute.domain.evacuation.graph.service.MapGraphService;
+import com.saferoute.global.api.response.ApiResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/floors/{floorId}")
+@RequiredArgsConstructor
+public class MapGraphController {
+
+    private final MapGraphService mapGraphService;
+
+    // 커스텀 편집 UI 캔버스 초기 로딩용 - 노드/엣지 전체 조회
+    @GetMapping("/graph")
+    public ResponseEntity<ApiResponse<FloorGraphResponse>> getGraph(@PathVariable UUID floorId) {
+        return ResponseEntity.ok(ApiResponse.success(mapGraphService.getFloorGraph(floorId)));
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
@@ -1,0 +1,68 @@
+package com.saferoute.domain.evacuation.controller;
+
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapEdgeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapNodeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.UpdateMapNodePositionRequest;
+import com.saferoute.domain.evacuation.graph.dto.response.MapEdgeResponse;
+import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
+import com.saferoute.domain.evacuation.graph.service.MapGraphService;
+import com.saferoute.global.api.response.ApiResponse;
+import com.saferoute.global.api.response.EvacuationSuccessCode;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 커스텀 편집 UI(드래그로 노드 추가/이동, 엣지 연결)를 위한 CRUD 엔드포인트
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class MapGraphEditController {
+
+    private final MapGraphService mapGraphService;
+
+    @PostMapping("/floors/{floorId}/nodes")
+    public ResponseEntity<ApiResponse<MapNodeResponse>> createNode(
+            @PathVariable UUID floorId,
+            @Valid @RequestBody CreateMapNodeRequest request
+    ) {
+        MapNodeResponse response = mapGraphService.createNode(floorId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(EvacuationSuccessCode.MAP_NODE_CREATED, response));
+    }
+
+    @PatchMapping("/nodes/{nodeId}")
+    public ResponseEntity<ApiResponse<MapNodeResponse>> updateNodePosition(
+            @PathVariable UUID nodeId,
+            @Valid @RequestBody UpdateMapNodePositionRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(mapGraphService.updateNodePosition(nodeId, request)));
+    }
+
+    @DeleteMapping("/nodes/{nodeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteNode(@PathVariable UUID nodeId) {
+        mapGraphService.deleteNode(nodeId);
+        return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.MAP_NODE_DELETED, null));
+    }
+
+    @PostMapping("/edges")
+    public ResponseEntity<ApiResponse<MapEdgeResponse>> createEdge(@Valid @RequestBody CreateMapEdgeRequest request) {
+        MapEdgeResponse response = mapGraphService.createEdge(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(EvacuationSuccessCode.MAP_EDGE_CREATED, response));
+    }
+
+    @DeleteMapping("/edges/{edgeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteEdge(@PathVariable UUID edgeId) {
+        mapGraphService.deleteEdge(edgeId);
+        return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.MAP_EDGE_DELETED, null));
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/CreateMapEdgeRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/CreateMapEdgeRequest.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.evacuation.graph.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record CreateMapEdgeRequest(
+        @NotNull UUID fromNodeId,
+        @NotNull UUID toNodeId,
+        @NotNull Double distance,
+        @NotNull Boolean bidirectional
+) {}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/CreateMapNodeRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/CreateMapNodeRequest.java
@@ -1,0 +1,14 @@
+package com.saferoute.domain.evacuation.graph.dto.request;
+
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateMapNodeRequest(
+        @NotBlank String code,
+        @NotNull NodeType type,
+        @NotBlank String name,
+        @NotNull Double x,
+        @NotNull Double y,
+        boolean isExitTarget
+) {}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/UpdateMapNodePositionRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/UpdateMapNodePositionRequest.java
@@ -1,0 +1,9 @@
+package com.saferoute.domain.evacuation.graph.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+// 커스텀 편집 UI에서 드래그로 노드 위치 옮길 때 사용
+public record UpdateMapNodePositionRequest(
+        @NotNull Double x,
+        @NotNull Double y
+) {}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/response/FloorGraphResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/response/FloorGraphResponse.java
@@ -1,0 +1,18 @@
+package com.saferoute.domain.evacuation.graph.dto.response;
+
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import java.util.List;
+
+// 커스텀 편집 UI가 캔버스를 그릴 때 쓰는 층별 그래프 전체 응답
+public record FloorGraphResponse(
+        List<MapNodeResponse> nodes,
+        List<MapEdgeResponse> edges
+) {
+    public static FloorGraphResponse of(List<MapNode> nodes, List<MapEdge> edges) {
+        return new FloorGraphResponse(
+                nodes.stream().map(MapNodeResponse::from).toList(),
+                edges.stream().map(MapEdgeResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/response/MapEdgeResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/response/MapEdgeResponse.java
@@ -1,0 +1,22 @@
+package com.saferoute.domain.evacuation.graph.dto.response;
+
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import java.util.UUID;
+
+public record MapEdgeResponse(
+        UUID id,
+        UUID fromNodeId,
+        UUID toNodeId,
+        double distance,
+        boolean bidirectional
+) {
+    public static MapEdgeResponse from(MapEdge edge) {
+        return new MapEdgeResponse(
+                edge.getId(),
+                edge.getFromNode().getId(),
+                edge.getToNode().getId(),
+                edge.getDistance(),
+                edge.isBidirectional()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/response/MapNodeResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/response/MapNodeResponse.java
@@ -1,0 +1,27 @@
+package com.saferoute.domain.evacuation.graph.dto.response;
+
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import java.util.UUID;
+
+public record MapNodeResponse(
+        UUID id,
+        String code,
+        NodeType type,
+        String name,
+        double x,
+        double y,
+        boolean isExitTarget
+) {
+    public static MapNodeResponse from(MapNode node) {
+        return new MapNodeResponse(
+                node.getId(),
+                node.getCode(),
+                node.getType(),
+                node.getName(),
+                node.getX(),
+                node.getY(),
+                node.isExitTarget()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapEdgeJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapEdgeJpaRepository.java
@@ -9,6 +9,13 @@ public interface MapEdgeJpaRepository extends JpaRepository<MapEdge, UUID> {
 
     List<MapEdge> findAllByFloor_Id(UUID floorId);
 
-    // 특정 노드에 연결된 엣지 (유도등 좌/우 Edge 검증용)
+    // 특정 노드에 연결된 엣지 (유도등 좌/우 Edge 검증용, 노드 삭제 시 연결 엣지 조회용으로도 사용)
     List<MapEdge> findAllByFromNode_IdOrToNode_Id(UUID fromNodeId, UUID toNodeId);
+
+    // 노드 삭제 시 연결된 엣지 cascade 삭제용
+    void deleteByFromNode_IdOrToNode_Id(UUID fromNodeId, UUID toNodeId);
+
+    // 동일 노드 쌍 중복 엣지 방지용 - 통행은 양방향으로 취급하므로 두 방향 다 체크
+    boolean existsByFromNode_IdAndToNode_IdOrFromNode_IdAndToNode_Id(
+            UUID fromNodeId1, UUID toNodeId1, UUID fromNodeId2, UUID toNodeId2);
 }

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
@@ -5,6 +5,7 @@ import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
 import com.saferoute.domain.floor.entity.Floor;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MapGraphRepository {
@@ -21,4 +22,19 @@ public interface MapGraphRepository {
 
     // 특정 층의 엣지 전체 조회
     List<MapEdge> findEdgesByFloor(UUID floorId);
+
+    // 노드 단건 조회 (수정/삭제/엣지 생성 시 참조용)
+    Optional<MapNode> findNodeById(UUID nodeId);
+
+    // 엣지 단건 조회 (삭제 시 참조용)
+    Optional<MapEdge> findEdgeById(UUID edgeId);
+
+    // 노드 위치 수정 (드래그 편집)
+    MapNode updateNodePosition(MapNode node, double x, double y);
+
+    // 노드 삭제 - 연결된 엣지도 함께 삭제(cascade)
+    void deleteNode(MapNode node);
+
+    // 엣지 삭제
+    void deleteEdge(MapEdge edge);
 }

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
@@ -4,7 +4,10 @@ import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
 import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -25,8 +28,32 @@ public class MapGraphRepositoryImpl implements MapGraphRepository {
 
     @Override
     public MapEdge addEdge(Floor floor, MapNode fromNode, MapNode toNode, double distance, boolean bidirectional) {
+        validateConnection(fromNode, toNode);
+        validateNotDuplicate(fromNode, toNode);
         MapEdge edge = MapEdge.create(floor, fromNode, toNode, distance, bidirectional);
         return mapEdgeJpaRepository.save(edge);
+    }
+
+    // 동일 노드 쌍(A-B, B-A 포함) 사이에는 엣지를 하나만 허용
+    private void validateNotDuplicate(MapNode fromNode, MapNode toNode) {
+        boolean exists = mapEdgeJpaRepository.existsByFromNode_IdAndToNode_IdOrFromNode_IdAndToNode_Id(
+                fromNode.getId(), toNode.getId(), toNode.getId(), fromNode.getId());
+        if (exists) {
+            throw new ApiException(EvacuationErrorCode.DUPLICATE_MAP_EDGE);
+        }
+    }
+
+    // ROOM 노드는 DOOR 노드를 거치지 않고는 다른 노드(HALLWAY 등)와 직접 연결될 수 없다
+    private void validateConnection(MapNode fromNode, MapNode toNode) {
+        boolean fromIsRoom = fromNode.getType() == NodeType.ROOM;
+        boolean toIsRoom = toNode.getType() == NodeType.ROOM;
+
+        if (fromIsRoom && toNode.getType() != NodeType.DOOR) {
+            throw new ApiException(EvacuationErrorCode.INVALID_MAP_EDGE_CONNECTION);
+        }
+        if (toIsRoom && fromNode.getType() != NodeType.DOOR) {
+            throw new ApiException(EvacuationErrorCode.INVALID_MAP_EDGE_CONNECTION);
+        }
     }
 
     @Override
@@ -37,5 +64,33 @@ public class MapGraphRepositoryImpl implements MapGraphRepository {
     @Override
     public List<MapEdge> findEdgesByFloor(UUID floorId) {
         return mapEdgeJpaRepository.findAllByFloor_Id(floorId);
+    }
+
+    @Override
+    public Optional<MapNode> findNodeById(UUID nodeId) {
+        return mapNodeJpaRepository.findById(nodeId);
+    }
+
+    @Override
+    public Optional<MapEdge> findEdgeById(UUID edgeId) {
+        return mapEdgeJpaRepository.findById(edgeId);
+    }
+
+    @Override
+    public MapNode updateNodePosition(MapNode node, double x, double y) {
+        node.moveTo(x, y);
+        return node; // 영속 상태 엔티티라 dirty checking으로 트랜잭션 커밋 시 반영됨
+    }
+
+    @Override
+    public void deleteNode(MapNode node) {
+        // 노드 삭제 시 연결된 엣지(from/to 어느 쪽이든) 먼저 cascade 삭제
+        mapEdgeJpaRepository.deleteByFromNode_IdOrToNode_Id(node.getId(), node.getId());
+        mapNodeJpaRepository.delete(node);
+    }
+
+    @Override
+    public void deleteEdge(MapEdge edge) {
+        mapEdgeJpaRepository.delete(edge);
     }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
@@ -1,0 +1,92 @@
+package com.saferoute.domain.evacuation.graph.service;
+
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapEdgeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapNodeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.UpdateMapNodePositionRequest;
+import com.saferoute.domain.evacuation.graph.dto.response.FloorGraphResponse;
+import com.saferoute.domain.evacuation.graph.dto.response.MapEdgeResponse;
+import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapGraphRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MapGraphService {
+
+    private final MapGraphRepository mapGraphRepository;
+    private final FloorRepository floorRepository;
+
+    // 커스텀 편집 UI 초기 로딩용 - 층의 노드/엣지 전체 조회
+    public FloorGraphResponse getFloorGraph(UUID floorId) {
+        validateFloorExists(floorId);
+        List<MapNode> nodes = mapGraphRepository.findNodesByFloor(floorId);
+        List<MapEdge> edges = mapGraphRepository.findEdgesByFloor(floorId);
+        return FloorGraphResponse.of(nodes, edges);
+    }
+
+    // 노드 추가
+    @Transactional
+    public MapNodeResponse createNode(UUID floorId, CreateMapNodeRequest request) {
+        Floor floor = floorRepository.findById(floorId)
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+        MapNode node = mapGraphRepository.addNode(floor, request.code(), request.type(), request.name(),
+                request.x(), request.y(), request.isExitTarget());
+        return MapNodeResponse.from(node);
+    }
+
+    // 노드 위치 수정 (드래그 편집)
+    @Transactional
+    public MapNodeResponse updateNodePosition(UUID nodeId, UpdateMapNodePositionRequest request) {
+        MapNode node = findNodeOrThrow(nodeId);
+        MapNode updated = mapGraphRepository.updateNodePosition(node, request.x(), request.y());
+        return MapNodeResponse.from(updated);
+    }
+
+    // 노드 삭제 (연결된 엣지도 함께 삭제)
+    @Transactional
+    public void deleteNode(UUID nodeId) {
+        MapNode node = findNodeOrThrow(nodeId);
+        mapGraphRepository.deleteNode(node);
+    }
+
+    // 엣지 연결 (fromNode가 속한 floor를 그대로 사용, room-hallway 직접 연결은 Repository에서 검증)
+    @Transactional
+    public MapEdgeResponse createEdge(CreateMapEdgeRequest request) {
+        MapNode fromNode = findNodeOrThrow(request.fromNodeId());
+        MapNode toNode = findNodeOrThrow(request.toNodeId());
+        MapEdge edge = mapGraphRepository.addEdge(
+                fromNode.getFloor(), fromNode, toNode, request.distance(), request.bidirectional());
+        return MapEdgeResponse.from(edge);
+    }
+
+    // 엣지 삭제
+    @Transactional
+    public void deleteEdge(UUID edgeId) {
+        MapEdge edge = mapGraphRepository.findEdgeById(edgeId)
+                .orElseThrow(() -> new ApiException(EvacuationErrorCode.MAP_EDGE_NOT_FOUND));
+        mapGraphRepository.deleteEdge(edge);
+    }
+
+    private MapNode findNodeOrThrow(UUID nodeId) {
+        return mapGraphRepository.findNodeById(nodeId)
+                .orElseThrow(() -> new ApiException(EvacuationErrorCode.MAP_NODE_NOT_FOUND));
+    }
+
+    private void validateFloorExists(UUID floorId) {
+        if (!floorRepository.existsById(floorId)) {
+            throw new ApiException(FloorErrorCode.FLOOR_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
@@ -1,0 +1,21 @@
+package com.saferoute.global.api.error;
+
+import com.saferoute.global.api.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EvacuationErrorCode implements BaseErrorCode {
+
+    MAP_NODE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVAC001", "노드를 찾을 수 없습니다."),
+    MAP_EDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVAC002", "엣지를 찾을 수 없습니다."),
+    DUPLICATE_MAP_EDGE(HttpStatus.CONFLICT, "EVAC003", "이미 연결된 노드 쌍입니다."),
+    INVALID_MAP_EDGE_CONNECTION(HttpStatus.BAD_REQUEST, "EVAC004", "ROOM 노드는 DOOR 노드를 통해서만 연결할 수 있습니다."),
+    EVACUATION_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVAC005", "도달 가능한 EXIT 노드가 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/saferoute/global/api/response/EvacuationSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/EvacuationSuccessCode.java
@@ -1,0 +1,20 @@
+package com.saferoute.global.api.response;
+
+import com.saferoute.global.api.code.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EvacuationSuccessCode implements BaseCode {
+
+    MAP_NODE_CREATED(HttpStatus.CREATED, "EVAC_SUCCESS_001", "노드가 생성되었습니다."),
+    MAP_NODE_DELETED(HttpStatus.OK, "EVAC_SUCCESS_002", "노드가 삭제되었습니다."),
+    MAP_EDGE_CREATED(HttpStatus.CREATED, "EVAC_SUCCESS_003", "엣지가 생성되었습니다."),
+    MAP_EDGE_DELETED(HttpStatus.OK, "EVAC_SUCCESS_004", "엣지가 삭제되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/saferoute/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/saferoute/global/config/JpaAuditingConfig.java
@@ -1,0 +1,12 @@
+package com.saferoute.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+// @EnableJpaAuditing을 SafeRouteApplication에서 분리한 이유:
+// 메인 클래스에 직접 붙어있으면 @WebMvcTest 슬라이스에서도 이 어노테이션이 그대로 로드되면서
+// JPA 레이어가 없어 jpaMappingContext 빈을 못 찾는 BeanCreationException이 발생함.
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/java/com/saferoute/domain/evacuation/controller/MapGraphControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/controller/MapGraphControllerTest.java
@@ -1,0 +1,94 @@
+package com.saferoute.domain.evacuation.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.saferoute.domain.evacuation.graph.dto.response.FloorGraphResponse;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.service.MapGraphService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MapGraphController.class)
+@AutoConfigureMockMvc(addFilters = false) // Security 필터는 HTTP 매핑/예외 응답 검증과 무관하니 비활성화
+class MapGraphControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MapGraphService mapGraphService;
+
+    private final UUID floorId = UUID.randomUUID();
+    private Floor floor;
+    private MapNode room1;
+    private MapNode door1;
+
+    @BeforeEach
+    void setUp() {
+        floor = mock(Floor.class);
+        room1 = createNode("ROOM1", NodeType.ROOM, false);
+        door1 = createNode("DOOR1", NodeType.DOOR, true);
+    }
+
+    private MapNode createNode(String code, NodeType type, boolean isExitTarget) {
+        MapNode node = MapNode.create(floor, code, type, code, 0, 0, isExitTarget);
+        ReflectionTestUtils.setField(node, "id", UUID.randomUUID());
+        return node;
+    }
+
+    private MapEdge createEdge(MapNode from, MapNode to, double distance) {
+        MapEdge edge = MapEdge.create(floor, from, to, distance, true);
+        ReflectionTestUtils.setField(edge, "id", UUID.randomUUID());
+        return edge;
+    }
+
+    @Test
+    @DisplayName("GET /graph - 층의 노드/엣지 전체를 반환한다")
+    void getGraph_success() throws Exception {
+        // given
+        MapEdge edge = createEdge(room1, door1, 2);
+        given(mapGraphService.getFloorGraph(floorId))
+                .willReturn(FloorGraphResponse.of(List.of(room1, door1), List.of(edge)));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/floors/{floorId}/graph", floorId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.nodes.length()").value(2))
+                .andExpect(jsonPath("$.result.nodes[0].code").value("ROOM1"))
+                .andExpect(jsonPath("$.result.edges.length()").value(1))
+                .andExpect(jsonPath("$.result.edges[0].distance").value(2));
+    }
+
+    @Test
+    @DisplayName("GET /graph - 층이 없으면 404를 반환한다")
+    void getGraph_floorNotFound() throws Exception {
+        // given
+        given(mapGraphService.getFloorGraph(floorId)).willThrow(new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/floors/{floorId}/graph", floorId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.message", containsString("도면을 찾을 수 없습니다")));
+    }
+}

--- a/src/test/java/com/saferoute/domain/evacuation/controller/MapGraphEditControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/controller/MapGraphEditControllerTest.java
@@ -1,0 +1,216 @@
+package com.saferoute.domain.evacuation.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapEdgeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapNodeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.UpdateMapNodePositionRequest;
+import com.saferoute.domain.evacuation.graph.dto.response.MapEdgeResponse;
+import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.service.MapGraphService;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MapGraphEditController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MapGraphEditControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private MapGraphService mapGraphService;
+
+    private final UUID floorId = UUID.randomUUID();
+    private final UUID nodeId = UUID.randomUUID();
+    private final UUID edgeId = UUID.randomUUID();
+
+    // === createNode ===
+
+    @Test
+    @DisplayName("POST /nodes - 노드를 생성하면 201을 반환한다")
+    void createNode_success() throws Exception {
+        // given
+        CreateMapNodeRequest request = new CreateMapNodeRequest("ROOM1", NodeType.ROOM, "방1", 0.0, 0.0, false);
+        MapNodeResponse response = new MapNodeResponse(nodeId, "ROOM1", NodeType.ROOM, "방1", 0.0, 0.0, false);
+        given(mapGraphService.createNode(eq(floorId), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/floors/{floorId}/nodes", floorId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.code").value("ROOM1"));
+    }
+
+    @Test
+    @DisplayName("POST /nodes - code가 비어있으면 400을 반환한다")
+    void createNode_blankCode_returnsBadRequest() throws Exception {
+        // given: code가 빈 문자열이라 @NotBlank 검증에 걸림
+        String invalidJson = """
+                {"code":"","type":"ROOM","name":"방1","x":0,"y":0,"isExitTarget":false}
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/v1/floors/{floorId}/nodes", floorId)
+                        .contentType("application/json")
+                        .content(invalidJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /nodes - 층이 없으면 404를 반환한다")
+    void createNode_floorNotFound() throws Exception {
+        // given
+        CreateMapNodeRequest request = new CreateMapNodeRequest("ROOM1", NodeType.ROOM, "방1", 0.0, 0.0, false);
+        given(mapGraphService.createNode(eq(floorId), any()))
+                .willThrow(new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/floors/{floorId}/nodes", floorId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", containsString("도면을 찾을 수 없습니다")));
+    }
+
+    // === updateNodePosition ===
+
+    @Test
+    @DisplayName("PATCH /nodes/{nodeId} - 위치를 수정하면 200을 반환한다")
+    void updateNodePosition_success() throws Exception {
+        // given
+        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0);
+        MapNodeResponse response = new MapNodeResponse(nodeId, "ROOM1", NodeType.ROOM, "방1", 10.0, 20.0, false);
+        given(mapGraphService.updateNodePosition(eq(nodeId), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/nodes/{nodeId}", nodeId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.x").value(10.0))
+                .andExpect(jsonPath("$.result.y").value(20.0));
+    }
+
+    @Test
+    @DisplayName("PATCH /nodes/{nodeId} - 노드가 없으면 404를 반환한다")
+    void updateNodePosition_notFound() throws Exception {
+        // given
+        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0);
+        given(mapGraphService.updateNodePosition(eq(nodeId), any()))
+                .willThrow(new ApiException(EvacuationErrorCode.MAP_NODE_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/nodes/{nodeId}", nodeId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    // === deleteNode ===
+
+    @Test
+    @DisplayName("DELETE /nodes/{nodeId} - 노드를 삭제하면 200을 반환한다")
+    void deleteNode_success() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/v1/nodes/{nodeId}", nodeId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+    }
+
+    @Test
+    @DisplayName("DELETE /nodes/{nodeId} - 노드가 없으면 404를 반환한다")
+    void deleteNode_notFound() throws Exception {
+        // given
+        Mockito.doThrow(new ApiException(EvacuationErrorCode.MAP_NODE_NOT_FOUND))
+                .when(mapGraphService).deleteNode(nodeId);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/nodes/{nodeId}", nodeId))
+                .andExpect(status().isNotFound());
+    }
+
+    // === createEdge ===
+
+    @Test
+    @DisplayName("POST /edges - 엣지를 생성하면 201을 반환한다")
+    void createEdge_success() throws Exception {
+        // given
+        UUID fromNodeId = UUID.randomUUID();
+        UUID toNodeId = UUID.randomUUID();
+        CreateMapEdgeRequest request = new CreateMapEdgeRequest(fromNodeId, toNodeId, 5.0, true);
+        MapEdgeResponse response = new MapEdgeResponse(edgeId, fromNodeId, toNodeId, 5.0, true);
+        given(mapGraphService.createEdge(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/edges")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.result.distance").value(5.0));
+    }
+
+    @Test
+    @DisplayName("POST /edges - room-hallway 직접 연결이면 400을 반환한다")
+    void createEdge_invalidConnection_returnsBadRequest() throws Exception {
+        // given
+        CreateMapEdgeRequest request = new CreateMapEdgeRequest(UUID.randomUUID(), UUID.randomUUID(), 5.0, true);
+        given(mapGraphService.createEdge(any()))
+                .willThrow(new ApiException(EvacuationErrorCode.INVALID_MAP_EDGE_CONNECTION));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/edges")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", containsString("DOOR 노드를 통해서만")));
+    }
+
+    // === deleteEdge ===
+
+    @Test
+    @DisplayName("DELETE /edges/{edgeId} - 엣지를 삭제하면 200을 반환한다")
+    void deleteEdge_success() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/v1/edges/{edgeId}", edgeId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+    }
+
+    @Test
+    @DisplayName("DELETE /edges/{edgeId} - 엣지가 없으면 404를 반환한다")
+    void deleteEdge_notFound() throws Exception {
+        // given
+        Mockito.doThrow(new ApiException(EvacuationErrorCode.MAP_EDGE_NOT_FOUND))
+                .when(mapGraphService).deleteEdge(edgeId);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/edges/{edgeId}", edgeId))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
@@ -1,23 +1,30 @@
 package com.saferoute.domain.evacuation.graph.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
 import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class MapGraphRepositoryImplTest {
@@ -85,5 +92,110 @@ class MapGraphRepositoryImplTest {
         // then
         assertThat(nodes).hasSize(1);
         assertThat(edges).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("ROOM 노드는 DOOR가 아닌 노드와 직접 연결할 수 없다")
+    void addEdge_roomWithoutDoor_throws() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode room = mock(MapNode.class);
+        MapNode hallway = mock(MapNode.class);
+        given(room.getType()).willReturn(NodeType.ROOM);
+        given(hallway.getType()).willReturn(NodeType.HALLWAY);
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphRepository.addEdge(floor, room, hallway, 3.0, true))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.INVALID_MAP_EDGE_CONNECTION.getMessage());
+    }
+
+    @Test
+    @DisplayName("ROOM-DOOR 연결은 허용된다")
+    void addEdge_roomWithDoor_success() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode room = mock(MapNode.class);
+        MapNode door = mock(MapNode.class);
+        given(room.getType()).willReturn(NodeType.ROOM);
+        given(door.getType()).willReturn(NodeType.DOOR);
+        MapEdge savedEdge = MapEdge.create(floor, room, door, 2.0, true);
+        given(mapEdgeJpaRepository.save(any(MapEdge.class))).willReturn(savedEdge);
+
+        // when
+        MapEdge result = mapGraphRepository.addEdge(floor, room, door, 2.0, true);
+
+        // then
+        assertThat(result.getDistance()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("이미 연결된 노드 쌍은 다시 연결할 수 없다 (역방향도 동일하게 차단)")
+    void addEdge_duplicate_throws() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode nodeA = mock(MapNode.class);
+        MapNode nodeB = mock(MapNode.class);
+        UUID nodeAId = UUID.randomUUID();
+        UUID nodeBId = UUID.randomUUID();
+        given(nodeA.getId()).willReturn(nodeAId);
+        given(nodeB.getId()).willReturn(nodeBId);
+        given(mapEdgeJpaRepository.existsByFromNode_IdAndToNode_IdOrFromNode_IdAndToNode_Id(
+                nodeAId, nodeBId, nodeBId, nodeAId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphRepository.addEdge(floor, nodeA, nodeB, 3.0, true))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.DUPLICATE_MAP_EDGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("노드 위치를 수정하면 dirty checking으로 반영된다 (save 호출 없음)")
+    void updateNodePosition_success() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode node = MapNode.create(floor, "ROOM1", NodeType.ROOM, "방1", 0, 0, false);
+
+        // when
+        MapNode result = mapGraphRepository.updateNodePosition(node, 10, 20);
+
+        // then
+        assertThat(result.getX()).isEqualTo(10);
+        assertThat(result.getY()).isEqualTo(20);
+        verify(mapNodeJpaRepository, never()).save(any(MapNode.class));
+    }
+
+    @Test
+    @DisplayName("노드를 삭제하면 연결된 엣지가 먼저 삭제된 후 노드가 삭제된다")
+    void deleteNode_cascadesConnectedEdges() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode node = MapNode.create(floor, "ROOM1", NodeType.ROOM, "방1", 0, 0, false);
+        UUID nodeId = UUID.randomUUID();
+        ReflectionTestUtils.setField(node, "id", nodeId);
+
+        // when
+        mapGraphRepository.deleteNode(node);
+
+        // then: 엣지 삭제가 노드 삭제보다 먼저 호출돼야 FK 제약조건 위반이 안 남
+        InOrder inOrder = inOrder(mapEdgeJpaRepository, mapNodeJpaRepository);
+        inOrder.verify(mapEdgeJpaRepository).deleteByFromNode_IdOrToNode_Id(nodeId, nodeId);
+        inOrder.verify(mapNodeJpaRepository).delete(node);
+    }
+
+    @Test
+    @DisplayName("엣지를 삭제하면 Repository에 삭제가 위임된다")
+    void deleteEdge_success() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode from = mock(MapNode.class);
+        MapNode to = mock(MapNode.class);
+        MapEdge edge = MapEdge.create(floor, from, to, 5.0, true);
+
+        // when
+        mapGraphRepository.deleteEdge(edge);
+
+        // then
+        verify(mapEdgeJpaRepository).delete(edge);
     }
 }

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
@@ -1,0 +1,262 @@
+package com.saferoute.domain.evacuation.graph.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapEdgeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapNodeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.UpdateMapNodePositionRequest;
+import com.saferoute.domain.evacuation.graph.dto.response.FloorGraphResponse;
+import com.saferoute.domain.evacuation.graph.dto.response.MapEdgeResponse;
+import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapGraphRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MapGraphServiceTest {
+
+    @InjectMocks
+    private MapGraphService mapGraphService;
+
+    @Mock
+    private MapGraphRepository mapGraphRepository;
+
+    @Mock
+    private FloorRepository floorRepository;
+
+    private final UUID floorId = UUID.randomUUID();
+    private Floor floor;
+
+    @BeforeEach
+    void setUp() {
+        floor = mock(Floor.class);
+    }
+
+    private MapNode createNode(String code, NodeType type) {
+        MapNode node = MapNode.create(floor, code, type, code, 0, 0, false);
+        ReflectionTestUtils.setField(node, "id", UUID.randomUUID());
+        return node;
+    }
+
+    // === getFloorGraph ===
+
+    @Test
+    @DisplayName("층의 노드/엣지 전체를 조회한다")
+    void getFloorGraph_success() {
+        // given
+        MapNode node = createNode("ROOM1", NodeType.ROOM);
+        MapNode doorNode = createNode("DOOR1", NodeType.DOOR);
+        MapEdge edge = MapEdge.create(floor, node, doorNode, 3.0, true);
+        ReflectionTestUtils.setField(edge, "id", UUID.randomUUID());
+        given(floorRepository.existsById(floorId)).willReturn(true);
+        given(mapGraphRepository.findNodesByFloor(floorId)).willReturn(List.of(node));
+        given(mapGraphRepository.findEdgesByFloor(floorId)).willReturn(List.of(edge));
+
+        // when
+        FloorGraphResponse response = mapGraphService.getFloorGraph(floorId);
+
+        // then
+        assertThat(response.nodes()).hasSize(1);
+        assertThat(response.edges()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 층을 조회하면 예외가 발생한다")
+    void getFloorGraph_floorNotFound_throws() {
+        // given
+        given(floorRepository.existsById(floorId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphService.getFloorGraph(floorId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(FloorErrorCode.FLOOR_NOT_FOUND.getMessage());
+    }
+
+    // === createNode ===
+
+    @Test
+    @DisplayName("노드를 생성한다")
+    void createNode_success() {
+        // given
+        CreateMapNodeRequest request = new CreateMapNodeRequest("ROOM1", NodeType.ROOM, "방1", 0.0, 0.0, false);
+        MapNode savedNode = createNode("ROOM1", NodeType.ROOM);
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(mapGraphRepository.addNode(floor, "ROOM1", NodeType.ROOM, "방1", 0.0, 0.0, false))
+                .willReturn(savedNode);
+
+        // when
+        MapNodeResponse response = mapGraphService.createNode(floorId, request);
+
+        // then
+        assertThat(response.code()).isEqualTo("ROOM1");
+        assertThat(response.type()).isEqualTo(NodeType.ROOM);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 층에 노드를 생성하려 하면 예외가 발생한다")
+    void createNode_floorNotFound_throws() {
+        // given
+        CreateMapNodeRequest request = new CreateMapNodeRequest("ROOM1", NodeType.ROOM, "방1", 0.0, 0.0, false);
+        given(floorRepository.findById(floorId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphService.createNode(floorId, request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(FloorErrorCode.FLOOR_NOT_FOUND.getMessage());
+    }
+
+    // === updateNodePosition ===
+
+    @Test
+    @DisplayName("노드 위치를 수정한다")
+    void updateNodePosition_success() {
+        // given
+        MapNode node = createNode("ROOM1", NodeType.ROOM);
+        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0);
+        given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
+        given(mapGraphRepository.updateNodePosition(node, 10.0, 20.0)).willReturn(node);
+
+        // when
+        MapNodeResponse response = mapGraphService.updateNodePosition(node.getId(), request);
+
+        // then
+        assertThat(response.id()).isEqualTo(node.getId());
+        verify(mapGraphRepository).updateNodePosition(node, 10.0, 20.0);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 노드의 위치를 수정하려 하면 예외가 발생한다")
+    void updateNodePosition_nodeNotFound_throws() {
+        // given
+        UUID unknownNodeId = UUID.randomUUID();
+        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0);
+        given(mapGraphRepository.findNodeById(unknownNodeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphService.updateNodePosition(unknownNodeId, request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.MAP_NODE_NOT_FOUND.getMessage());
+    }
+
+    // === deleteNode ===
+
+    @Test
+    @DisplayName("노드를 삭제한다")
+    void deleteNode_success() {
+        // given
+        MapNode node = createNode("ROOM1", NodeType.ROOM);
+        given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
+
+        // when
+        mapGraphService.deleteNode(node.getId());
+
+        // then
+        verify(mapGraphRepository).deleteNode(node);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 노드를 삭제하려 하면 예외가 발생한다")
+    void deleteNode_notFound_throws() {
+        // given
+        UUID unknownNodeId = UUID.randomUUID();
+        given(mapGraphRepository.findNodeById(unknownNodeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphService.deleteNode(unknownNodeId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.MAP_NODE_NOT_FOUND.getMessage());
+    }
+
+    // === createEdge ===
+
+    @Test
+    @DisplayName("엣지를 연결한다 - floor는 fromNode의 floor를 그대로 사용한다")
+    void createEdge_success() {
+        // given
+        MapNode fromNode = createNode("DOOR1", NodeType.DOOR);
+        MapNode toNode = createNode("HALLWAY1", NodeType.HALLWAY);
+        CreateMapEdgeRequest request = new CreateMapEdgeRequest(fromNode.getId(), toNode.getId(), 5.0, true);
+        MapEdge savedEdge = MapEdge.create(floor, fromNode, toNode, 5.0, true);
+
+        given(mapGraphRepository.findNodeById(fromNode.getId())).willReturn(Optional.of(fromNode));
+        given(mapGraphRepository.findNodeById(toNode.getId())).willReturn(Optional.of(toNode));
+        given(mapGraphRepository.addEdge(fromNode.getFloor(), fromNode, toNode, 5.0, true)).willReturn(savedEdge);
+
+        // when
+        MapEdgeResponse response = mapGraphService.createEdge(request);
+
+        // then
+        assertThat(response.distance()).isEqualTo(5.0);
+        assertThat(response.fromNodeId()).isEqualTo(fromNode.getId());
+        assertThat(response.toNodeId()).isEqualTo(toNode.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 노드로 엣지를 연결하려 하면 예외가 발생한다")
+    void createEdge_fromNodeNotFound_throws() {
+        // given
+        UUID unknownNodeId = UUID.randomUUID();
+        UUID toNodeId = UUID.randomUUID();
+        CreateMapEdgeRequest request = new CreateMapEdgeRequest(unknownNodeId, toNodeId, 5.0, true);
+        given(mapGraphRepository.findNodeById(unknownNodeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphService.createEdge(request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.MAP_NODE_NOT_FOUND.getMessage());
+    }
+
+    // === deleteEdge ===
+
+    @Test
+    @DisplayName("엣지를 삭제한다")
+    void deleteEdge_success() {
+        // given
+        MapNode fromNode = createNode("DOOR1", NodeType.DOOR);
+        MapNode toNode = createNode("HALLWAY1", NodeType.HALLWAY);
+        MapEdge edge = MapEdge.create(floor, fromNode, toNode, 5.0, true);
+        UUID edgeId = UUID.randomUUID();
+        ReflectionTestUtils.setField(edge, "id", edgeId);
+        given(mapGraphRepository.findEdgeById(edgeId)).willReturn(Optional.of(edge));
+
+        // when
+        mapGraphService.deleteEdge(edgeId);
+
+        // then
+        verify(mapGraphRepository).deleteEdge(edge);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 엣지를 삭제하려 하면 예외가 발생한다")
+    void deleteEdge_notFound_throws() {
+        // given
+        UUID unknownEdgeId = UUID.randomUUID();
+        given(mapGraphRepository.findEdgeById(unknownEdgeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphService.deleteEdge(unknownEdgeId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.MAP_EDGE_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

closes #22

## 📋 작업 내용

- 도면 위 노드/엣지 커스텀 편집을 위한 CRUD API 구현 (프론트 편집 UI 지원용)
- `MapGraphController`: GET `/floors/{floorId}/graph` — 편집 UI 초기 로딩용 노드/엣지 전체 조회
  - 다음 이슈(다익스트라 라우팅)의 `/routes` 엔드포인트와 역할을 분리하기 위해 별도 컨트롤러로 구성
- `MapGraphEditController`: 노드 추가/위치 수정/삭제, 엣지 연결/삭제
- room 노드는 door 노드를 거치지 않으면 다른 노드와 직접 연결 불가하도록 validation 추가
- 동일 노드 쌍 사이 중복 엣지 방지 validation 추가
- 노드 삭제 시 연결된 엣지 cascade 삭제 처리
- WebMvcTest 슬라이스에서 JPA 빈 로딩 실패하던 설정 문제 수정

## 📄 API 변경사항

<!-- Request / Response 변경 시 작성 -->

- GET `/api/v1/floors/{floorId}/graph` — 노드/엣지 전체 조회
- POST `/api/v1/floors/{floorId}/nodes` — 노드 생성
- PATCH `/api/v1/nodes/{nodeId}` — 노드 위치 수정
- DELETE `/api/v1/nodes/{nodeId}` — 노드 삭제
- POST `/api/v1/edges` — 엣지 연결
- DELETE `/api/v1/edges/{edgeId}` — 엣지 삭제

## 🧪 테스트 결과

<!-- Postman, Swagger 테스트 결과 첨부 -->

- `./gradlew test` 전체 통과
- Service/Controller 단위 테스트 작성 완료 (정상 케이스 + 존재하지 않는 층/노드/엣지 예외 케이스)

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] 테스트 통과
- [x] ./gradlew build 성공