### PR TITLE
[CHORE] Swagger @Tag로 API 그룹핑

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/com/saferoute/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/saferoute/domain/analysis/controller/AnalysisController.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.analysis.controller;
 
 import com.saferoute.domain.floor.service.FloorService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "AI 분석", description = "도면 AI 세그멘테이션 분석 요청 API")
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/saferoute/domain/building/controller/BuildingController.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.building.dto.request.UpdateBuildingRequest;
 import com.saferoute.domain.building.service.BuildingService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.BuildingSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import java.util.List;
@@ -16,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "건물", description = "건물 등록/조회/수정/삭제 API")
 @RestController
 @RequestMapping("/api/v1/buildings")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/dashboard/DashboardController.java
+++ b/src/main/java/com/saferoute/domain/dashboard/DashboardController.java
@@ -5,6 +5,7 @@ import com.saferoute.domain.report.dto.RecentTrainingReportResponse;
 import com.saferoute.domain.training.dto.TrainingStatusResponse;
 import com.saferoute.domain.report.service.TrainingReportService;
 import com.saferoute.domain.training.service.TrainingSessionService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "대시보드", description = "훈련 현황 및 통계 대시보드 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dashboard")

--- a/src/main/java/com/saferoute/domain/device/client/IoTLightPiClient.java
+++ b/src/main/java/com/saferoute/domain/device/client/IoTLightPiClient.java
@@ -1,0 +1,41 @@
+package com.saferoute.domain.device.client;
+
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import com.saferoute.global.api.error.IoTLightErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+// Spring 서버가 라즈베리파이(Pi Flask 서버)에 유도등 방향 명령을 전달하는 책임을 전담한다.
+// Pi 쪽 API 스펙: POST {piEndpoint}/lights/direction, body { lightCode, direction }
+// 하드웨어(Pi) 구현은 아직 없어 실제 통신은 검증되지 않았다 - 스펙만 정의된 상태이며
+// 로컬 Flask 스텁 서버로 대신 검증한다.
+@Slf4j
+@Component
+public class IoTLightPiClient {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(3);
+    private static final String DIRECTION_PATH = "/lights/direction";
+
+    private final WebClient webClient;
+
+    public IoTLightPiClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.build();
+    }
+
+    public void sendDirection(String piEndpoint, String lightCode, IoTLightDirection direction) {
+        try {
+            webClient.post()
+                    .uri(piEndpoint + DIRECTION_PATH)
+                    .bodyValue(new PiLightDirectionRequest(lightCode, direction))
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block(TIMEOUT);
+        } catch (RuntimeException exception) {
+            log.warn("라즈베리파이 통신 실패: piEndpoint={}, lightCode={}", piEndpoint, lightCode, exception);
+            throw new ApiException(IoTLightErrorCode.DEVICE_UNREACHABLE, exception);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/client/PiLightDirectionRequest.java
+++ b/src/main/java/com/saferoute/domain/device/client/PiLightDirectionRequest.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.device.client;
+
+import com.saferoute.domain.device.entity.IoTLightDirection;
+
+// 라즈베리파이(Pi Flask 서버)로 전달하는 방향 명령 요청 body.
+// lightCode는 IoTLight.code를 그대로 사용한다 - Pi 한 대가 릴레이 2대(분기점 2곳)를 담당하므로
+// 어느 분기점에 대한 명령인지 Pi 쪽이 이 값으로 식별한다.
+public record PiLightDirectionRequest(
+        String lightCode,
+        IoTLightDirection direction
+) {}

--- a/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
@@ -1,9 +1,12 @@
 package com.saferoute.domain.device.controller;
 
+import com.saferoute.domain.device.dto.request.ChangeLightDirectionRequest;
 import com.saferoute.domain.device.dto.request.ConfigureGuidanceRequest;
 import com.saferoute.domain.device.dto.request.CreateIoTLightRequest;
 import com.saferoute.domain.device.dto.request.UpdateIoTLightRequest;
+import com.saferoute.domain.device.dto.request.UpdatePiEndpointRequest;
 import com.saferoute.domain.device.dto.response.IoTLightResponse;
+import com.saferoute.domain.device.dto.response.LightDirectionResponse;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.IoTLightSuccessCode;
@@ -67,6 +70,24 @@ public class IoTLightController {
     ) {
         IoTLightResponse response = iotLightService.updateLight(lightId, request);
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_UPDATED, response));
+    }
+
+    @PatchMapping("/{lightId}/direction")
+    public ResponseEntity<ApiResponse<LightDirectionResponse>> changeDirection(
+            @PathVariable UUID lightId,
+            @Valid @RequestBody ChangeLightDirectionRequest request
+    ) {
+        LightDirectionResponse response = iotLightService.changeDirection(lightId, request);
+        return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_DIRECTION_CHANGED, response));
+    }
+
+    @PatchMapping("/{lightId}/pi-endpoint")
+    public ResponseEntity<ApiResponse<IoTLightResponse>> updatePiEndpoint(
+            @PathVariable UUID lightId,
+            @Valid @RequestBody UpdatePiEndpointRequest request
+    ) {
+        IoTLightResponse response = iotLightService.updatePiEndpoint(lightId, request);
+        return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_PI_ENDPOINT_UPDATED, response));
     }
 
     @PatchMapping("/{lightId}/enable")

--- a/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
@@ -10,6 +10,7 @@ import com.saferoute.domain.device.dto.response.LightDirectionResponse;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.IoTLightSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "IoT 유도등", description = "IoT 유도등 등록/조회/방향 제어 API")
 @RestController
 @RequestMapping("/api/v1/lights")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/device/dto/request/ChangeLightDirectionRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/ChangeLightDirectionRequest.java
@@ -1,0 +1,8 @@
+package com.saferoute.domain.device.dto.request;
+
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import jakarta.validation.constraints.NotNull;
+
+public record ChangeLightDirectionRequest(
+        @NotNull IoTLightDirection direction
+) {}

--- a/src/main/java/com/saferoute/domain/device/dto/request/UpdatePiEndpointRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/UpdatePiEndpointRequest.java
@@ -1,0 +1,7 @@
+package com.saferoute.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdatePiEndpointRequest(
+        @NotBlank String piEndpoint
+) {}

