### PR TITLE
feat: IoT 유도등 등록/관리 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
@@ -1,0 +1,83 @@
+package com.saferoute.domain.device.controller;
+
+import com.saferoute.domain.device.dto.request.ConfigureGuidanceRequest;
+import com.saferoute.domain.device.dto.request.CreateIoTLightRequest;
+import com.saferoute.domain.device.dto.request.UpdateIoTLightRequest;
+import com.saferoute.domain.device.dto.response.IoTLightResponse;
+import com.saferoute.domain.device.service.IoTLightService;
+import com.saferoute.global.api.response.ApiResponse;
+import com.saferoute.global.api.response.IoTLightSuccessCode;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/lights")
+@RequiredArgsConstructor
+public class IoTLightController {
+
+    private final IoTLightService iotLightService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<IoTLightResponse>> createLight(
+            @Valid @RequestBody CreateIoTLightRequest request
+    ) {
+        IoTLightResponse response = iotLightService.createLight(request);
+        return ResponseEntity.status(IoTLightSuccessCode.IOT_LIGHT_CREATED.getHttpStatus())
+                .body(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_CREATED, response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<IoTLightResponse>>> getLights(
+            @RequestParam(required = false) UUID floorId
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_LIST_FOUND, iotLightService.getLights(floorId)));
+    }
+
+    @GetMapping("/{lightId}")
+    public ResponseEntity<ApiResponse<IoTLightResponse>> getLight(@PathVariable UUID lightId) {
+        return ResponseEntity.ok(
+                ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_DETAIL_FOUND, iotLightService.getLight(lightId)));
+    }
+
+    @PatchMapping("/{lightId}/guidance")
+    public ResponseEntity<ApiResponse<IoTLightResponse>> configureGuidance(
+            @PathVariable UUID lightId,
+            @Valid @RequestBody ConfigureGuidanceRequest request
+    ) {
+        IoTLightResponse response = iotLightService.configureGuidance(lightId, request);
+        return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_GUIDANCE_CONFIGURED, response));
+    }
+
+    @PatchMapping("/{lightId}")
+    public ResponseEntity<ApiResponse<IoTLightResponse>> updateLight(
+            @PathVariable UUID lightId,
+            @Valid @RequestBody UpdateIoTLightRequest request
+    ) {
+        IoTLightResponse response = iotLightService.updateLight(lightId, request);
+        return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_UPDATED, response));
+    }
+
+    @PatchMapping("/{lightId}/enable")
+    public ResponseEntity<ApiResponse<IoTLightResponse>> enableLight(@PathVariable UUID lightId) {
+        IoTLightResponse response = iotLightService.enableLight(lightId);
+        return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_ENABLED, response));
+    }
+
+    @PatchMapping("/{lightId}/disable")
+    public ResponseEntity<ApiResponse<IoTLightResponse>> disableLight(@PathVariable UUID lightId) {
+        IoTLightResponse response = iotLightService.disableLight(lightId);
+        return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_DISABLED, response));
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/dto/request/ConfigureGuidanceRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/ConfigureGuidanceRequest.java
@@ -1,0 +1,10 @@
+package com.saferoute.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ConfigureGuidanceRequest(
+        @NotNull UUID decisionNodeId,
+        @NotNull UUID leftEdgeId,
+        @NotNull UUID rightEdgeId
+) {}

