### PR TITLE
feat: 다익스트라 기반 대피 경로 추천 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
@@ -1,0 +1,33 @@
+package com.saferoute.domain.evacuation.controller;
+
+import com.saferoute.domain.evacuation.service.EvacuationRoute;
+import com.saferoute.domain.evacuation.service.EvacuationRouteService;
+import com.saferoute.domain.evacuation.service.dto.response.EvacuationRouteResponse;
+import com.saferoute.global.api.response.ApiResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+// /graph(노드/엣지 편집용) 엔드포인트와 역할 분리를 위해 별도 컨트롤러로 구성 - MapGraphController 참고
+@RestController
+@RequestMapping("/api/v1/floors/{floorId}")
+@RequiredArgsConstructor
+public class EvacuationRouteController {
+
+    private final EvacuationRouteService evacuationRouteService;
+
+    // 시작 노드에서 가장 가까운 EXIT까지의 추천 경로 (mock data 기준, congestion/danger 0 고정)
+    @GetMapping("/routes")
+    public ResponseEntity<ApiResponse<EvacuationRouteResponse>> getShortestRoute(
+            @PathVariable UUID floorId,
+            @RequestParam UUID startNodeId
+    ) {
+        EvacuationRoute route = evacuationRouteService.findShortestRoute(floorId, startNodeId);
+        return ResponseEntity.ok(ApiResponse.success(EvacuationRouteResponse.from(route)));
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
@@ -2,7 +2,7 @@ package com.saferoute.domain.evacuation.controller;
 
 import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
-import com.saferoute.domain.evacuation.service.dto.response.EvacuationRouteResponse;
+import com.saferoute.domain.evacuation.dto.response.EvacuationRouteResponse;
 import com.saferoute.global.api.response.ApiResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/saferoute/domain/evacuation/dto/response/EvacuationRouteResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/dto/response/EvacuationRouteResponse.java
@@ -1,4 +1,4 @@
-package com.saferoute.domain.evacuation.service.dto.response;
+package com.saferoute.domain.evacuation.dto.response;
 
 import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
 import com.saferoute.domain.evacuation.service.EvacuationRoute;

--- a/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRoute.java
+++ b/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRoute.java
@@ -1,0 +1,8 @@
+package com.saferoute.domain.evacuation.service;
+
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import java.util.List;
+
+// 다익스트라 계산 결과: 시작 노드부터 도착 EXIT 노드까지의 경로와 총 가중치
+public record EvacuationRoute(List<MapNode> path, double totalWeight) {
+}

--- a/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRouteService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRouteService.java
@@ -1,0 +1,121 @@
+package com.saferoute.domain.evacuation.service;
+
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapGraphRepository;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EvacuationRouteService {
+
+    // TODO: 혼잡도 가중치 계수 - DynamoDB 혼잡도 연동 인터페이스 확정 후 담당 팀원과 조율
+    private static final double CONGESTION_WEIGHT = 1.0; // α
+    // TODO: 위험도(화재 확산 단계) 가중치 계수 - 확정 필요
+    private static final double DANGER_WEIGHT = 1.0; // β
+
+    private final MapGraphRepository mapGraphRepository;
+
+    // 시작 노드에서 가장 가까운 EXIT 대상 노드까지 최단 경로 계산 (mock data 기준, congestion/danger는 0 고정)
+    public EvacuationRoute findShortestRoute(UUID floorId, UUID startNodeId) {
+        List<MapNode> nodes = mapGraphRepository.findNodesByFloor(floorId);
+        List<MapEdge> edges = mapGraphRepository.findEdgesByFloor(floorId);
+
+        Map<UUID, MapNode> nodeById = new HashMap<>();
+        for (MapNode node : nodes) {
+            nodeById.put(node.getId(), node);
+        }
+        if (!nodeById.containsKey(startNodeId)) {
+            throw new ApiException(EvacuationErrorCode.MAP_NODE_NOT_FOUND);
+        }
+
+        Map<UUID, List<MapEdge>> adjacency = buildAdjacencyList(edges);
+
+        Map<UUID, Double> distance = new HashMap<>();
+        Map<UUID, UUID> previous = new HashMap<>();
+        distance.put(startNodeId, 0.0);
+
+        PriorityQueue<NodeDistance> queue = new PriorityQueue<>(Comparator.comparingDouble(NodeDistance::distance));
+        queue.add(new NodeDistance(startNodeId, 0.0));
+        Set<UUID> visited = new HashSet<>();
+
+        while (!queue.isEmpty()) {
+            NodeDistance current = queue.poll();
+            if (!visited.add(current.nodeId())) {
+                continue;
+            }
+
+            MapNode currentNode = nodeById.get(current.nodeId());
+            if (currentNode.isExitTarget()) {
+                return buildRoute(nodeById, previous, distance, current.nodeId());
+            }
+
+            for (MapEdge edge : adjacency.getOrDefault(current.nodeId(), Collections.emptyList())) {
+                // TODO: blocked 상태는 더 이상 MapEdge 컬럼이 아니라 훈련별 서버 메모리에서 관리됨 -
+                // 런타임 blocked 데이터 소스 연동 확정 후 여기서 제외 처리 추가 필요
+                UUID neighbor = edge.getToNode().getId().equals(current.nodeId())
+                        ? edge.getFromNode().getId()
+                        : edge.getToNode().getId();
+
+                double newDistance = distance.get(current.nodeId()) + calculateWeight(edge);
+                if (newDistance < distance.getOrDefault(neighbor, Double.MAX_VALUE)) {
+                    distance.put(neighbor, newDistance);
+                    previous.put(neighbor, current.nodeId());
+                    queue.add(new NodeDistance(neighbor, newDistance));
+                }
+            }
+        }
+
+        throw new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND);
+    }
+
+    // bidirectional 엣지만 양방향 인접 리스트에 등록, 단방향 엣지는 fromNode -> toNode 방향으로만 등록
+    private Map<UUID, List<MapEdge>> buildAdjacencyList(List<MapEdge> edges) {
+        Map<UUID, List<MapEdge>> adjacency = new HashMap<>();
+        for (MapEdge edge : edges) {
+            adjacency.computeIfAbsent(edge.getFromNode().getId(), k -> new ArrayList<>()).add(edge);
+            if (edge.isBidirectional()) {
+                adjacency.computeIfAbsent(edge.getToNode().getId(), k -> new ArrayList<>()).add(edge);
+            }
+        }
+        return adjacency;
+    }
+
+    // weight = distance + α×congestion + β×danger
+    // TODO: congestion/danger 현재 0 고정 - 혼잡도(DynamoDB)·blocked 외 danger 데이터 연동 확정 후 반영
+    private double calculateWeight(MapEdge edge) {
+        double congestion = 0.0;
+        double danger = 0.0;
+        return edge.getDistance() + CONGESTION_WEIGHT * congestion + DANGER_WEIGHT * danger;
+    }
+
+    private EvacuationRoute buildRoute(Map<UUID, MapNode> nodeById, Map<UUID, UUID> previous,
+            Map<UUID, Double> distance, UUID exitNodeId) {
+        List<MapNode> path = new ArrayList<>();
+        UUID current = exitNodeId;
+        while (current != null) {
+            path.add(nodeById.get(current));
+            current = previous.get(current);
+        }
+        Collections.reverse(path);
+        return new EvacuationRoute(path, distance.get(exitNodeId));
+    }
+
+    private record NodeDistance(UUID nodeId, double distance) {
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/service/dto/response/EvacuationRouteResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/service/dto/response/EvacuationRouteResponse.java
@@ -1,0 +1,17 @@
+package com.saferoute.domain.evacuation.service.dto.response;
+
+import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
+import com.saferoute.domain.evacuation.service.EvacuationRoute;
+import java.util.List;
+
+public record EvacuationRouteResponse(
+        List<MapNodeResponse> path,
+        double totalWeight
+) {
+    public static EvacuationRouteResponse from(EvacuationRoute route) {
+        return new EvacuationRouteResponse(
+                route.path().stream().map(MapNodeResponse::from).toList(),
+                route.totalWeight()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/global/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/saferoute/global/api/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -50,6 +51,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<Void>> handleTypeMismatch() {
+        return response(ErrorCode.INVALID_INPUT, null);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingParameter() {
         return response(ErrorCode.INVALID_INPUT, null);
     }
 

--- a/src/test/java/com/saferoute/domain/evacuation/controller/EvacuationRouteControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/controller/EvacuationRouteControllerTest.java
@@ -1,0 +1,111 @@
+package com.saferoute.domain.evacuation.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.service.EvacuationRoute;
+import com.saferoute.domain.evacuation.service.EvacuationRouteService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(EvacuationRouteController.class)
+@AutoConfigureMockMvc(addFilters = false) // Security 필터는 HTTP 매핑/예외 응답 검증과 무관하니 비활성화
+class EvacuationRouteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EvacuationRouteService evacuationRouteService;
+
+    private final UUID floorId = UUID.randomUUID();
+    private Floor floor;
+    private MapNode room1;
+    private MapNode door1;
+
+    @BeforeEach
+    void setUp() {
+        floor = mock(Floor.class);
+        room1 = createNode("ROOM1", NodeType.ROOM, false);
+        door1 = createNode("DOOR1", NodeType.DOOR, true);
+    }
+
+    private MapNode createNode(String code, NodeType type, boolean isExitTarget) {
+        MapNode node = MapNode.create(floor, code, type, code, 0, 0, isExitTarget);
+        ReflectionTestUtils.setField(node, "id", UUID.randomUUID());
+        return node;
+    }
+
+    @Test
+    @DisplayName("GET /routes - 시작 노드에서 가장 가까운 EXIT까지의 경로를 반환한다")
+    void getShortestRoute_success() throws Exception {
+        // given
+        EvacuationRoute route = new EvacuationRoute(List.of(room1, door1), 2.0);
+        given(evacuationRouteService.findShortestRoute(floorId, room1.getId())).willReturn(route);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/floors/{floorId}/routes", floorId)
+                        .param("startNodeId", room1.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.totalWeight").value(2.0))
+                .andExpect(jsonPath("$.result.path.length()").value(2))
+                .andExpect(jsonPath("$.result.path[1].code").value("DOOR1"));
+    }
+
+    @Test
+    @DisplayName("GET /routes - 시작 노드가 없으면 404를 반환한다")
+    void getShortestRoute_startNodeNotFound() throws Exception {
+        // given
+        UUID unknownNodeId = UUID.randomUUID();
+        given(evacuationRouteService.findShortestRoute(floorId, unknownNodeId))
+                .willThrow(new ApiException(EvacuationErrorCode.MAP_NODE_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/floors/{floorId}/routes", floorId)
+                        .param("startNodeId", unknownNodeId.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.message", containsString("노드를 찾을 수 없습니다")));
+    }
+
+    @Test
+    @DisplayName("GET /routes - 도달 가능한 EXIT이 없으면 404를 반환한다")
+    void getShortestRoute_noReachableExit() throws Exception {
+        // given
+        given(evacuationRouteService.findShortestRoute(floorId, room1.getId()))
+                .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/floors/{floorId}/routes", floorId)
+                        .param("startNodeId", room1.getId().toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.message").value("도달 가능한 EXIT 노드가 없습니다."));
+    }
+
+    @Test
+    @DisplayName("GET /routes - startNodeId 파라미터가 없으면 400을 반환한다")
+    void getShortestRoute_missingParam() throws Exception {
+        mockMvc.perform(get("/api/v1/floors/{floorId}/routes", floorId))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/saferoute/domain/evacuation/service/EvacuationRouteServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/service/EvacuationRouteServiceTest.java
@@ -1,0 +1,129 @@
+package com.saferoute.domain.evacuation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapGraphRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EvacuationRouteServiceTest {
+
+    @InjectMocks
+    private EvacuationRouteService evacuationRouteService;
+
+    @Mock
+    private MapGraphRepository mapGraphRepository;
+
+    private final UUID floorId = UUID.randomUUID();
+    private Floor floor;
+
+    // 테스트용 그래프:
+    // ROOM1 -- DOOR1 -- HALLWAY1 -- STAIR1(EXIT, 우회 경로)
+    //                       |
+    //                   HALLWAY2 -- STAIR2(EXIT, 최단 경로)
+    private MapNode room1;
+    private MapNode door1;
+    private MapNode hallway1;
+    private MapNode hallway2;
+    private MapNode stair1;
+    private MapNode stair2;
+
+    @BeforeEach
+    void setUp() {
+        floor = mock(Floor.class);
+
+        room1 = createNode("ROOM1", NodeType.ROOM, false);
+        door1 = createNode("DOOR1", NodeType.DOOR, false);
+        hallway1 = createNode("HALLWAY1", NodeType.HALLWAY, false);
+        hallway2 = createNode("HALLWAY2", NodeType.HALLWAY, false);
+        stair1 = createNode("STAIR1", NodeType.STAIR, true);
+        stair2 = createNode("STAIR2", NodeType.STAIR, true);
+    }
+
+    private MapNode createNode(String code, NodeType type, boolean isExitTarget) {
+        MapNode node = MapNode.create(floor, code, type, code, 0, 0, isExitTarget);
+        ReflectionTestUtils.setField(node, "id", UUID.randomUUID());
+        return node;
+    }
+
+    private MapEdge createEdge(MapNode from, MapNode to, double distance) {
+        MapEdge edge = MapEdge.create(floor, from, to, distance, true);
+        ReflectionTestUtils.setField(edge, "id", UUID.randomUUID());
+        return edge;
+    }
+
+    @Test
+    @DisplayName("여러 EXIT 후보 중 가장 가까운 경로를 반환한다")
+    void findShortestRoute_picksNearestExit() {
+        // given
+        MapEdge e1 = createEdge(room1, door1, 2);
+        MapEdge e2 = createEdge(door1, hallway1, 5);
+        MapEdge e3 = createEdge(hallway1, stair1, 10); // 멀리 있는 EXIT
+        MapEdge e4 = createEdge(hallway1, hallway2, 3);
+        MapEdge e5 = createEdge(hallway2, stair2, 2); // 가까운 EXIT
+
+        given(mapGraphRepository.findNodesByFloor(floorId))
+                .willReturn(List.of(room1, door1, hallway1, hallway2, stair1, stair2));
+        given(mapGraphRepository.findEdgesByFloor(floorId))
+                .willReturn(List.of(e1, e2, e3, e4, e5));
+
+        // when
+        EvacuationRoute route = evacuationRouteService.findShortestRoute(floorId, room1.getId());
+
+        // then
+        assertThat(route.totalWeight()).isEqualTo(2 + 5 + 3 + 2);
+        assertThat(route.path()).containsExactly(room1, door1, hallway1, hallway2, stair2);
+    }
+
+    @Test
+    @DisplayName("도달 가능한 EXIT이 없으면 예외를 던진다")
+    void findShortestRoute_noReachableExit_throws() {
+        // given
+        MapNode isolatedRoom = createNode("ISOLATED", NodeType.ROOM, false);
+        MapNode exitOnly = createNode("EXIT_ONLY", NodeType.STAIR, true);
+        // 두 노드 사이 엣지 없음 -> 도달 불가
+
+        given(mapGraphRepository.findNodesByFloor(floorId))
+                .willReturn(List.of(isolatedRoom, exitOnly));
+        given(mapGraphRepository.findEdgesByFloor(floorId))
+                .willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> evacuationRouteService.findShortestRoute(floorId, isolatedRoom.getId()))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("시작 노드가 해당 층에 없으면 예외를 던진다")
+    void findShortestRoute_startNodeNotInFloor_throws() {
+        // given
+        given(mapGraphRepository.findNodesByFloor(floorId)).willReturn(List.of(room1));
+        given(mapGraphRepository.findEdgesByFloor(floorId)).willReturn(List.of());
+
+        UUID unknownNodeId = UUID.randomUUID();
+
+        // when & then
+        assertThatThrownBy(() -> evacuationRouteService.findShortestRoute(floorId, unknownNodeId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.MAP_NODE_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #24
- 관련: #22 (노드/엣지 커스텀 편집 API) — 같은 그래프 데이터(MapNode/MapEdge)를 사용하지만 코드 의존성은 없음

## ✨ 작업 내용

### 다익스트라 기반 대피 경로 추천
- 시작 노드에서 가장 가까운 EXIT 노드까지 최단 경로 계산 (EvacuationRouteService)
- 가중치 공식 적용: `distance + α×congestion + β×danger` (congestion/danger는 0 고정 mock, 카메라 혼잡도 연동 이후 별도 이슈에서 고도화 예정)
- bidirectional 엣지만 양방향 탐색, 단방향 엣지는 from→to로만 탐색
- 시작 노드 미존재 시 `MAP_NODE_NOT_FOUND` 예외 처리
- 출구 노드 미존재 / 경로 없음(고립 노드)은 `EVACUATION_ROUTE_NOT_FOUND`로 통합 처리
- 경로 계산 결과 도메인 객체(`EvacuationRoute`) 및 응답 DTO(`EvacuationRouteResponse`) 설계
  - `EvacuationRoute`는 API 응답 DTO가 아니라 다익스트라 계산 결과를 담는 내부 도메인 객체
  - 요청은 request body 없이 `@RequestParam startNodeId`로만 받음 (별도 Request DTO 없음)

### 컨트롤러 분리
- `/graph`(노드/엣지 편집용) 엔드포인트와 역할을 분리하기 위해 `EvacuationRouteController`를 `MapGraphController`와 별도로 구성

### 버그 수정
- 필수 쿼리 파라미터(`startNodeId`) 누락 시 500 대신 400을 반환하도록 `GlobalExceptionHandler`에 `MissingServletRequestParameterException` 핸들러 추가
- ⚠️ `GlobalExceptionHandler`는 전역 파일이라 이 수정이 프로젝트 전체 API에 적용됩니다 (이번 라우팅 API에 한정된 변경이 아님)

## 🔗 API

### 대피 경로 추천
```http
GET /api/v1/floors/{floorId}/routes?startNodeId={startNodeId}
```

## 🧪 테스트 결과

<!-- Postman, Swagger 테스트 결과 첨부 -->

- `./gradlew test` 전체 통과
- Service/Controller 단위 테스트 작성 완료 (정상 경로 / 시작 노드 없음 / 경로 없음 예외 케이스)

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] 테스트 통과
- [x] ./gradlew build 성공