--- a/src/main/java/com/saferoute/domain/device/dto/response/IoTLightResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/IoTLightResponse.java
@@ -14,7 +14,8 @@ public record IoTLightResponse(
         UUID leftEdgeId,
         UUID rightEdgeId,
         boolean guidanceConfigured,
-        boolean enabled
+        boolean enabled,
+        String piEndpoint
 ) {
     public static IoTLightResponse from(IoTLight light) {
         return new IoTLightResponse(
@@ -28,7 +29,8 @@ public record IoTLightResponse(
                 light.getLeftEdge() != null ? light.getLeftEdge().getId() : null,
                 light.getRightEdge() != null ? light.getRightEdge().getId() : null,
                 light.isGuidanceConfigured(),
-                light.isEnabled()
+                light.isEnabled(),
+                light.getPiEndpoint()
         );
     }
 }

--- a/src/main/java/com/saferoute/domain/device/dto/response/LightDirectionResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/LightDirectionResponse.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.device.dto.response;
+
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import java.time.Instant;
+import java.util.UUID;
+
+public record LightDirectionResponse(
+        UUID lightId,
+        IoTLightDirection direction,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/saferoute/domain/device/entity/IoTLight.java
+++ b/src/main/java/com/saferoute/domain/device/entity/IoTLight.java
@@ -67,6 +67,11 @@ public class IoTLight {
     @Column(name = "enabled", nullable = false)
     private boolean enabled;
 
+    // 이 유도등의 명령을 실제로 전달받는 라즈베리파이 주소 (예: http://192.168.0.50:5000)
+    // 등록 시점에는 비어있을 수 있음 - 하드웨어 배치 후 별도로 설정
+    @Column(name = "pi_endpoint", length = 255)
+    private String piEndpoint;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -132,6 +137,14 @@ public class IoTLight {
 
     public void enable() {
         this.enabled = true;
+    }
+
+    // 하드웨어 배치/교체 시 관리자가 라즈베리파이 주소를 지정한다.
+    public void updatePiEndpoint(String piEndpoint) {
+        if (piEndpoint == null || piEndpoint.isBlank()) {
+            throw new IllegalArgumentException("piEndpoint는 비어있을 수 없습니다.");
+        }
+        this.piEndpoint = piEndpoint;
     }
 
     private static void validateCustomNode(MapNode customNode) {

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightDirectionStore.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightDirectionStore.java
@@ -1,0 +1,24 @@
+package com.saferoute.domain.device.service;
+
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+// 유도등의 실시간 방향 상태를 보관한다. 훈련별로 바뀌는 동적 상태라 IoTLight 엔티티(DB)에는
+// 저장하지 않고 서버 메모리에서만 관리한다 (IoTLight 클래스 상단 주석 참고).
+// 서버가 재시작되면 초기화되는 것을 의도한 동작으로 본다 - 재시작 후에는 관리자가 방향을 다시 지정해야 한다.
+@Component
+public class IoTLightDirectionStore {
+
+    private final Map<UUID, IoTLightDirection> directions = new ConcurrentHashMap<>();
+
+    public void update(UUID lightId, IoTLightDirection direction) {
+        directions.put(lightId, direction);
+    }
+
+    public IoTLightDirection get(UUID lightId) {
+        return directions.getOrDefault(lightId, IoTLightDirection.OFF);
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -1,10 +1,15 @@
 package com.saferoute.domain.device.service;
 
+import com.saferoute.domain.device.client.IoTLightPiClient;
+import com.saferoute.domain.device.dto.request.ChangeLightDirectionRequest;
 import com.saferoute.domain.device.dto.request.ConfigureGuidanceRequest;
 import com.saferoute.domain.device.dto.request.CreateIoTLightRequest;
 import com.saferoute.domain.device.dto.request.UpdateIoTLightRequest;
+import com.saferoute.domain.device.dto.request.UpdatePiEndpointRequest;
 import com.saferoute.domain.device.dto.response.IoTLightResponse;
+import com.saferoute.domain.device.dto.response.LightDirectionResponse;
 import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.entity.IoTLightDirection;
 import com.saferoute.domain.device.repository.IoTLightJpaRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
@@ -15,6 +20,8 @@ import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.error.IoTLightErrorCode;
 import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +37,9 @@ public class IoTLightService {
     private final MapNodeJpaRepository mapNodeJpaRepository;
     private final MapEdgeJpaRepository mapEdgeJpaRepository;
     private final FloorRepository floorRepository;
+    private final IoTLightPiClient iotLightPiClient;
+    private final IoTLightDirectionStore iotLightDirectionStore;
+    private final TrainingEventPublisher trainingEventPublisher;
 
     @Transactional
     public IoTLightResponse createLight(CreateIoTLightRequest request) {
@@ -103,6 +113,13 @@ public class IoTLightService {
     }
 
     @Transactional
+    public IoTLightResponse updatePiEndpoint(UUID lightId, UpdatePiEndpointRequest request) {
+        IoTLight light = findLightOrThrow(lightId);
+        light.updatePiEndpoint(request.piEndpoint());
+        return IoTLightResponse.from(light);
+    }
+
+    @Transactional
     public IoTLightResponse enableLight(UUID lightId) {
         IoTLight light = findLightOrThrow(lightId);
         light.enable();
@@ -114,6 +131,29 @@ public class IoTLightService {
         IoTLight light = findLightOrThrow(lightId);
         light.disable();
         return IoTLightResponse.from(light);
+    }
+
+    // 검증(enabled/guidance) -> Pi 호출 -> 상태 저장 -> 이벤트 발행 순서로 조립한다.
+    // direction은 훈련별 동적 상태라 DB에 저장하지 않고 IoTLightDirectionStore(서버 메모리)에 저장한다 (IoTLight 참고).
+    public LightDirectionResponse changeDirection(UUID lightId, ChangeLightDirectionRequest request) {
+        IoTLight light = findLightOrThrow(lightId);
+        IoTLightDirection direction = request.direction();
+
+        if (!light.isEnabled()) {
+            throw new ApiException(IoTLightErrorCode.LIGHT_DISABLED);
+        }
+        if (direction != IoTLightDirection.OFF && !light.isGuidanceConfigured()) {
+            throw new ApiException(IoTLightErrorCode.GUIDANCE_NOT_CONFIGURED);
+        }
+        if (light.getPiEndpoint() == null || light.getPiEndpoint().isBlank()) {
+            throw new ApiException(IoTLightErrorCode.DEVICE_UNREACHABLE);
+        }
+
+        iotLightPiClient.sendDirection(light.getPiEndpoint(), light.getCode(), direction);
+        iotLightDirectionStore.update(light.getId(), direction);
+        trainingEventPublisher.publishIoTLightStatusUpdatedAfterCommit(light, direction);
+
+        return new LightDirectionResponse(light.getId(), direction, Instant.now());
     }
 
     private IoTLight findLightOrThrow(UUID lightId) {

--- a/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.evacuation.dto.response.EvacuationRouteResponse;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 // /graph(노드/엣지 편집용) 엔드포인트와 역할 분리를 위해 별도 컨트롤러로 구성 - MapGraphController 참고
+@Tag(name = "대피 경로", description = "최단 대피 경로 조회 API")
 @RestController
 @RequestMapping("/api/v1/floors/{floorId}")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.evacuation.controller;
 import com.saferoute.domain.evacuation.graph.dto.response.FloorGraphResponse;
 import com.saferoute.domain.evacuation.graph.service.MapGraphService;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "맵 그래프", description = "층별 맵 그래프(노드/엣지) 조회 API")
 @RestController
 @RequestMapping("/api/v1/floors/{floorId}")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
@@ -8,6 +8,7 @@ import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
 import com.saferoute.domain.evacuation.graph.service.MapGraphService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.EvacuationSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 // 커스텀 편집 UI(드래그로 노드 추가/이동, 엣지 연결)를 위한 CRUD 엔드포인트
+@Tag(name = "맵 그래프 편집", description = "맵 그래프 노드/엣지 생성/수정/삭제 API")
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
+++ b/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.floor.dto.response.FloorResponse;
 import com.saferoute.domain.floor.service.FloorService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.FloorSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -15,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "층/도면", description = "건물 내 층 및 도면 등록/조회/삭제 API")
 @RestController
 @RequestMapping("/api/v1/buildings/{buildingId}/floors")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/report/controller/TrainingReportController.java
+++ b/src/main/java/com/saferoute/domain/report/controller/TrainingReportController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.report.controller;
 import com.saferoute.domain.report.dto.CreateReportRequest;
 import com.saferoute.domain.report.dto.ReportResponse;
 import com.saferoute.domain.report.service.TrainingReportService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "훈련 리포트", description = "훈련 세션 결과 리포트 생성 API")
 @RestController
 @RequestMapping("/api/v1/analysis/trainings")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
 import com.saferoute.domain.training.service.TrainingScenarioService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "훈련 시나리오", description = "훈련 시나리오 등록/조회/수정/삭제 API")
 @RestController
 @RequestMapping("/api/v1/scenarios")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -5,6 +5,7 @@ import com.saferoute.domain.training.dto.TrainingSessionResponse;
 import com.saferoute.domain.training.service.TrainingSessionService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.TrainingSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "훈련 세션", description = "훈련 세션 생성/시작/종료 API")
 @RestController
 @RequestMapping("/api/v1/sessions")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/user/controller/UserController.java
+++ b/src/main/java/com/saferoute/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.saferoute.domain.user.dto.SignupResponse;
 import com.saferoute.domain.user.service.UserService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.UserSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "사용자", description = "회원가입/로그인 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/global/api/error/IoTLightErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/IoTLightErrorCode.java
@@ -12,7 +12,10 @@ public enum IoTLightErrorCode implements BaseErrorCode {
     IOT_LIGHT_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT001", "유도등을 찾을 수 없습니다."),
     DECISION_NODE_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT003", "분기 노드를 찾을 수 없습니다."),
     GUIDANCE_EDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IOTLIGHT004", "안내 통로(엣지)를 찾을 수 없습니다."),
-    INVALID_GUIDANCE_EDGE(HttpStatus.BAD_REQUEST, "IOTLIGHT005", "leftEdge/rightEdge는 decisionNode에 연결된 엣지여야 합니다.");
+    INVALID_GUIDANCE_EDGE(HttpStatus.BAD_REQUEST, "IOTLIGHT005", "leftEdge/rightEdge는 decisionNode에 연결된 엣지여야 합니다."),
+    GUIDANCE_NOT_CONFIGURED(HttpStatus.BAD_REQUEST, "IOTLIGHT006", "경로 안내(좌/우 통로)가 설정되지 않은 유도등입니다."),
+    LIGHT_DISABLED(HttpStatus.BAD_REQUEST, "IOTLIGHT007", "비활성화된 유도등에는 명령을 보낼 수 없습니다."),
+    DEVICE_UNREACHABLE(HttpStatus.BAD_GATEWAY, "IOTLIGHT008", "라즈베리파이 기기와 통신에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/api/response/IoTLightSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/IoTLightSuccessCode.java
@@ -15,7 +15,9 @@ public enum IoTLightSuccessCode implements BaseCode {
     IOT_LIGHT_GUIDANCE_CONFIGURED(HttpStatus.OK, "IOTLIGHT_SUCCESS_004", "분기 경로가 설정되었습니다."),
     IOT_LIGHT_UPDATED(HttpStatus.OK, "IOTLIGHT_SUCCESS_005", "유도등 정보가 수정되었습니다."),
     IOT_LIGHT_ENABLED(HttpStatus.OK, "IOTLIGHT_SUCCESS_006", "유도등이 활성화되었습니다."),
-    IOT_LIGHT_DISABLED(HttpStatus.OK, "IOTLIGHT_SUCCESS_007", "유도등이 비활성화되었습니다.");
+    IOT_LIGHT_DISABLED(HttpStatus.OK, "IOTLIGHT_SUCCESS_007", "유도등이 비활성화되었습니다."),
+    IOT_LIGHT_PI_ENDPOINT_UPDATED(HttpStatus.OK, "IOTLIGHT_SUCCESS_008", "라즈베리파이 주소가 설정되었습니다."),
+    IOT_LIGHT_DIRECTION_CHANGED(HttpStatus.OK, "IOTLIGHT_SUCCESS_009", "유도등 방향이 변경되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/IoTLightEventMessage.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/IoTLightEventMessage.java
@@ -1,0 +1,18 @@
+package com.saferoute.infrastructure.websocket.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// 층 도면 화면(/topic/floors/{floorId}/lights)으로 전달되는 유도등 이벤트 envelope.
+// TrainingEventMessage는 sessionId 고정 필드라 유도등(floorId 기준) 이벤트에 맞지 않아 별도로 둔다.
+public record IoTLightEventMessage<T>(
+        TrainingEventType eventType,
+        UUID floorId,
+        Instant occurredAt,
+        T data
+) {
+
+    public static <T> IoTLightEventMessage<T> of(TrainingEventType eventType, UUID floorId, T data) {
+        return new IoTLightEventMessage<>(eventType, floorId, Instant.now(), data);
+    }
+}

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/IoTLightStatusEventData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/IoTLightStatusEventData.java
@@ -1,0 +1,11 @@
+package com.saferoute.infrastructure.websocket.dto;
+
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import java.time.Instant;
+import java.util.UUID;
+
+public record IoTLightStatusEventData(
+        UUID lightId,
+        IoTLightDirection direction,
+        Instant updatedAt
+) {}

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
@@ -6,10 +6,12 @@ public enum TrainingEventType {
     // 현재는 위 도메인 메서드를 호출하는 시작/종료 API가 없어 실제로 발행되지는 않는다.
     TRAINING_STATUS_UPDATED,
 
-    // 아래 3개는 계약(메시지 규격) 정의만 되어 있는 상태다.
-    // 대응하는 도메인 로직(혼잡도 계산, 경로 재계산, 유도등 상태 변경)이 아직 없어
+    // 아래 2개는 계약(메시지 규격) 정의만 되어 있는 상태다.
+    // 대응하는 도메인 로직(혼잡도 계산, 경로 재계산)이 아직 없어
     // 전용 데이터 DTO와 TrainingEventPublisher 발행 메서드는 이번 작업에서 추가하지 않았다.
     CONGESTION_UPDATED,
     EVACUATION_ROUTE_UPDATED,
+
+    // IoTLightService.changeDirection() 호출 시 TrainingEventPublisher.publishIoTLightStatusUpdated()가 발행한다.
     IOT_LIGHT_STATUS_UPDATED
 }

--- a/src/main/java/com/saferoute/infrastructure/websocket/security/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/security/StompAuthChannelInterceptor.java
@@ -1,5 +1,6 @@
 package com.saferoute.infrastructure.websocket.security;
 
+import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.global.security.CustomUserDetailsService;
 import com.saferoute.global.security.JwtTokenProvider;
@@ -41,10 +42,13 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     private static final String USER_ERROR_DESTINATION = "/user/queue/errors";
     private static final Pattern SESSION_TOPIC_PATTERN =
             Pattern.compile("^/topic/training-sessions/([0-9a-fA-F-]{36})$");
+    private static final Pattern FLOOR_LIGHTS_TOPIC_PATTERN =
+            Pattern.compile("^/topic/floors/([0-9a-fA-F-]{36})/lights$");
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
     private final TrainingSessionRepository trainingSessionRepository;
+    private final FloorRepository floorRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -127,22 +131,45 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return;
         }
 
-        Matcher matcher = SESSION_TOPIC_PATTERN.matcher(destination);
+        Matcher sessionMatcher = SESSION_TOPIC_PATTERN.matcher(destination);
 
-        if (!matcher.matches()) {
-            log.warn("WebSocket SUBSCRIBE 거부: 지원하지 않는 destination입니다.");
-            throw new IllegalArgumentException("지원하지 않는 구독 경로입니다.");
+        if (sessionMatcher.matches()) {
+            authorizeTrainingSessionTopic(sessionMatcher);
+            return;
         }
 
-        // 세션 존재 여부만 검증한다.
-        // 관리자별로 "본인이 담당하는 세션만 구독 가능"하도록 제한하려면 User-TrainingSession
-        // 소유 관계가 필요한데, 현재 도메인 모델에는 그런 관계가 없어(모든 MANAGER가 모든
-        // TrainingSession에 접근 가능한 구조) 역할 기반 제한 이상은 적용하지 않았다.
+        Matcher floorLightsMatcher = FLOOR_LIGHTS_TOPIC_PATTERN.matcher(destination);
+
+        if (floorLightsMatcher.matches()) {
+            authorizeFloorLightsTopic(floorLightsMatcher);
+            return;
+        }
+
+        log.warn("WebSocket SUBSCRIBE 거부: 지원하지 않는 destination입니다.");
+        throw new IllegalArgumentException("지원하지 않는 구독 경로입니다.");
+    }
+
+    // 세션 존재 여부만 검증한다.
+    // 관리자별로 "본인이 담당하는 세션만 구독 가능"하도록 제한하려면 User-TrainingSession
+    // 소유 관계가 필요한데, 현재 도메인 모델에는 그런 관계가 없어(모든 MANAGER가 모든
+    // TrainingSession에 접근 가능한 구조) 역할 기반 제한 이상은 적용하지 않았다.
+    private void authorizeTrainingSessionTopic(Matcher matcher) {
         UUID sessionId = UUID.fromString(matcher.group(1));
 
         if (!trainingSessionRepository.existsById(sessionId)) {
             log.warn("WebSocket SUBSCRIBE 거부: 존재하지 않는 훈련 세션입니다.");
             throw new IllegalArgumentException("존재하지 않는 훈련 세션입니다.");
+        }
+    }
+
+    // 층 존재 여부만 검증한다. 세션 토픽과 동일하게 "본인이 담당하는 층만 구독 가능" 같은
+    // 소유 관계 기반 제한은 현재 도메인 모델에 없어 적용하지 않았다.
+    private void authorizeFloorLightsTopic(Matcher matcher) {
+        UUID floorId = UUID.fromString(matcher.group(1));
+
+        if (!floorRepository.existsById(floorId)) {
+            log.warn("WebSocket SUBSCRIBE 거부: 존재하지 않는 층입니다.");
+            throw new IllegalArgumentException("존재하지 않는 층입니다.");
         }
     }
 

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -35,9 +35,8 @@ public class TrainingEventPublisher {
 
     private final SimpMessagingTemplate messagingTemplate;
 
-    // 현재 이 메서드를 호출하는 지점은 없다.
-    // TrainingSession.complete()/stop()/fail() 을 호출하는 훈련 종료 API가 추가되면
-    // 트랜잭션 커밋 이후 이 메서드(또는 publishTrainingStatusUpdatedAfterCommit)를 호출해 연동한다.
+    // 트랜잭션 커밋 시점과 무관하게 즉시 발행한다.
+    // 커밋 이후에만 발행해야 하는 일반적인 경우에는 publishTrainingStatusUpdatedAfterCommit을 사용한다.
     public void publishTrainingStatusUpdated(TrainingSession session) {
         TrainingEventMessage<TrainingStatusEventData> message = TrainingEventMessage.of(
                 TrainingEventType.TRAINING_STATUS_UPDATED,

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -1,9 +1,15 @@
 package com.saferoute.infrastructure.websocket.service;
 
+import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.entity.IoTLightDirection;
 import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.infrastructure.websocket.dto.IoTLightEventMessage;
+import com.saferoute.infrastructure.websocket.dto.IoTLightStatusEventData;
 import com.saferoute.infrastructure.websocket.dto.TrainingEventMessage;
 import com.saferoute.infrastructure.websocket.dto.TrainingEventType;
 import com.saferoute.infrastructure.websocket.dto.TrainingStatusEventData;
+import java.time.Instant;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -11,10 +17,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-// 관리자 대시보드(/topic/training-sessions/{sessionId})로 보내는 WebSocket 이벤트 발행 책임을 이 클래스가 전담한다.
+// 관리자 대시보드로 보내는 WebSocket 이벤트 발행 책임을 이 클래스가 전담한다.
 // SimpMessagingTemplate을 다른 서비스에 직접 주입하지 않고 항상 이 클래스를 거친다.
+// 훈련 세션 이벤트는 /topic/training-sessions/{sessionId}, 유도등 이벤트는 층 도면 화면이
+// 층 전체를 한 번에 보여주는 구조라 /topic/floors/{floorId}/lights로 발행한다.
 //
-// 혼잡도 / 경로 재계산 / 유도등 상태 이벤트 발행 메서드는 아직 없다.
+// 혼잡도 / 경로 재계산 이벤트 발행 메서드는 아직 없다.
 // 대응하는 도메인 로직이 만들어지면 이 클래스에 전용 메서드를 추가한다.
 @Slf4j
 @Component
@@ -22,6 +30,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class TrainingEventPublisher {
 
     private static final String SESSION_TOPIC_PREFIX = "/topic/training-sessions/";
+    private static final String FLOOR_LIGHTS_TOPIC_PREFIX = "/topic/floors/";
+    private static final String FLOOR_LIGHTS_TOPIC_SUFFIX = "/lights";
 
     private final SimpMessagingTemplate messagingTemplate;
 
@@ -67,6 +77,52 @@ public class TrainingEventPublisher {
                             log.error(
                                     "커밋 후 훈련 상태 이벤트 발행 실패: sessionId={}",
                                     session.getId(),
+                                    exception
+                            );
+                        }
+                    }
+                }
+        );
+    }
+
+    // floorId는 light.getCustomNode().getFloor().getId()로 조회한다.
+    // direction은 IoTLight 엔티티가 아니라 IoTLightDirectionStore(서버 메모리)가 원천이므로 별도 파라미터로 받는다.
+    public void publishIoTLightStatusUpdated(IoTLight light, IoTLightDirection direction) {
+        UUID floorId = light.getCustomNode().getFloor().getId();
+        IoTLightEventMessage<IoTLightStatusEventData> message = IoTLightEventMessage.of(
+                TrainingEventType.IOT_LIGHT_STATUS_UPDATED,
+                floorId,
+                new IoTLightStatusEventData(light.getId(), direction, Instant.now())
+        );
+
+        messagingTemplate.convertAndSend(FLOOR_LIGHTS_TOPIC_PREFIX + floorId + FLOOR_LIGHTS_TOPIC_SUFFIX, message);
+
+        log.debug(
+                "유도등 상태 이벤트 발행: lightId={}, floorId={}, direction={}",
+                light.getId(),
+                floorId,
+                direction
+        );
+    }
+
+    // 훈련 상태 이벤트와 동일하게, DB 트랜잭션이 실제로 커밋된 이후에만 발행하고
+    // 발행 실패는 로그만 남기고 삼킨다 (publishTrainingStatusUpdatedAfterCommit 참고).
+    public void publishIoTLightStatusUpdatedAfterCommit(IoTLight light, IoTLightDirection direction) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            publishIoTLightStatusUpdated(light, direction);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        try {
+                            publishIoTLightStatusUpdated(light, direction);
+                        } catch (RuntimeException exception) {
+                            log.error(
+                                    "커밋 후 유도등 상태 이벤트 발행 실패: lightId={}",
+                                    light.getId(),
                                     exception
                             );
                         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,12 +38,13 @@ aws:
     bucket: ${S3_BUCKET:project10-87-ohio-s3}
     presigned-url-expiration: 1m
 
+  dynamodb:
+    table-name: ${DYNAMODB_TABLE:saferoute-telemetry}
+
 saferoute:
   ai-service:
     base-url: ${AI_SERVICE_BASE_URL:http://localhost:8001}
-  dynamodb:
-    table-name: ${DYNAMODB_TABLE:saferoute-telemetry}
-    
+
 management:
   endpoints:
     web:

--- a/src/test/java/com/saferoute/domain/device/controller/IoTLightControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/IoTLightControllerTest.java
@@ -11,10 +11,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.device.dto.request.ChangeLightDirectionRequest;
 import com.saferoute.domain.device.dto.request.ConfigureGuidanceRequest;
 import com.saferoute.domain.device.dto.request.CreateIoTLightRequest;
 import com.saferoute.domain.device.dto.request.UpdateIoTLightRequest;
+import com.saferoute.domain.device.dto.request.UpdatePiEndpointRequest;
 import com.saferoute.domain.device.dto.response.IoTLightResponse;
+import com.saferoute.domain.device.dto.response.LightDirectionResponse;
+import com.saferoute.domain.device.entity.IoTLightDirection;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.error.IoTLightErrorCode;
@@ -61,7 +65,7 @@ class IoTLightControllerTest {
 
     private IoTLightResponse sampleResponse() {
         return new IoTLightResponse(lightId, "LIGHT_001", "복도1 유도등", floorId, 0.3, 0.4,
-                null, null, null, false, true);
+                null, null, null, false, true, null);
     }
 
     // === createLight ===
@@ -190,5 +194,96 @@ class IoTLightControllerTest {
 
         mockMvc.perform(patch("/api/v1/lights/{lightId}/disable", lightId))
                 .andExpect(status().isOk());
+    }
+
+    // === updatePiEndpoint ===
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/pi-endpoint - 라즈베리파이 주소를 설정하면 200을 반환한다")
+    void updatePiEndpoint_success() throws Exception {
+        UpdatePiEndpointRequest request = new UpdatePiEndpointRequest("http://192.168.0.50:5000");
+        given(iotLightService.updatePiEndpoint(eq(lightId), any())).willReturn(sampleResponse());
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/pi-endpoint", lightId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/pi-endpoint - 값이 비어있으면 400을 반환한다")
+    void updatePiEndpoint_blank_returnsBadRequest() throws Exception {
+        String invalidJson = """
+                {"piEndpoint":""}
+                """;
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/pi-endpoint", lightId)
+                        .contentType("application/json")
+                        .content(invalidJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    // === changeDirection ===
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/direction - 방향 명령을 보내면 200을 반환한다")
+    void changeDirection_success() throws Exception {
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.LEFT);
+        given(iotLightService.changeDirection(eq(lightId), any()))
+                .willReturn(new LightDirectionResponse(lightId, IoTLightDirection.LEFT, java.time.Instant.now()));
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/direction", lightId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.direction").value("LEFT"));
+    }
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/direction - 경로 안내가 없으면 400을 반환한다")
+    void changeDirection_guidanceNotConfigured_returnsBadRequest() throws Exception {
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.LEFT);
+        given(iotLightService.changeDirection(eq(lightId), any()))
+                .willThrow(new ApiException(IoTLightErrorCode.GUIDANCE_NOT_CONFIGURED));
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/direction", lightId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/direction - 비활성화된 유도등이면 400을 반환한다")
+    void changeDirection_lightDisabled_returnsBadRequest() throws Exception {
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.OFF);
+        given(iotLightService.changeDirection(eq(lightId), any()))
+                .willThrow(new ApiException(IoTLightErrorCode.LIGHT_DISABLED));
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/direction", lightId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/direction - Pi와 통신 실패 시 502를 반환한다")
+    void changeDirection_deviceUnreachable_returnsBadGateway() throws Exception {
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.OFF);
+        given(iotLightService.changeDirection(eq(lightId), any()))
+                .willThrow(new ApiException(IoTLightErrorCode.DEVICE_UNREACHABLE));
+
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/direction", lightId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadGateway());
+    }
+
+    @Test
+    @DisplayName("PATCH /lights/{lightId}/direction - direction이 없으면 400을 반환한다")
+    void changeDirection_missingDirection_returnsBadRequest() throws Exception {
+        mockMvc.perform(patch("/api/v1/lights/{lightId}/direction", lightId)
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
@@ -5,12 +5,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.saferoute.domain.device.client.IoTLightPiClient;
+import com.saferoute.domain.device.dto.request.ChangeLightDirectionRequest;
 import com.saferoute.domain.device.dto.request.ConfigureGuidanceRequest;
 import com.saferoute.domain.device.dto.request.CreateIoTLightRequest;
 import com.saferoute.domain.device.dto.request.UpdateIoTLightRequest;
 import com.saferoute.domain.device.dto.response.IoTLightResponse;
+import com.saferoute.domain.device.dto.response.LightDirectionResponse;
 import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.entity.IoTLightDirection;
 import com.saferoute.domain.device.repository.IoTLightJpaRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
@@ -22,6 +28,7 @@ import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.error.IoTLightErrorCode;
 import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -51,6 +58,15 @@ class IoTLightServiceTest {
 
     @Mock
     private FloorRepository floorRepository;
+
+    @Mock
+    private IoTLightPiClient iotLightPiClient;
+
+    @Mock
+    private IoTLightDirectionStore iotLightDirectionStore;
+
+    @Mock
+    private TrainingEventPublisher trainingEventPublisher;
 
     private final UUID floorId = UUID.randomUUID();
     private Floor floor;
@@ -296,5 +312,125 @@ class IoTLightServiceTest {
 
         // then
         assertThat(response.enabled()).isFalse();
+    }
+
+    // === changeDirection ===
+
+    @Test
+    @DisplayName("OFF 방향은 경로 안내 설정 없이도 명령을 보낼 수 있다")
+    void changeDirection_off_success() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.OFF);
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when
+        LightDirectionResponse response = iotLightService.changeDirection(light.getId(), request);
+
+        // then
+        assertThat(response.direction()).isEqualTo(IoTLightDirection.OFF);
+        verify(iotLightPiClient).sendDirection("http://192.168.0.50:5000", "LIGHT_001", IoTLightDirection.OFF);
+        verify(iotLightDirectionStore).update(light.getId(), IoTLightDirection.OFF);
+        verify(trainingEventPublisher).publishIoTLightStatusUpdatedAfterCommit(light, IoTLightDirection.OFF);
+    }
+
+    @Test
+    @DisplayName("경로 안내가 설정된 유도등에 LEFT 명령을 보낼 수 있다")
+    void changeDirection_left_withGuidance_success() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        MapNode decisionNode = createNode("HALLWAY1", NodeType.HALLWAY);
+        MapNode leftTarget = createNode("HALLWAY2", NodeType.HALLWAY);
+        MapNode rightTarget = createNode("HALLWAY3", NodeType.HALLWAY);
+        light.configureGuidance(decisionNode, createEdge(decisionNode, leftTarget), createEdge(decisionNode, rightTarget));
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.LEFT);
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when
+        LightDirectionResponse response = iotLightService.changeDirection(light.getId(), request);
+
+        // then
+        assertThat(response.direction()).isEqualTo(IoTLightDirection.LEFT);
+        verify(iotLightPiClient).sendDirection("http://192.168.0.50:5000", "LIGHT_001", IoTLightDirection.LEFT);
+    }
+
+    @Test
+    @DisplayName("경로 안내가 설정되지 않은 유도등에 LEFT/RIGHT 명령을 보내면 예외가 발생한다")
+    void changeDirection_left_withoutGuidance_throws() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.LEFT);
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.changeDirection(light.getId(), request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.GUIDANCE_NOT_CONFIGURED.getMessage());
+        verifyNoInteractions(iotLightPiClient, iotLightDirectionStore, trainingEventPublisher);
+    }
+
+    @Test
+    @DisplayName("비활성화된 유도등에 명령을 보내면 예외가 발생한다")
+    void changeDirection_disabledLight_throws() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        light.disable();
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.OFF);
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.changeDirection(light.getId(), request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.LIGHT_DISABLED.getMessage());
+        verifyNoInteractions(iotLightPiClient, iotLightDirectionStore, trainingEventPublisher);
+    }
+
+    @Test
+    @DisplayName("piEndpoint가 설정되지 않은 유도등에 명령을 보내면 예외가 발생한다")
+    void changeDirection_piEndpointNotSet_throws() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.OFF);
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.changeDirection(light.getId(), request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.DEVICE_UNREACHABLE.getMessage());
+        verifyNoInteractions(iotLightPiClient, iotLightDirectionStore, trainingEventPublisher);
+    }
+
+    @Test
+    @DisplayName("Pi 통신이 실패하면 예외가 전파되고 상태 저장/이벤트 발행은 일어나지 않는다")
+    void changeDirection_piUnreachable_throws() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.OFF);
+
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+        org.mockito.BDDMockito.willThrow(new ApiException(IoTLightErrorCode.DEVICE_UNREACHABLE))
+                .given(iotLightPiClient).sendDirection(any(), any(), any());
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.changeDirection(light.getId(), request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.DEVICE_UNREACHABLE.getMessage());
+        verifyNoInteractions(iotLightDirectionStore, trainingEventPublisher);
     }
 }