--- a/src/main/java/com/saferoute/domain/device/dto/request/CreateIoTLightRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/CreateIoTLightRequest.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 
 public record CreateIoTLightRequest(
         @NotNull UUID floorId,
-        @NotBlank String code,
         @NotBlank String name,
         @NotNull Double x,
         @NotNull Double y

--- a/src/main/java/com/saferoute/domain/device/dto/request/CreateIoTLightRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/CreateIoTLightRequest.java
@@ -1,0 +1,13 @@
+package com.saferoute.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record CreateIoTLightRequest(
+        @NotNull UUID floorId,
+        @NotBlank String code,
+        @NotBlank String name,
+        @NotNull Double x,
+        @NotNull Double y
+) {}

--- a/src/main/java/com/saferoute/domain/device/dto/request/UpdateIoTLightRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/UpdateIoTLightRequest.java
@@ -1,0 +1,10 @@
+package com.saferoute.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateIoTLightRequest(
+        @NotBlank String name,
+        @NotNull Double x,
+        @NotNull Double y
+) {}

--- a/src/main/java/com/saferoute/domain/device/dto/response/IoTLightResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/IoTLightResponse.java
@@ -1,0 +1,34 @@
+package com.saferoute.domain.device.dto.response;
+
+import com.saferoute.domain.device.entity.IoTLight;
+import java.util.UUID;
+
+public record IoTLightResponse(
+        UUID id,
+        String code,
+        String name,
+        UUID floorId,
+        double x,
+        double y,
+        UUID decisionNodeId,
+        UUID leftEdgeId,
+        UUID rightEdgeId,
+        boolean guidanceConfigured,
+        boolean enabled
+) {
+    public static IoTLightResponse from(IoTLight light) {
+        return new IoTLightResponse(
+                light.getId(),
+                light.getCode(),
+                light.getName(),
+                light.getCustomNode().getFloor().getId(),
+                light.getCustomNode().getX(),
+                light.getCustomNode().getY(),
+                light.getDecisionNode() != null ? light.getDecisionNode().getId() : null,
+                light.getLeftEdge() != null ? light.getLeftEdge().getId() : null,
+                light.getRightEdge() != null ? light.getRightEdge().getId() : null,
+                light.isGuidanceConfigured(),
+                light.isEnabled()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/repository/IoTLightJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/IoTLightJpaRepository.java
@@ -15,8 +15,6 @@ public interface IoTLightJpaRepository extends JpaRepository<IoTLight, UUID> {
 
     Optional<IoTLight> findByCode(String code);
 
-    boolean existsByCode(String code);
-
     Optional<IoTLight> findByCustomNode_Id(UUID customNodeId);
 
     // 특정 분기점에 설치된 유도등 (경로 재계산 시 방향 지시 대상 조회용)

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -53,6 +53,7 @@ public class IoTLightService {
         return IoTLightResponse.from(light);
     }
 
+    @Transactional(readOnly = true)
     public List<IoTLightResponse> getLights(UUID floorId) {
         List<IoTLight> lights = floorId != null
                 ? iotLightJpaRepository.findAllByCustomNode_Floor_Id(floorId)
@@ -60,6 +61,7 @@ public class IoTLightService {
         return lights.stream().map(IoTLightResponse::from).toList();
     }
 
+    @Transactional(readOnly = true)
     public IoTLightResponse getLight(UUID lightId) {
         return IoTLightResponse.from(findLightOrThrow(lightId));
     }

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -1,0 +1,120 @@
+package com.saferoute.domain.device.service;
+
+import com.saferoute.domain.device.dto.request.ConfigureGuidanceRequest;
+import com.saferoute.domain.device.dto.request.CreateIoTLightRequest;
+import com.saferoute.domain.device.dto.request.UpdateIoTLightRequest;
+import com.saferoute.domain.device.dto.response.IoTLightResponse;
+import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.repository.IoTLightJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.error.IoTLightErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IoTLightService {
+
+    private final IoTLightJpaRepository iotLightJpaRepository;
+    private final MapNodeJpaRepository mapNodeJpaRepository;
+    private final MapEdgeJpaRepository mapEdgeJpaRepository;
+    private final FloorRepository floorRepository;
+
+    @Transactional
+    public IoTLightResponse createLight(CreateIoTLightRequest request) {
+        Floor floor = floorRepository.findById(request.floorId())
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+
+        if (iotLightJpaRepository.existsByCode(request.code())) {
+            throw new ApiException(IoTLightErrorCode.DUPLICATE_LIGHT_CODE);
+        }
+
+        // customNode의 code/name은 유도등 자체의 code/name을 그대로 사용한다.
+        // IoTLight.code는 시스템 전역 유일이 보장되므로 MapNode의 (floor, code) 유니크 제약도 자동 충족된다.
+        MapNode customNode = mapNodeJpaRepository.save(
+                MapNode.createCustom(floor, request.code(), request.name(), request.x(), request.y())
+        );
+
+        IoTLight light = iotLightJpaRepository.save(
+                IoTLight.create(request.code(), request.name(), customNode)
+        );
+
+        return IoTLightResponse.from(light);
+    }
+
+    public List<IoTLightResponse> getLights(UUID floorId) {
+        List<IoTLight> lights = floorId != null
+                ? iotLightJpaRepository.findAllByCustomNode_Floor_Id(floorId)
+                : iotLightJpaRepository.findAll();
+        return lights.stream().map(IoTLightResponse::from).toList();
+    }
+
+    public IoTLightResponse getLight(UUID lightId) {
+        return IoTLightResponse.from(findLightOrThrow(lightId));
+    }
+
+    @Transactional
+    public IoTLightResponse configureGuidance(UUID lightId, ConfigureGuidanceRequest request) {
+        IoTLight light = findLightOrThrow(lightId);
+
+        MapNode decisionNode = mapNodeJpaRepository.findById(request.decisionNodeId())
+                .orElseThrow(() -> new ApiException(IoTLightErrorCode.DECISION_NODE_NOT_FOUND));
+        MapEdge leftEdge = mapEdgeJpaRepository.findById(request.leftEdgeId())
+                .orElseThrow(() -> new ApiException(IoTLightErrorCode.GUIDANCE_EDGE_NOT_FOUND));
+        MapEdge rightEdge = mapEdgeJpaRepository.findById(request.rightEdgeId())
+                .orElseThrow(() -> new ApiException(IoTLightErrorCode.GUIDANCE_EDGE_NOT_FOUND));
+
+        validateConnectedToDecisionNode(decisionNode, leftEdge);
+        validateConnectedToDecisionNode(decisionNode, rightEdge);
+
+        light.configureGuidance(decisionNode, leftEdge, rightEdge);
+        return IoTLightResponse.from(light);
+    }
+
+    @Transactional
+    public IoTLightResponse updateLight(UUID lightId, UpdateIoTLightRequest request) {
+        IoTLight light = findLightOrThrow(lightId);
+        light.rename(request.name());
+        light.getCustomNode().moveTo(request.x(), request.y());
+        return IoTLightResponse.from(light);
+    }
+
+    @Transactional
+    public IoTLightResponse enableLight(UUID lightId) {
+        IoTLight light = findLightOrThrow(lightId);
+        light.enable();
+        return IoTLightResponse.from(light);
+    }
+
+    @Transactional
+    public IoTLightResponse disableLight(UUID lightId) {
+        IoTLight light = findLightOrThrow(lightId);
+        light.disable();
+        return IoTLightResponse.from(light);
+    }
+
+    private IoTLight findLightOrThrow(UUID lightId) {
+        return iotLightJpaRepository.findById(lightId)
+                .orElseThrow(() -> new ApiException(IoTLightErrorCode.IOT_LIGHT_NOT_FOUND));
+    }
+
+    // leftEdge/rightEdge가 실제로 decisionNode에 연결된 엣지인지 검증 (엔티티가 아닌 Service 책임)
+    private void validateConnectedToDecisionNode(MapNode decisionNode, MapEdge edge) {
+        boolean connected = edge.getFromNode().getId().equals(decisionNode.getId())
+                || edge.getToNode().getId().equals(decisionNode.getId());
+        if (!connected) {
+            throw new ApiException(IoTLightErrorCode.INVALID_GUIDANCE_EDGE);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -68,6 +68,12 @@ public class IoTLightService {
     public IoTLightResponse configureGuidance(UUID lightId, ConfigureGuidanceRequest request) {
         IoTLight light = findLightOrThrow(lightId);
 
+        // leftEdge/rightEdge가 같은 엣지면 IoTLight.configureGuidance()가 IllegalArgumentException을
+        // 던지는데 GlobalExceptionHandler가 이를 500으로 처리하므로 여기서 먼저 ApiException으로 막는다.
+        if (request.leftEdgeId().equals(request.rightEdgeId())) {
+            throw new ApiException(IoTLightErrorCode.INVALID_GUIDANCE_EDGE);
+        }
+
         MapNode decisionNode = mapNodeJpaRepository.findById(request.decisionNodeId())
                 .orElseThrow(() -> new ApiException(IoTLightErrorCode.DECISION_NODE_NOT_FOUND));
         MapEdge leftEdge = mapEdgeJpaRepository.findById(request.leftEdgeId())

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -36,21 +36,25 @@ public class IoTLightService {
         Floor floor = floorRepository.findById(request.floorId())
                 .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
 
-        if (iotLightJpaRepository.existsByCode(request.code())) {
-            throw new ApiException(IoTLightErrorCode.DUPLICATE_LIGHT_CODE);
-        }
+        String code = generateLightCode();
 
         // customNode의 code/name은 유도등 자체의 code/name을 그대로 사용한다.
         // IoTLight.code는 시스템 전역 유일이 보장되므로 MapNode의 (floor, code) 유니크 제약도 자동 충족된다.
         MapNode customNode = mapNodeJpaRepository.save(
-                MapNode.createCustom(floor, request.code(), request.name(), request.x(), request.y())
+                MapNode.createCustom(floor, code, request.name(), request.x(), request.y())
         );
 
         IoTLight light = iotLightJpaRepository.save(
-                IoTLight.create(request.code(), request.name(), customNode)
+                IoTLight.create(code, request.name(), customNode)
         );
 
         return IoTLightResponse.from(light);
+    }
+
+    // 유도등 code는 기기가 보고하는 시리얼이 아니라 서버가 등록 시점에 채번하는 식별자다 (예: LIGHT_001).
+    private String generateLightCode() {
+        long seq = iotLightJpaRepository.count() + 1;
+        return "LIGHT_%03d".formatted(seq);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/saferoute/global/api/error/IoTLightErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/IoTLightErrorCode.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpStatus;
 public enum IoTLightErrorCode implements BaseErrorCode {
 
     IOT_LIGHT_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT001", "유도등을 찾을 수 없습니다."),
-    DUPLICATE_LIGHT_CODE(HttpStatus.CONFLICT, "IOTLIGHT002", "이미 등록된 유도등 코드입니다."),
     DECISION_NODE_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT003", "분기 노드를 찾을 수 없습니다."),
     GUIDANCE_EDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT004", "안내 통로(엣지)를 찾을 수 없습니다."),
     INVALID_GUIDANCE_EDGE(HttpStatus.BAD_REQUEST, "IOTLIGHT005", "leftEdge/rightEdge는 decisionNode에 연결된 엣지여야 합니다.");

--- a/src/main/java/com/saferoute/global/api/error/IoTLightErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/IoTLightErrorCode.java
@@ -1,0 +1,21 @@
+package com.saferoute.global.api.error;
+
+import com.saferoute.global.api.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum IoTLightErrorCode implements BaseErrorCode {
+
+    IOT_LIGHT_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT001", "유도등을 찾을 수 없습니다."),
+    DUPLICATE_LIGHT_CODE(HttpStatus.CONFLICT, "IOTLIGHT002", "이미 등록된 유도등 코드입니다."),
+    DECISION_NODE_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT003", "분기 노드를 찾을 수 없습니다."),
+    GUIDANCE_EDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT004", "안내 통로(엣지)를 찾을 수 없습니다."),
+    INVALID_GUIDANCE_EDGE(HttpStatus.BAD_REQUEST, "IOTLIGHT005", "leftEdge/rightEdge는 decisionNode에 연결된 엣지여야 합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/saferoute/global/api/response/IoTLightSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/IoTLightSuccessCode.java
@@ -1,0 +1,23 @@
+package com.saferoute.global.api.response;
+
+import com.saferoute.global.api.code.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum IoTLightSuccessCode implements BaseCode {
+
+    IOT_LIGHT_CREATED(HttpStatus.CREATED, "IOTLIGHT_SUCCESS_001", "유도등이 등록되었습니다."),
+    IOT_LIGHT_LIST_FOUND(HttpStatus.OK, "IOTLIGHT_SUCCESS_002", "유도등 목록 조회에 성공했습니다."),
+    IOT_LIGHT_DETAIL_FOUND(HttpStatus.OK, "IOTLIGHT_SUCCESS_003", "유도등 상세 조회에 성공했습니다."),
+    IOT_LIGHT_GUIDANCE_CONFIGURED(HttpStatus.OK, "IOTLIGHT_SUCCESS_004", "분기 경로가 설정되었습니다."),
+    IOT_LIGHT_UPDATED(HttpStatus.OK, "IOTLIGHT_SUCCESS_005", "유도등 정보가 수정되었습니다."),
+    IOT_LIGHT_ENABLED(HttpStatus.OK, "IOTLIGHT_SUCCESS_006", "유도등이 활성화되었습니다."),
+    IOT_LIGHT_DISABLED(HttpStatus.OK, "IOTLIGHT_SUCCESS_007", "유도등이 비활성화되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/test/java/com/saferoute/domain/device/controller/IoTLightControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/IoTLightControllerTest.java
@@ -1,0 +1,184 @@
+package com.saferoute.domain.device.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.device.dto.request.ConfigureGuidanceRequest;
+import com.saferoute.domain.device.dto.request.CreateIoTLightRequest;
+import com.saferoute.domain.device.dto.request.UpdateIoTLightRequest;
+import com.saferoute.domain.device.dto.response.IoTLightResponse;
+import com.saferoute.domain.device.service.IoTLightService;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.error.IoTLightErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(IoTLightController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class IoTLightControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private IoTLightService iotLightService;
+
+    private final UUID lightId = UUID.randomUUID();
+    private final UUID floorId = UUID.randomUUID();
+
+    private IoTLightResponse sampleResponse() {
+        return new IoTLightResponse(lightId, "LIGHT_001", "복도1 유도등", floorId, 0.3, 0.4,
+                null, null, null, false, true);
+    }
+
+    // === createLight ===
+
+    @Test
+    @DisplayName("POST /lights - 유도등을 등록하면 201을 반환한다")
+    void createLight_success() throws Exception {
+        // given
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        given(iotLightService.createLight(any())).willReturn(sampleResponse());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/lights")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.code").value("LIGHT_001"));
+    }
+
+    @Test
+    @DisplayName("POST /lights - 층이 없으면 404를 반환한다")
+    void createLight_floorNotFound() throws Exception {
+        // given
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        given(iotLightService.createLight(any()))
+                .willThrow(new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/lights")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", containsString("도면을 찾을 수 없습니다")));
+    }
+
+    @Test
+    @DisplayName("POST /lights - code가 비어있으면 400을 반환한다")
+    void createLight_blankCode_returnsBadRequest() throws Exception {
+        String invalidJson = """
+                {"floorId":"%s","code":"","name":"복도1 유도등","x":0.3,"y":0.4}
+                """.formatted(floorId);
+
+        mockMvc.perform(post("/api/v1/lights")
+                        .contentType("application/json")
+                        .content(invalidJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    // === getLights / getLight ===
+
+    @Test
+    @DisplayName("GET /lights - 층별로 유도등 목록을 조회한다")
+    void getLights_success() throws Exception {
+        given(iotLightService.getLights(floorId)).willReturn(List.of(sampleResponse()));
+
+        mockMvc.perform(get("/api/v1/lights").param("floorId", floorId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /lights/{lightId} - 유도등이 없으면 404를 반환한다")
+    void getLight_notFound() throws Exception {
+        given(iotLightService.getLight(lightId))
+                .willThrow(new ApiException(IoTLightErrorCode.IOT_LIGHT_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/lights/{lightId}", lightId))
+                .andExpect(status().isNotFound());
+    }
+
+    // === configureGuidance ===
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/guidance - 분기 경로를 설정하면 200을 반환한다")
+    void configureGuidance_success() throws Exception {
+        ConfigureGuidanceRequest request =
+                new ConfigureGuidanceRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        given(iotLightService.configureGuidance(eq(lightId), any())).willReturn(sampleResponse());
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/guidance", lightId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/guidance - 연결 안 된 엣지면 400을 반환한다")
+    void configureGuidance_invalidEdge_returnsBadRequest() throws Exception {
+        ConfigureGuidanceRequest request =
+                new ConfigureGuidanceRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        given(iotLightService.configureGuidance(eq(lightId), any()))
+                .willThrow(new ApiException(IoTLightErrorCode.INVALID_GUIDANCE_EDGE));
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/guidance", lightId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // === updateLight ===
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId} - 이름/위치를 수정하면 200을 반환한다")
+    void updateLight_success() throws Exception {
+        UpdateIoTLightRequest request = new UpdateIoTLightRequest("변경된 이름", 0.7, 0.8);
+        given(iotLightService.updateLight(eq(lightId), any())).willReturn(sampleResponse());
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}", lightId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    // === enable / disable ===
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/enable - 활성화하면 200을 반환한다")
+    void enableLight_success() throws Exception {
+        given(iotLightService.enableLight(lightId)).willReturn(sampleResponse());
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/enable", lightId))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/disable - 비활성화하면 200을 반환한다")
+    void disableLight_success() throws Exception {
+        given(iotLightService.disableLight(lightId)).willReturn(sampleResponse());
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/disable", lightId))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/saferoute/domain/device/controller/IoTLightControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/IoTLightControllerTest.java
@@ -56,7 +56,7 @@ class IoTLightControllerTest {
     @DisplayName("POST /lights - 유도등을 등록하면 201을 반환한다")
     void createLight_success() throws Exception {
         // given
-        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "복도1 유도등", 0.3, 0.4);
         given(iotLightService.createLight(any())).willReturn(sampleResponse());
 
         // when & then
@@ -72,7 +72,7 @@ class IoTLightControllerTest {
     @DisplayName("POST /lights - 층이 없으면 404를 반환한다")
     void createLight_floorNotFound() throws Exception {
         // given
-        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "복도1 유도등", 0.3, 0.4);
         given(iotLightService.createLight(any()))
                 .willThrow(new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
 
@@ -85,10 +85,10 @@ class IoTLightControllerTest {
     }
 
     @Test
-    @DisplayName("POST /lights - code가 비어있으면 400을 반환한다")
-    void createLight_blankCode_returnsBadRequest() throws Exception {
+    @DisplayName("POST /lights - name이 비어있으면 400을 반환한다")
+    void createLight_blankName_returnsBadRequest() throws Exception {
         String invalidJson = """
-                {"floorId":"%s","code":"","name":"복도1 유도등","x":0.3,"y":0.4}
+                {"floorId":"%s","name":"","x":0.3,"y":0.4}
                 """.formatted(floorId);
 
         mockMvc.perform(post("/api/v1/lights")

--- a/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
@@ -219,6 +219,24 @@ class IoTLightServiceTest {
     }
 
     @Test
+    @DisplayName("leftEdge와 rightEdge가 같으면 예외가 발생한다 (500이 아닌 400)")
+    void configureGuidance_sameLeftAndRightEdge_throws() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        UUID decisionNodeId = UUID.randomUUID();
+        UUID sameEdgeId = UUID.randomUUID();
+        ConfigureGuidanceRequest request = new ConfigureGuidanceRequest(decisionNodeId, sameEdgeId, sameEdgeId);
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when & then: decisionNode/엣지 조회 전에 걸러지므로 관련 mock 없이도 검증 가능
+        assertThatThrownBy(() -> iotLightService.configureGuidance(light.getId(), request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.INVALID_GUIDANCE_EDGE.getMessage());
+    }
+
+    @Test
     @DisplayName("존재하지 않는 decisionNode로 설정하려 하면 예외가 발생한다")
     void configureGuidance_decisionNodeNotFound_throws() {
         // given

--- a/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
@@ -1,0 +1,276 @@
+package com.saferoute.domain.device.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.saferoute.domain.device.dto.request.ConfigureGuidanceRequest;
+import com.saferoute.domain.device.dto.request.CreateIoTLightRequest;
+import com.saferoute.domain.device.dto.request.UpdateIoTLightRequest;
+import com.saferoute.domain.device.dto.response.IoTLightResponse;
+import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.repository.IoTLightJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.error.IoTLightErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class IoTLightServiceTest {
+
+    @InjectMocks
+    private IoTLightService iotLightService;
+
+    @Mock
+    private IoTLightJpaRepository iotLightJpaRepository;
+
+    @Mock
+    private MapNodeJpaRepository mapNodeJpaRepository;
+
+    @Mock
+    private MapEdgeJpaRepository mapEdgeJpaRepository;
+
+    @Mock
+    private FloorRepository floorRepository;
+
+    private final UUID floorId = UUID.randomUUID();
+    private Floor floor;
+
+    @BeforeEach
+    void setUp() {
+        floor = mock(Floor.class);
+    }
+
+    private MapNode createNode(String code, NodeType type) {
+        MapNode node = type == NodeType.CUSTOM
+                ? MapNode.createCustom(floor, code, code, 0, 0)
+                : MapNode.create(floor, code, type, code, 0, 0, false);
+        ReflectionTestUtils.setField(node, "id", UUID.randomUUID());
+        return node;
+    }
+
+    private MapEdge createEdge(MapNode from, MapNode to) {
+        MapEdge edge = MapEdge.create(floor, from, to, 3.0, true);
+        ReflectionTestUtils.setField(edge, "id", UUID.randomUUID());
+        return edge;
+    }
+
+    private IoTLight createLight(String code, MapNode customNode) {
+        IoTLight light = IoTLight.create(code, code, customNode);
+        ReflectionTestUtils.setField(light, "id", UUID.randomUUID());
+        return light;
+    }
+
+    // === createLight ===
+
+    @Test
+    @DisplayName("유도등을 등록하면 도면 위치 노드가 함께 생성된다")
+    void createLight_success() {
+        // given
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight savedLight = createLight("LIGHT_001", customNode);
+
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(iotLightJpaRepository.existsByCode("LIGHT_001")).willReturn(false);
+        given(mapNodeJpaRepository.save(any(MapNode.class))).willReturn(customNode);
+        given(iotLightJpaRepository.save(any(IoTLight.class))).willReturn(savedLight);
+
+        // when
+        IoTLightResponse response = iotLightService.createLight(request);
+
+        // then
+        assertThat(response.code()).isEqualTo("LIGHT_001");
+        assertThat(response.enabled()).isTrue();
+        assertThat(response.guidanceConfigured()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 층에 등록하려 하면 예외가 발생한다")
+    void createLight_floorNotFound_throws() {
+        // given
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        given(floorRepository.findById(floorId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.createLight(request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(FloorErrorCode.FLOOR_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미 등록된 code로 등록하려 하면 예외가 발생한다")
+    void createLight_duplicateCode_throws() {
+        // given
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(iotLightJpaRepository.existsByCode("LIGHT_001")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.createLight(request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.DUPLICATE_LIGHT_CODE.getMessage());
+    }
+
+    // === getLights / getLight ===
+
+    @Test
+    @DisplayName("층 ID로 유도등 목록을 조회한다")
+    void getLights_byFloor_success() {
+        // given
+        MapNode node = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", node);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Id(floorId)).willReturn(List.of(light));
+
+        // when
+        List<IoTLightResponse> responses = iotLightService.getLights(floorId);
+
+        // then
+        assertThat(responses).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유도등을 조회하면 예외가 발생한다")
+    void getLight_notFound_throws() {
+        // given
+        UUID unknownId = UUID.randomUUID();
+        given(iotLightJpaRepository.findById(unknownId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.getLight(unknownId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.IOT_LIGHT_NOT_FOUND.getMessage());
+    }
+
+    // === configureGuidance ===
+
+    @Test
+    @DisplayName("decisionNode에 연결된 엣지로 분기 경로를 설정한다")
+    void configureGuidance_success() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        MapNode decisionNode = createNode("HALLWAY1", NodeType.HALLWAY);
+        MapNode leftTarget = createNode("HALLWAY2", NodeType.HALLWAY);
+        MapNode rightTarget = createNode("HALLWAY3", NodeType.HALLWAY);
+        MapEdge leftEdge = createEdge(decisionNode, leftTarget);
+        MapEdge rightEdge = createEdge(decisionNode, rightTarget);
+
+        ConfigureGuidanceRequest request =
+                new ConfigureGuidanceRequest(decisionNode.getId(), leftEdge.getId(), rightEdge.getId());
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+        given(mapNodeJpaRepository.findById(decisionNode.getId())).willReturn(Optional.of(decisionNode));
+        given(mapEdgeJpaRepository.findById(leftEdge.getId())).willReturn(Optional.of(leftEdge));
+        given(mapEdgeJpaRepository.findById(rightEdge.getId())).willReturn(Optional.of(rightEdge));
+
+        // when
+        IoTLightResponse response = iotLightService.configureGuidance(light.getId(), request);
+
+        // then
+        assertThat(response.guidanceConfigured()).isTrue();
+        assertThat(response.decisionNodeId()).isEqualTo(decisionNode.getId());
+    }
+
+    @Test
+    @DisplayName("decisionNode에 연결되지 않은 엣지로 설정하려 하면 예외가 발생한다")
+    void configureGuidance_edgeNotConnectedToDecisionNode_throws() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        MapNode decisionNode = createNode("HALLWAY1", NodeType.HALLWAY);
+        MapNode unrelatedA = createNode("HALLWAY2", NodeType.HALLWAY);
+        MapNode unrelatedB = createNode("HALLWAY3", NodeType.HALLWAY);
+        MapEdge unrelatedEdge = createEdge(unrelatedA, unrelatedB); // decisionNode와 무관한 엣지
+        MapNode rightTarget = createNode("HALLWAY4", NodeType.HALLWAY);
+        MapEdge rightEdge = createEdge(decisionNode, rightTarget);
+
+        ConfigureGuidanceRequest request =
+                new ConfigureGuidanceRequest(decisionNode.getId(), unrelatedEdge.getId(), rightEdge.getId());
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+        given(mapNodeJpaRepository.findById(decisionNode.getId())).willReturn(Optional.of(decisionNode));
+        given(mapEdgeJpaRepository.findById(unrelatedEdge.getId())).willReturn(Optional.of(unrelatedEdge));
+        given(mapEdgeJpaRepository.findById(rightEdge.getId())).willReturn(Optional.of(rightEdge));
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.configureGuidance(light.getId(), request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.INVALID_GUIDANCE_EDGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 decisionNode로 설정하려 하면 예외가 발생한다")
+    void configureGuidance_decisionNodeNotFound_throws() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        UUID unknownNodeId = UUID.randomUUID();
+        ConfigureGuidanceRequest request =
+                new ConfigureGuidanceRequest(unknownNodeId, UUID.randomUUID(), UUID.randomUUID());
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+        given(mapNodeJpaRepository.findById(unknownNodeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.configureGuidance(light.getId(), request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.DECISION_NODE_NOT_FOUND.getMessage());
+    }
+
+    // === updateLight ===
+
+    @Test
+    @DisplayName("이름과 위치를 수정한다")
+    void updateLight_success() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        UpdateIoTLightRequest request = new UpdateIoTLightRequest("변경된 이름", 0.7, 0.8);
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when
+        IoTLightResponse response = iotLightService.updateLight(light.getId(), request);
+
+        // then
+        assertThat(response.name()).isEqualTo("변경된 이름");
+        assertThat(response.x()).isEqualTo(0.7);
+        assertThat(response.y()).isEqualTo(0.8);
+    }
+
+    // === enable / disable ===
+
+    @Test
+    @DisplayName("유도등을 비활성화한다")
+    void disableLight_success() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when
+        IoTLightResponse response = iotLightService.disableLight(light.getId());
+
+        // then
+        assertThat(response.enabled()).isFalse();
+    }
+}

--- a/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
@@ -86,12 +86,12 @@ class IoTLightServiceTest {
     @DisplayName("유도등을 등록하면 도면 위치 노드가 함께 생성된다")
     void createLight_success() {
         // given
-        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "복도1 유도등", 0.3, 0.4);
         MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
         IoTLight savedLight = createLight("LIGHT_001", customNode);
 
         given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
-        given(iotLightJpaRepository.existsByCode("LIGHT_001")).willReturn(false);
+        given(iotLightJpaRepository.count()).willReturn(0L);
         given(mapNodeJpaRepository.save(any(MapNode.class))).willReturn(customNode);
         given(iotLightJpaRepository.save(any(IoTLight.class))).willReturn(savedLight);
 
@@ -105,30 +105,36 @@ class IoTLightServiceTest {
     }
 
     @Test
+    @DisplayName("등록할 때마다 code가 순번대로 자동 생성된다")
+    void createLight_generatesSequentialCode() {
+        // given
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "복도1 유도등", 0.3, 0.4);
+        MapNode customNode = createNode("LIGHT_006", NodeType.CUSTOM);
+        IoTLight savedLight = createLight("LIGHT_006", customNode);
+
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(iotLightJpaRepository.count()).willReturn(5L);
+        given(mapNodeJpaRepository.save(any(MapNode.class))).willReturn(customNode);
+        given(iotLightJpaRepository.save(any(IoTLight.class))).willReturn(savedLight);
+
+        // when
+        IoTLightResponse response = iotLightService.createLight(request);
+
+        // then
+        assertThat(response.code()).isEqualTo("LIGHT_006");
+    }
+
+    @Test
     @DisplayName("존재하지 않는 층에 등록하려 하면 예외가 발생한다")
     void createLight_floorNotFound_throws() {
         // given
-        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
+        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "복도1 유도등", 0.3, 0.4);
         given(floorRepository.findById(floorId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> iotLightService.createLight(request))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(FloorErrorCode.FLOOR_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    @DisplayName("이미 등록된 code로 등록하려 하면 예외가 발생한다")
-    void createLight_duplicateCode_throws() {
-        // given
-        CreateIoTLightRequest request = new CreateIoTLightRequest(floorId, "LIGHT_001", "복도1 유도등", 0.3, 0.4);
-        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
-        given(iotLightJpaRepository.existsByCode("LIGHT_001")).willReturn(true);
-
-        // when & then
-        assertThatThrownBy(() -> iotLightService.createLight(request))
-                .isInstanceOf(ApiException.class)
-                .hasMessage(IoTLightErrorCode.DUPLICATE_LIGHT_CODE.getMessage());
     }
 
     // === getLights / getLight ===


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #27

## ✨ 작업 내용

### IoT 유도등 등록/관리 API

- 유도등 등록 시 도면 위치 노드(MapNode, type=CUSTOM)를 하나의 트랜잭션에서 함께 생성 (`MapNode.createCustom()` 활용)
  - node.code는 유도등의 code를 그대로 재사용 (전역 유일이 보장되므로 층 단위 유니크 제약도 자동 충족)
- 층별 필터링 목록 조회 / 단건 조회
- 분기 경로 설정(leftEdge/rightEdge/decisionNode) — leftEdge/rightEdge가 실제로 decisionNode에 연결된 엣지인지 Service 레벨에서 검증
- 이름/위치 수정, 활성화·비활성화 토글
- code 중복 등록 방지 검증

### 버그 수정

- `leftEdge`와 `rightEdge`를 같은 엣지로 지정하면 `IoTLight.configureGuidance()`가 던지는 `IllegalArgumentException`이 `GlobalExceptionHandler`에서 처리되지 않아 500으로 응답하던 문제 → Service에서 사전 검증하도록 수정

## 🔗 API

```http
POST   /api/v1/lights
GET    /api/v1/lights?floorId={floorId}
GET    /api/v1/lights/{lightId}
PATCH  /api/v1/lights/{lightId}/guidance
PATCH  /api/v1/lights/{lightId}
PATCH  /api/v1/lights/{lightId}/enable
PATCH  /api/v1/lights/{lightId}/disable
```

## 🧩 설계 결정 (리뷰어용)
customNode 생성 방식: #22의 범용 노드 생성 API(POST /floors/{floorId}/nodes)로 미리 만들어두는 대신, 유도등 등록 API 안에서 MapNode.createCustom()으로 함께 생성하도록 함. 두 API를 나누면 중간 실패 시 주인 없는 노드가 남을 위험이 있고, createCustom()이 애초에 이 용도로 만들어져 있었으나 미사용 상태였음.
⚠️ 참고: 이 방식이든 아니든 상관없이, GET /floors/{floorId}/graph(#22)가 노드 타입을 필터링하지 않아 CUSTOM 노드(유도등 위치 핀)가 그래프 편집 화면 조회 결과에 섞여 나오는 별개의 이슈를 발견함 → 별도 이슈로 분리 예정 (이 PR 범위 아님)

## ✅ 테스트
IoTLightServiceTest: 등록 성공/층 미존재/code 중복, 목록·단건 조회, 분기 경로 설정 성공/decisionNode 미연결 엣지/leftEdge=rightEdge/decisionNode 미존재, 이름·위치 수정, 비활성화
IoTLightControllerTest: 각 엔드포인트 @WebMvcTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * IoT 유도등을 등록하고 층별 목록 및 상세 정보를 조회할 수 있습니다.
  * 유도등의 위치와 이름을 수정하고 활성화·비활성화할 수 있습니다.
  * 결정 노드와 좌·우 안내 경로를 설정할 수 있습니다.
  * 유도등의 안내 설정 상태와 연결된 경로 정보를 확인할 수 있습니다.

* **유효성 검사 및 오류 처리**
  * 필수 입력값과 잘못된 안내 경로를 검증합니다.
  * 존재하지 않는 유도등, 노드 또는 경로 요청에 대해 명확한 오류를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->