--- a/src/test/java/com/saferoute/infrastructure/websocket/security/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/security/StompAuthChannelInterceptorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.global.security.CustomUserDetailsService;
 import com.saferoute.global.security.JwtTokenProvider;
@@ -42,6 +43,9 @@ class StompAuthChannelInterceptorTest {
     private TrainingSessionRepository trainingSessionRepository;
 
     @Mock
+    private FloorRepository floorRepository;
+
+    @Mock
     private MessageChannel channel;
 
     private StompAuthChannelInterceptor interceptor;
@@ -55,7 +59,8 @@ class StompAuthChannelInterceptorTest {
         interceptor = new StompAuthChannelInterceptor(
                 jwtTokenProvider,
                 userDetailsService,
-                trainingSessionRepository
+                trainingSessionRepository,
+                floorRepository
         );
     }
 
@@ -200,6 +205,34 @@ class StompAuthChannelInterceptorTest {
 
         StompHeaderAccessor accessor =
                 subscribeAccessor("/topic/training-sessions/" + sessionId, managerAuthentication());
+        Message<?> message = build(accessor);
+
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("인증된 MANAGER는 존재하는 층의 유도등 topic을 구독할 수 있다")
+    void subscribeSucceedsForAuthenticatedManagerWithExistingFloor() {
+        UUID floorId = UUID.randomUUID();
+        given(floorRepository.existsById(floorId)).willReturn(true);
+
+        StompHeaderAccessor accessor =
+                subscribeAccessor("/topic/floors/" + floorId + "/lights", managerAuthentication());
+        Message<?> message = build(accessor);
+
+        org.assertj.core.api.Assertions.assertThatCode(() -> interceptor.preSend(message, channel))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 층의 유도등 topic 구독은 거부한다")
+    void subscribeRejectsUnknownFloor() {
+        UUID floorId = UUID.randomUUID();
+        given(floorRepository.existsById(floorId)).willReturn(false);
+
+        StompHeaderAccessor accessor =
+                subscribeAccessor("/topic/floors/" + floorId + "/lights", managerAuthentication());
         Message<?> message = build(accessor);
 
         assertThatThrownBy(() -> interceptor.preSend(message, channel))

--- a/src/test/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisherTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisherTest.java
@@ -9,8 +9,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.infrastructure.websocket.dto.IoTLightEventMessage;
+import com.saferoute.infrastructure.websocket.dto.IoTLightStatusEventData;
 import com.saferoute.infrastructure.websocket.dto.TrainingEventMessage;
 import com.saferoute.infrastructure.websocket.dto.TrainingEventType;
 import com.saferoute.infrastructure.websocket.dto.TrainingStatusEventData;
@@ -117,6 +123,62 @@ class TrainingEventPublisherTest {
                 TransactionSynchronizationManager.clearSynchronization();
             }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("올바른 층 topic으로, eventType/floorId/occurredAt/data가 누락되지 않은 유도등 메시지를 발행한다")
+    void publishesIoTLightMessageWithAllRequiredFieldsToCorrectDestination() {
+        IoTLight light = mockLight();
+        UUID floorId = light.getCustomNode().getFloor().getId();
+
+        publisher.publishIoTLightStatusUpdated(light, IoTLightDirection.LEFT);
+
+        ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(messagingTemplate).convertAndSend(destinationCaptor.capture(), payloadCaptor.capture());
+
+        assertThat(destinationCaptor.getValue()).isEqualTo("/topic/floors/" + floorId + "/lights");
+
+        IoTLightEventMessage<IoTLightStatusEventData> message =
+                (IoTLightEventMessage<IoTLightStatusEventData>) payloadCaptor.getValue();
+
+        assertThat(message.eventType()).isEqualTo(TrainingEventType.IOT_LIGHT_STATUS_UPDATED);
+        assertThat(message.floorId()).isEqualTo(floorId);
+        assertThat(message.occurredAt()).isNotNull();
+        assertThat(message.data().lightId()).isEqualTo(light.getId());
+        assertThat(message.data().direction()).isEqualTo(IoTLightDirection.LEFT);
+    }
+
+    @Test
+    @DisplayName("유도등 이벤트도 트랜잭션 커밋 이후에만 발행한다")
+    void publishesIoTLightEventOnlyAfterCommit() {
+        IoTLight light = mockLight();
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            publisher.publishIoTLightStatusUpdatedAfterCommit(light, IoTLightDirection.RIGHT);
+
+            verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+
+            for (TransactionSynchronization synchronization :
+                    TransactionSynchronizationManager.getSynchronizations()) {
+                synchronization.afterCommit();
+            }
+
+            verify(messagingTemplate, times(1)).convertAndSend(anyString(), any(Object.class));
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    private IoTLight mockLight() {
+        Floor floor = mock(Floor.class);
+        lenient().when(floor.getId()).thenReturn(UUID.randomUUID());
+        MapNode customNode = MapNode.createCustom(floor, "LIGHT_001", "복도 유도등", 0.3, 0.4);
+        IoTLight light = IoTLight.create("LIGHT_001", "복도 유도등", customNode);
+        org.springframework.test.util.ReflectionTestUtils.setField(light, "id", UUID.randomUUID());
+        return light;
     }
 
     // 테스트별로 publish가 실제로 호출되지 않아 일부 스텁이 쓰이지 않을 수 있으므로 lenient로 등록한다.

--- a/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
@@ -8,6 +8,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.entity.BuildingType;
 import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import com.saferoute.domain.device.repository.IoTLightJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
@@ -72,6 +79,15 @@ class WebSocketIntegrationTest {
 
     @Autowired
     private TrainingEventPublisher trainingEventPublisher;
+
+    @Autowired
+    private FloorRepository floorRepository;
+
+    @Autowired
+    private MapNodeJpaRepository mapNodeJpaRepository;
+
+    @Autowired
+    private IoTLightJpaRepository iotLightJpaRepository;
 
     @Autowired
     private com.saferoute.domain.training.service.TrainingSessionService trainingSessionService;
@@ -245,6 +261,55 @@ class WebSocketIntegrationTest {
             session.disconnect();
         } finally {
             trainingSessionRepository.deleteById(runningSession.getId());
+        }
+    }
+
+    @Test
+    @DisplayName("MANAGER 토큰으로 층 유도등 topic을 구독하면 발행된 유도등 상태 이벤트를 수신한다")
+    void managerCanSubscribeFloorLightsTopicAndReceiveEvent() throws Exception {
+        Floor floor = Floor.create(building, 3);
+        floorRepository.save(floor);
+        MapNode customNode = mapNodeJpaRepository.save(MapNode.createCustom(floor, "LIGHT_TEST_001", "복도 유도등", 0.3, 0.4));
+        IoTLight light = iotLightJpaRepository.save(IoTLight.create("LIGHT_TEST_001", "복도 유도등", customNode));
+
+        try {
+            StompSession session = connect(managerToken);
+
+            BlockingQueue<String> received = new LinkedBlockingQueue<>();
+            session.subscribe(
+                    "/topic/floors/" + floor.getId() + "/lights",
+                    new StompFrameHandler() {
+                        @Override
+                        public Type getPayloadType(StompHeaders headers) {
+                            return byte[].class;
+                        }
+
+                        @Override
+                        public void handleFrame(StompHeaders headers, Object payload) {
+                            received.add(new String((byte[]) payload));
+                        }
+                    }
+            );
+
+            // 구독이 브로커에 등록될 시간을 확보한다.
+            Thread.sleep(300);
+
+            trainingEventPublisher.publishIoTLightStatusUpdated(light, IoTLightDirection.LEFT);
+
+            String payload = received.poll(5, TimeUnit.SECONDS);
+            assertThat(payload).isNotNull();
+
+            JsonNode json = objectMapper.readTree(payload);
+            assertThat(json.get("eventType").asText()).isEqualTo("IOT_LIGHT_STATUS_UPDATED");
+            assertThat(json.get("floorId").asText()).isEqualTo(floor.getId().toString());
+            assertThat(json.get("data").get("lightId").asText()).isEqualTo(light.getId().toString());
+            assertThat(json.get("data").get("direction").asText()).isEqualTo("LEFT");
+
+            session.disconnect();
+        } finally {
+            iotLightJpaRepository.delete(light);
+            mapNodeJpaRepository.delete(customNode);
+            floorRepository.delete(floor);
         }
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,14 @@ jwt:
   issuer: saferoute
   access-token-expiration: 1h
 
+# AiAnalysisClient 는 컨텍스트 로딩 시점에 값이 필요하므로 더미값을 넣는다.
+# src/test/resources/application.yml이 클래스패스에서 src/main/resources/application.yml과
+# 파일명이 같아 완전히 가려버리므로(merge 안 됨), 메인 쪽 기본값(${AI_SERVICE_BASE_URL:...})도
+# 적용되지 않는다 - 실제 AI 서비스 호출은 테스트에서 하지 않으므로 형식만 맞는 더미값이면 된다.
+saferoute:
+  ai-service:
+    base-url: http://localhost:8001
+
 # S3Config 는 컨텍스트 로딩 시점에 값이 필요하므로 더미값을 넣는다.
 # 실제 S3 호출은 테스트에서 하지 않으므로 아무 값이나 형식만 맞으면 된다.
 aws:


### PR DESCRIPTION
## 🔗 관련 이슈

closes #46

## 📋 작업 내용

- Swagger UI에서 API가 도메인별로 구분되도록 각 컨트롤러에 @Tag(name, description) 추가 (12개 컨트롤러, S3Controller는 기존 적용됨)
  - IoTLightController : IoT 유도등
  - FloorController : 층/도면
  - AnalysisController : AI 분석
  - TrainingSessionController : 훈련 세션
  - TrainingScenarioController : 훈련 시나리오
  - EvacuationRouteController : 대피 경로
  - MapGraphController : 맵 그래프
  - MapGraphEditController : 맵 그래프 편집
  - UserController : 사용자
  - TrainingReportController : 훈련 리포트
  - DashboardController : 대시보드
  - BuildingController : 건물
  - S3Controller : S3 파일 업로드 (기존)

## 🧪 테스트 결과

- [x] ./gradlew compileJava 통과
- [x] Swagger UI(/swagger-ui.html)에서 그룹핑 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * IoT 유도등의 방향 변경 및 Raspberry Pi 연결 주소 설정 기능을 추가했습니다.
  * 유도등 상태가 층별 WebSocket 채널로 실시간 전달됩니다.
  * 조명 상태 조회 응답에 Raspberry Pi 연결 주소가 포함됩니다.
  * 층별 조명 채널 구독 시 유효한 층인지 확인합니다.

* **문서**
  * 주요 API에 Swagger/OpenAPI 그룹명과 설명을 추가했습니다.

* **오류 처리**
  * 안내 경로 미설정, 비활성화 조명, 장치 연결 실패 상황을 구분해 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->