### PR TITLE
feat: 혼잡 이벤트 수신 및 자동 재탐색 트리거 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionController.java
@@ -1,0 +1,25 @@
+package com.saferoute.domain.congestion.controller;
+
+import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
+import com.saferoute.domain.congestion.service.CongestionEventService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "혼잡도", description = "CCTV 혼잡 이벤트 수신 API")
+@RestController
+@RequestMapping("/api/v1/congestion-events")
+@RequiredArgsConstructor
+public class CongestionController {
+
+    private final CongestionEventService congestionEventService;
+
+    @PostMapping
+    public void reportCongestion(@Valid @RequestBody ReportCongestionRequest request) {
+        congestionEventService.reportCongestion(request);
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/dto/request/ReportCongestionRequest.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/request/ReportCongestionRequest.java
@@ -1,0 +1,16 @@
+package com.saferoute.domain.congestion.dto.request;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ReportCongestionRequest(
+        @NotNull UUID edgeId,
+        String cctvCode,
+        Integer avgHeadcount,
+        Integer peakHeadcount,
+        @NotNull CongestionLevel congestionLevel,
+        @NotNull Long windowStart,
+        @NotNull Long windowEnd,
+        String s3ImageKey
+) {}

--- a/src/main/java/com/saferoute/domain/congestion/dto/request/ReportCongestionRequest.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/request/ReportCongestionRequest.java
@@ -1,16 +1,34 @@
 package com.saferoute.domain.congestion.dto.request;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.UUID;
 
 public record ReportCongestionRequest(
         @NotNull UUID edgeId,
         String cctvCode,
-        Integer avgHeadcount,
-        Integer peakHeadcount,
+        @NotNull @PositiveOrZero Integer avgHeadcount,
+        @NotNull @PositiveOrZero Integer peakHeadcount,
         @NotNull CongestionLevel congestionLevel,
         @NotNull Long windowStart,
         @NotNull Long windowEnd,
         String s3ImageKey
-) {}
+) {
+    @AssertTrue(message = "avgHeadcount must not exceed peakHeadcount")
+    public boolean isHeadcountValid() {
+        if (avgHeadcount == null || peakHeadcount == null) {
+            return true;
+        }
+        return avgHeadcount <= peakHeadcount;
+    }
+
+    @AssertTrue(message = "windowStart must be before windowEnd")
+    public boolean isWindowValid() {
+        if (windowStart == null || windowEnd == null) {
+            return true;
+        }
+        return windowStart < windowEnd;
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -39,7 +39,7 @@ public class CongestionEventService {
 
         var buildingId = edge.getFloor().getBuilding().getId();
         TrainingSession session = trainingSessionRepository
-                .findFirstByStatusAndScenario_Building_Id(TrainingStatus.RUNNING, buildingId)
+                .findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(TrainingStatus.RUNNING, buildingId)
                 .orElse(null);
         if (session == null) {
             log.debug("훈련 중이 아닌 건물의 혼잡 이벤트라 무시함: buildingId={}, edgeId={}", buildingId, edge.getId());

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -1,0 +1,69 @@
+package com.saferoute.domain.congestion.service;
+
+import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionSummaryItem;
+import com.saferoute.domain.telemetry.dynamo.repository.CongestionSummaryRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CongestionEventService {
+
+    private final MapEdgeJpaRepository mapEdgeJpaRepository;
+    private final TrainingSessionRepository trainingSessionRepository;
+    private final CongestionSummaryRepository congestionSummaryRepository;
+    private final TrainingEventPublisher trainingEventPublisher;
+    private final RouteRecalculationService routeRecalculationService;
+
+    // Raspberry Pi / YOLO가 보고하는 혼잡 이벤트를 받아 DynamoDB에 저장하고, HIGH/CRITICAL이면 재탐색을 트리거한다.
+    // 대상 건물에 RUNNING 세션이 없으면(훈련 중이 아니면) 저장/트리거 없이 조용히 종료한다.
+    @Transactional
+    public void reportCongestion(ReportCongestionRequest request) {
+        MapEdge edge = mapEdgeJpaRepository.findById(request.edgeId())
+                .orElseThrow(() -> new ApiException(EvacuationErrorCode.MAP_EDGE_NOT_FOUND));
+
+        var buildingId = edge.getFloor().getBuilding().getId();
+        TrainingSession session = trainingSessionRepository
+                .findFirstByStatusAndScenario_Building_Id(TrainingStatus.RUNNING, buildingId)
+                .orElse(null);
+        if (session == null) {
+            log.debug("훈련 중이 아닌 건물의 혼잡 이벤트라 무시함: buildingId={}, edgeId={}", buildingId, edge.getId());
+            return;
+        }
+
+        CongestionSummaryItem item = CongestionSummaryItem.create(
+                session.getId().toString(),
+                edge.getId().toString(),
+                request.cctvCode(),
+                request.avgHeadcount(),
+                request.peakHeadcount(),
+                request.congestionLevel(),
+                request.windowStart(),
+                request.windowEnd(),
+                request.s3ImageKey()
+        );
+        congestionSummaryRepository.save(item);
+
+        trainingEventPublisher.publishCongestionUpdated(session.getId(), edge.getId(), item);
+
+        CongestionLevel level = request.congestionLevel();
+        if (level == CongestionLevel.HIGH || level == CongestionLevel.CRITICAL) {
+            routeRecalculationService.trigger(session, edge, level);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RecalculationStatus.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RecalculationStatus.java
@@ -1,0 +1,10 @@
+package com.saferoute.domain.evacuation.recalculation.entity;
+
+// 혼잡 감지로 트리거된 재탐색 결과의 승인 상태.
+// 상태 검증(guard)은 이 엔티티가 아니라 RouteRecalculationService에서 한다
+// (TrainingSessionService.start()/end()/forceEnd(), IoTLightService와 동일한 컨벤션 - 엔티티는 단순 세터).
+public enum RecalculationStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RouteRecalculation.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RouteRecalculation.java
@@ -1,0 +1,107 @@
+package com.saferoute.domain.evacuation.recalculation.entity;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.training.entity.TrainingSession;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+// 혼잡 감지로 트리거된 우회 경로 재탐색 결과. 관리자가 승인해야 실제 대피 경로에 반영된다.
+@Entity
+@Getter
+@Table(name = "route_recalculations")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RouteRecalculation {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "training_session_id", nullable = false)
+    private TrainingSession trainingSession;
+
+    // 혼잡이 감지되어 이번 재탐색을 트리거한 엣지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trigger_edge_id", nullable = false)
+    private MapEdge triggerEdge;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "congestion_level", nullable = false, length = 20)
+    private CongestionLevel congestionLevel;
+
+    // 우회 경로를 이루는 노드 id 순서 (출발 -> 도착)
+    @ElementCollection
+    @CollectionTable(
+            name = "route_recalculation_nodes",
+            joinColumns = @JoinColumn(name = "route_recalculation_id")
+    )
+    @OrderColumn(name = "node_order")
+    @Column(name = "node_id", nullable = false)
+    private List<UUID> recalculatedNodeIds = new ArrayList<>();
+
+    @Column(name = "total_weight", nullable = false)
+    private double totalWeight;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private RecalculationStatus status;
+
+    @CreatedDate
+    @Column(name = "requested_at", nullable = false, updatable = false)
+    private Instant requestedAt;
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+
+    private RouteRecalculation(TrainingSession trainingSession, MapEdge triggerEdge,
+            CongestionLevel congestionLevel, List<UUID> recalculatedNodeIds, double totalWeight) {
+        this.trainingSession = trainingSession;
+        this.triggerEdge = triggerEdge;
+        this.congestionLevel = congestionLevel;
+        this.recalculatedNodeIds = recalculatedNodeIds;
+        this.totalWeight = totalWeight;
+        this.status = RecalculationStatus.PENDING;
+    }
+
+    // 재탐색 결과를 승인 대기 상태로 저장하는 정적 팩토리 메서드
+    public static RouteRecalculation createPending(TrainingSession trainingSession, MapEdge triggerEdge,
+            CongestionLevel congestionLevel, List<UUID> recalculatedNodeIds, double totalWeight) {
+        return new RouteRecalculation(trainingSession, triggerEdge, congestionLevel, recalculatedNodeIds,
+                totalWeight);
+    }
+
+    // 상태 전이 검증은 이 엔티티가 아니라 RouteRecalculationService가 담당한다
+    // (TrainingSessionService.start()/end()/forceEnd(), IoTLightService와 동일한 컨벤션).
+    public void approve(Instant resolvedAt) {
+        this.status = RecalculationStatus.APPROVED;
+        this.resolvedAt = resolvedAt;
+    }
+
+    public void reject(Instant resolvedAt) {
+        this.status = RecalculationStatus.REJECTED;
+        this.resolvedAt = resolvedAt;
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RouteRecalculation.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RouteRecalculation.java
@@ -17,6 +17,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 // 혼잡 감지로 트리거된 우회 경로 재탐색 결과. 관리자가 승인해야 실제 대피 경로에 반영된다.
 @Entity
 @Getter
-@Table(name = "route_recalculations")
+@Table(name = "route_recalculations", uniqueConstraints = @UniqueConstraint(
+        name = "uk_route_recalculation_session_edge_status",
+        columnNames = {"training_session_id", "trigger_edge_id", "status"}
+))
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RouteRecalculation {

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
@@ -1,0 +1,14 @@
+package com.saferoute.domain.evacuation.recalculation.repository;
+
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteRecalculationRepository extends JpaRepository<RouteRecalculation, UUID> {
+
+    // Pi가 혼잡 이벤트를 짧은 주기로 반복 전송하므로, 같은 세션+엣지에 대해
+    // 이미 PENDING이 있으면 새로 트리거하지 않는다.
+    boolean existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+            UUID trainingSessionId, UUID triggerEdgeId, RecalculationStatus status);
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -1,0 +1,86 @@
+package com.saferoute.domain.evacuation.recalculation.service;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
+import com.saferoute.domain.evacuation.service.EvacuationRoute;
+import com.saferoute.domain.evacuation.service.EvacuationRouteService;
+import com.saferoute.domain.telemetry.dynamo.entity.EventType;
+import com.saferoute.domain.telemetry.dynamo.entity.TrainingEventItem;
+import com.saferoute.domain.telemetry.dynamo.repository.TrainingEventRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RouteRecalculationService {
+
+    private static final String TRIGGER_TYPE_CONGESTION = "CONGESTION";
+
+    private final RouteRecalculationRepository routeRecalculationRepository;
+    private final EvacuationRouteService evacuationRouteService;
+    private final TrainingEventRepository trainingEventRepository;
+    private final TrainingEventPublisher trainingEventPublisher;
+
+    // 혼잡 감지로 트리거되는 우회 경로 재탐색. 같은 세션+엣지에 이미 PENDING이 있으면 새로 만들지 않고,
+    // 우회 경로 자체가 없으면 로그만 남기고 승인 대기 항목을 만들지 않는다 (관리자 "재탐색 실패" 알림은 범위 밖).
+    @Transactional
+    public void trigger(TrainingSession session, MapEdge triggerEdge, CongestionLevel level) {
+        if (routeRecalculationRepository.existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+                session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING)) {
+            return;
+        }
+
+        UUID floorId = triggerEdge.getFloor().getId();
+        // TODO: 양방향 엣지에서 실제로는 반대편 기준 우회도 필요할 수 있음 - 일단 fromNode 기준으로 고정
+        UUID startNodeId = triggerEdge.getFromNode().getId();
+
+        EvacuationRoute route;
+        try {
+            route = evacuationRouteService.findShortestRoute(floorId, startNodeId, Set.of(triggerEdge.getId()));
+        } catch (ApiException exception) {
+            if (exception.getErrorCode() == EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND) {
+                log.warn("우회 경로를 찾을 수 없어 재탐색 승인 대기 항목을 생성하지 않음: sessionId={}, edgeId={}",
+                        session.getId(), triggerEdge.getId());
+                return;
+            }
+            throw exception;
+        }
+
+        List<UUID> newPathNodeIds = route.path().stream().map(node -> node.getId()).toList();
+
+        RouteRecalculation recalculation = routeRecalculationRepository.save(
+                RouteRecalculation.createPending(session, triggerEdge, level, newPathNodeIds, route.totalWeight())
+        );
+
+        trainingEventRepository.save(TrainingEventItem.create(
+                session.getId().toString(),
+                UUID.randomUUID().toString(),
+                Instant.now().toEpochMilli(),
+                EventType.ROUTE_RECALCULATED,
+                TRIGGER_TYPE_CONGESTION,
+                List.of(triggerEdge.getId().toString()),
+                null,
+                newPathNodeIds.stream().map(UUID::toString).toList(),
+                null,
+                null,
+                null
+        ));
+
+        trainingEventPublisher.publishRouteRecalculationRequestedAfterCommit(recalculation);
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,9 +64,16 @@ public class RouteRecalculationService {
 
         List<UUID> newPathNodeIds = route.path().stream().map(node -> node.getId()).toList();
 
-        RouteRecalculation recalculation = routeRecalculationRepository.save(
-                RouteRecalculation.createPending(session, triggerEdge, level, newPathNodeIds, route.totalWeight())
-        );
+        RouteRecalculation recalculation;
+        try {
+            recalculation = routeRecalculationRepository.save(
+                    RouteRecalculation.createPending(session, triggerEdge, level, newPathNodeIds, route.totalWeight())
+            );
+        } catch (DataIntegrityViolationException exception) {
+            // 동시에 들어온 중복 혼잡 이벤트가 exists() 체크를 함께 통과한 경우, DB 유니크 제약으로 걸러진 것이므로 조용히 무시한다.
+            log.debug("동시 요청으로 인한 중복 재탐색 저장을 무시함: sessionId={}, edgeId={}", session.getId(), triggerEdge.getId());
+            return;
+        }
 
         trainingEventRepository.save(TrainingEventItem.create(
                 session.getId().toString(),

--- a/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRouteService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRouteService.java
@@ -33,8 +33,16 @@ public class EvacuationRouteService {
 
     // 시작 노드에서 가장 가까운 EXIT 대상 노드까지 최단 경로 계산 (mock data 기준, congestion/danger는 0 고정)
     public EvacuationRoute findShortestRoute(UUID floorId, UUID startNodeId) {
+        return findShortestRoute(floorId, startNodeId, Set.of());
+    }
+
+    // 혼잡 재탐색용 - 지정된 엣지를 그래프에서 제외하고 우회 경로를 계산한다.
+    // congestion/danger 가중치 자체(현재 0 고정)와는 별개로, "엣지 제외" 방식의 임시 조치다.
+    public EvacuationRoute findShortestRoute(UUID floorId, UUID startNodeId, Set<UUID> excludedEdgeIds) {
         List<MapNode> nodes = mapGraphRepository.findNodesByFloor(floorId);
-        List<MapEdge> edges = mapGraphRepository.findEdgesByFloor(floorId);
+        List<MapEdge> edges = mapGraphRepository.findEdgesByFloor(floorId).stream()
+                .filter(edge -> !excludedEdgeIds.contains(edge.getId()))
+                .toList();
 
         Map<UUID, MapNode> nodeById = new HashMap<>();
         for (MapNode node : nodes) {

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -4,10 +4,15 @@ import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TrainingSessionRepository extends JpaRepository<TrainingSession, UUID> {
 
   List<TrainingSession> findByStatusAndStartedAtBefore(TrainingStatus status, Instant threshold);
+
+  // 혼잡 이벤트가 들어온 엣지가 속한 건물에 현재 진행 중인 세션이 있는지 조회한다.
+  // 건물당 동시 RUNNING 세션은 1개라고 가정한다 (TrainingSession에 세션-층 직접 연결이 없어 건물 단위로 조회).
+  Optional<TrainingSession> findFirstByStatusAndScenario_Building_Id(TrainingStatus status, UUID buildingId);
 }

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface TrainingSessionRepository extends JpaRepository<TrainingSession, UUID> {
 
@@ -14,5 +15,8 @@ public interface TrainingSessionRepository extends JpaRepository<TrainingSession
 
   // 혼잡 이벤트가 들어온 엣지가 속한 건물에 현재 진행 중인 세션이 있는지 조회한다.
   // 건물당 동시 RUNNING 세션은 1개라고 가정한다 (TrainingSession에 세션-층 직접 연결이 없어 건물 단위로 조회).
-  Optional<TrainingSession> findFirstByStatusAndScenario_Building_Id(TrainingStatus status, UUID buildingId);
+  // 이 가정이 실제로 DB 제약으로 강제되진 않으므로(건물↔세션이 시나리오를 거쳐 조인되어 단순 유니크 인덱스로 표현 불가),
+  // 여러 RUNNING 세션이 동시에 존재하는 예외적인 상황에서도 결과가 흔들리지 않도록 시작 시각 기준으로 정렬한다.
+  Optional<TrainingSession> findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(
+      @Param("status") TrainingStatus status, @Param("buildingId") UUID buildingId);
 }

--- a/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
@@ -15,7 +15,9 @@ public enum EvacuationErrorCode implements BaseErrorCode {
     INVALID_MAP_EDGE_CONNECTION(HttpStatus.BAD_REQUEST, "EVAC004", "ROOM 노드는 DOOR 노드를 통해서만 연결할 수 있습니다."),
     EVACUATION_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVAC005", "도달 가능한 EXIT 노드가 없습니다."),
     EXIT_NODE_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVAC006", "마지막 출구 노드는 삭제할 수 없습니다."),
-    EXIT_NODE_NOT_DESIGNATED(HttpStatus.NOT_FOUND, "EVAC007", "지정된 출구 노드가 없습니다.");
+    EXIT_NODE_NOT_DESIGNATED(HttpStatus.NOT_FOUND, "EVAC007", "지정된 출구 노드가 없습니다."),
+    ROUTE_RECALCULATION_NOT_FOUND(HttpStatus.NOT_FOUND, "EVAC008", "재탐색 요청을 찾을 수 없습니다."),
+    INVALID_RECALCULATION_STATUS_TRANSITION(HttpStatus.CONFLICT, "EVAC009", "이미 처리된 재탐색 요청입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventData.java
@@ -1,0 +1,26 @@
+package com.saferoute.infrastructure.websocket.dto;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionSummaryItem;
+import java.util.UUID;
+
+public record CongestionEventData(
+        UUID edgeId,
+        Integer avgHeadcount,
+        Integer peakHeadcount,
+        CongestionLevel congestionLevel,
+        Long windowStart,
+        Long windowEnd
+) {
+
+    public static CongestionEventData from(UUID edgeId, CongestionSummaryItem item) {
+        return new CongestionEventData(
+                edgeId,
+                item.getAvgHeadcount(),
+                item.getPeakHeadcount(),
+                item.getCongestionLevel(),
+                item.getWindowStart(),
+                item.getWindowEnd()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/RouteRecalculationEventData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/RouteRecalculationEventData.java
@@ -1,0 +1,28 @@
+package com.saferoute.infrastructure.websocket.dto;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import java.util.List;
+import java.util.UUID;
+
+public record RouteRecalculationEventData(
+        UUID recalculationId,
+        UUID triggerEdgeId,
+        CongestionLevel congestionLevel,
+        List<UUID> recalculatedNodeIds,
+        double totalWeight,
+        RecalculationStatus status
+) {
+
+    public static RouteRecalculationEventData from(RouteRecalculation recalculation) {
+        return new RouteRecalculationEventData(
+                recalculation.getId(),
+                recalculation.getTriggerEdge().getId(),
+                recalculation.getCongestionLevel(),
+                recalculation.getRecalculatedNodeIds(),
+                recalculation.getTotalWeight(),
+                recalculation.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
@@ -6,10 +6,13 @@ public enum TrainingEventType {
     // 현재는 위 도메인 메서드를 호출하는 시작/종료 API가 없어 실제로 발행되지는 않는다.
     TRAINING_STATUS_UPDATED,
 
-    // 아래 2개는 계약(메시지 규격) 정의만 되어 있는 상태다.
-    // 대응하는 도메인 로직(혼잡도 계산, 경로 재계산)이 아직 없어
-    // 전용 데이터 DTO와 TrainingEventPublisher 발행 메서드는 이번 작업에서 추가하지 않았다.
+    // CongestionEventService.reportCongestion() 호출 시 발행된다. (이슈 #48)
     CONGESTION_UPDATED,
+
+    // RouteRecalculationService.trigger()가 재탐색 결과를 PENDING으로 저장했을 때 발행된다. (이슈 #48)
+    ROUTE_RECALCULATION_REQUESTED,
+
+    // RouteRecalculationService.approve()가 재탐색 결과를 승인했을 때 발행된다. (이슈 #49에서 구현 예정)
     EVACUATION_ROUTE_UPDATED,
 
     // IoTLightService.changeDirection() 호출 시 TrainingEventPublisher.publishIoTLightStatusUpdated()가 발행한다.

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -2,9 +2,13 @@ package com.saferoute.infrastructure.websocket.service;
 
 import com.saferoute.domain.device.entity.IoTLight;
 import com.saferoute.domain.device.entity.IoTLightDirection;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionSummaryItem;
 import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.infrastructure.websocket.dto.CongestionEventData;
 import com.saferoute.infrastructure.websocket.dto.IoTLightEventMessage;
 import com.saferoute.infrastructure.websocket.dto.IoTLightStatusEventData;
+import com.saferoute.infrastructure.websocket.dto.RouteRecalculationEventData;
 import com.saferoute.infrastructure.websocket.dto.TrainingEventMessage;
 import com.saferoute.infrastructure.websocket.dto.TrainingEventType;
 import com.saferoute.infrastructure.websocket.dto.TrainingStatusEventData;
@@ -21,9 +25,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 // SimpMessagingTemplate을 다른 서비스에 직접 주입하지 않고 항상 이 클래스를 거친다.
 // 훈련 세션 이벤트는 /topic/training-sessions/{sessionId}, 유도등 이벤트는 층 도면 화면이
 // 층 전체를 한 번에 보여주는 구조라 /topic/floors/{floorId}/lights로 발행한다.
-//
-// 혼잡도 / 경로 재계산 이벤트 발행 메서드는 아직 없다.
-// 대응하는 도메인 로직이 만들어지면 이 클래스에 전용 메서드를 추가한다.
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -124,6 +125,71 @@ public class TrainingEventPublisher {
                                     light.getId(),
                                     exception
                             );
+                        }
+                    }
+                }
+        );
+    }
+
+    // 혼잡 이벤트 수신 시 즉시 발행한다 (DynamoDB 저장은 DB 트랜잭션과 무관하므로 AfterCommit 버전을 두지 않는다).
+    public void publishCongestionUpdated(UUID sessionId, UUID edgeId, CongestionSummaryItem item) {
+        TrainingEventMessage<CongestionEventData> message = TrainingEventMessage.of(
+                TrainingEventType.CONGESTION_UPDATED,
+                sessionId,
+                CongestionEventData.from(edgeId, item)
+        );
+
+        messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
+
+        log.debug(
+                "혼잡도 이벤트 발행: sessionId={}, edgeId={}, level={}",
+                sessionId,
+                edgeId,
+                item.getCongestionLevel()
+        );
+    }
+
+    // DB 트랜잭션이 실제로 커밋된 이후에만 발행한다 (publishTrainingStatusUpdatedAfterCommit 참고).
+    public void publishRouteRecalculationRequestedAfterCommit(RouteRecalculation recalculation) {
+        publishAfterCommit(
+                () -> publishRouteRecalculationRequested(recalculation),
+                "커밋 후 재탐색 요청 이벤트 발행 실패: recalculationId=" + recalculation.getId()
+        );
+    }
+
+    public void publishRouteRecalculationRequested(RouteRecalculation recalculation) {
+        UUID sessionId = recalculation.getTrainingSession().getId();
+        TrainingEventMessage<RouteRecalculationEventData> message = TrainingEventMessage.of(
+                TrainingEventType.ROUTE_RECALCULATION_REQUESTED,
+                sessionId,
+                RouteRecalculationEventData.from(recalculation)
+        );
+
+        messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
+
+        log.debug(
+                "재탐색 요청 이벤트 발행: sessionId={}, recalculationId={}",
+                sessionId,
+                recalculation.getId()
+        );
+    }
+
+    // approve() 승인 시 발행하는 EVACUATION_ROUTE_UPDATED는 승인/거절 API(이슈 #49)에서 추가한다.
+
+    private void publishAfterCommit(Runnable publish, String failureLogMessage) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            publish.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        try {
+                            publish.run();
+                        } catch (RuntimeException exception) {
+                            log.error(failureLogMessage, exception);
                         }
                     }
                 }

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
@@ -1,0 +1,85 @@
+package com.saferoute.domain.congestion.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.congestion.service.CongestionEventService;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.config.SecurityConfig;
+import com.saferoute.global.security.JwtAuthenticationFilter;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = CongestionController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {JwtAuthenticationFilter.class, SecurityConfig.class}
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class CongestionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CongestionEventService congestionEventService;
+
+    private ReportCongestionRequest validRequest() {
+        return new ReportCongestionRequest(
+                UUID.randomUUID(), "CCTV_001", 5, 8, CongestionLevel.HIGH, 1000L, 2000L, null);
+    }
+
+    @Test
+    @DisplayName("유효한 요청이면 200을 반환한다")
+    void reportCongestion_returnsOk() throws Exception {
+        mockMvc.perform(post("/api/v1/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("edgeId가 없으면 400을 반환한다")
+    void reportCongestion_returnsBadRequestWhenEdgeIdMissing() throws Exception {
+        ReportCongestionRequest invalid = new ReportCongestionRequest(
+                null, "CCTV_001", 5, 8, CongestionLevel.HIGH, 1000L, 2000L, null);
+
+        mockMvc.perform(post("/api/v1/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("서비스가 MAP_EDGE_NOT_FOUND를 던지면 404를 반환한다")
+    void reportCongestion_returnsNotFoundWhenEdgeMissing() throws Exception {
+        willThrow(new ApiException(EvacuationErrorCode.MAP_EDGE_NOT_FOUND))
+                .given(congestionEventService).reportCongestion(any());
+
+        mockMvc.perform(post("/api/v1/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
@@ -72,6 +72,54 @@ class CongestionControllerTest {
     }
 
     @Test
+    @DisplayName("avgHeadcount가 음수면 400을 반환한다")
+    void reportCongestion_returnsBadRequestWhenAvgHeadcountNegative() throws Exception {
+        ReportCongestionRequest invalid = new ReportCongestionRequest(
+                UUID.randomUUID(), "CCTV_001", -1, 8, CongestionLevel.HIGH, 1000L, 2000L, null);
+
+        mockMvc.perform(post("/api/v1/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("peakHeadcount가 음수면 400을 반환한다")
+    void reportCongestion_returnsBadRequestWhenPeakHeadcountNegative() throws Exception {
+        ReportCongestionRequest invalid = new ReportCongestionRequest(
+                UUID.randomUUID(), "CCTV_001", 5, -1, CongestionLevel.HIGH, 1000L, 2000L, null);
+
+        mockMvc.perform(post("/api/v1/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("avgHeadcount가 peakHeadcount보다 크면 400을 반환한다")
+    void reportCongestion_returnsBadRequestWhenAvgExceedsPeak() throws Exception {
+        ReportCongestionRequest invalid = new ReportCongestionRequest(
+                UUID.randomUUID(), "CCTV_001", 9, 8, CongestionLevel.HIGH, 1000L, 2000L, null);
+
+        mockMvc.perform(post("/api/v1/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("windowStart가 windowEnd보다 이후이면 400을 반환한다")
+    void reportCongestion_returnsBadRequestWhenWindowStartAfterWindowEnd() throws Exception {
+        ReportCongestionRequest invalid = new ReportCongestionRequest(
+                UUID.randomUUID(), "CCTV_001", 5, 8, CongestionLevel.HIGH, 2000L, 1000L, null);
+
+        mockMvc.perform(post("/api/v1/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("서비스가 MAP_EDGE_NOT_FOUND를 던지면 404를 반환한다")
     void reportCongestion_returnsNotFoundWhenEdgeMissing() throws Exception {
         willThrow(new ApiException(EvacuationErrorCode.MAP_EDGE_NOT_FOUND))

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -87,7 +87,7 @@ class CongestionEventServiceTest {
     @DisplayName("대상 건물에 RUNNING 세션이 없으면 저장/발행/트리거 없이 조용히 종료한다")
     void reportCongestion_noOpWhenNoRunningSession() {
         given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
-        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_Id(TrainingStatus.RUNNING, buildingId))
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(TrainingStatus.RUNNING, buildingId))
                 .willReturn(Optional.empty());
 
         congestionEventService.reportCongestion(request(CongestionLevel.HIGH));
@@ -104,7 +104,7 @@ class CongestionEventServiceTest {
         given(session.getId()).willReturn(UUID.randomUUID());
 
         given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
-        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_Id(TrainingStatus.RUNNING, buildingId))
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(TrainingStatus.RUNNING, buildingId))
                 .willReturn(Optional.of(session));
 
         congestionEventService.reportCongestion(request(CongestionLevel.MEDIUM));
@@ -121,7 +121,7 @@ class CongestionEventServiceTest {
         given(session.getId()).willReturn(UUID.randomUUID());
 
         given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
-        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_Id(TrainingStatus.RUNNING, buildingId))
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(TrainingStatus.RUNNING, buildingId))
                 .willReturn(Optional.of(session));
 
         congestionEventService.reportCongestion(request(CongestionLevel.CRITICAL));

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -1,0 +1,132 @@
+package com.saferoute.domain.congestion.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.repository.CongestionSummaryRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionEventServiceTest {
+
+    @InjectMocks
+    private CongestionEventService congestionEventService;
+
+    @Mock
+    private MapEdgeJpaRepository mapEdgeJpaRepository;
+
+    @Mock
+    private TrainingSessionRepository trainingSessionRepository;
+
+    @Mock
+    private CongestionSummaryRepository congestionSummaryRepository;
+
+    @Mock
+    private TrainingEventPublisher trainingEventPublisher;
+
+    @Mock
+    private RouteRecalculationService routeRecalculationService;
+
+    private final UUID edgeId = UUID.randomUUID();
+    private final UUID buildingId = UUID.randomUUID();
+    private MapEdge edge;
+
+    @BeforeEach
+    void setUp() {
+        Building building = mock(Building.class);
+        org.mockito.Mockito.lenient().when(building.getId()).thenReturn(buildingId);
+
+        Floor floor = mock(Floor.class);
+        org.mockito.Mockito.lenient().when(floor.getBuilding()).thenReturn(building);
+
+        edge = mock(MapEdge.class);
+        org.mockito.Mockito.lenient().when(edge.getId()).thenReturn(edgeId);
+        org.mockito.Mockito.lenient().when(edge.getFloor()).thenReturn(floor);
+    }
+
+    private ReportCongestionRequest request(CongestionLevel level) {
+        return new ReportCongestionRequest(edgeId, "CCTV_001", 5, 8, level, 1000L, 2000L, null);
+    }
+
+    @Test
+    @DisplayName("엣지를 찾을 수 없으면 MAP_EDGE_NOT_FOUND를 던진다")
+    void reportCongestion_throwsWhenEdgeNotFound() {
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> congestionEventService.reportCongestion(request(CongestionLevel.LOW)))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EvacuationErrorCode.MAP_EDGE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("대상 건물에 RUNNING 세션이 없으면 저장/발행/트리거 없이 조용히 종료한다")
+    void reportCongestion_noOpWhenNoRunningSession() {
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_Id(TrainingStatus.RUNNING, buildingId))
+                .willReturn(Optional.empty());
+
+        congestionEventService.reportCongestion(request(CongestionLevel.HIGH));
+
+        verify(congestionSummaryRepository, never()).save(any());
+        verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("LOW/MEDIUM은 저장·발행만 하고 재탐색은 트리거하지 않는다")
+    void reportCongestion_doesNotTriggerRecalculationForLowLevel() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(UUID.randomUUID());
+
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_Id(TrainingStatus.RUNNING, buildingId))
+                .willReturn(Optional.of(session));
+
+        congestionEventService.reportCongestion(request(CongestionLevel.MEDIUM));
+
+        verify(congestionSummaryRepository, org.mockito.Mockito.times(1)).save(any());
+        verify(trainingEventPublisher, org.mockito.Mockito.times(1)).publishCongestionUpdated(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("HIGH/CRITICAL이면 저장·발행 후 재탐색을 트리거한다")
+    void reportCongestion_triggersRecalculationForHighLevel() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(UUID.randomUUID());
+
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_Id(TrainingStatus.RUNNING, buildingId))
+                .willReturn(Optional.of(session));
+
+        congestionEventService.reportCongestion(request(CongestionLevel.CRITICAL));
+
+        verify(routeRecalculationService, org.mockito.Mockito.times(1))
+                .trigger(session, edge, CongestionLevel.CRITICAL);
+    }
+}

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -25,11 +25,13 @@ import com.saferoute.global.api.error.EvacuationErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -125,6 +127,10 @@ class RouteRecalculationServiceTest {
         routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.HIGH);
 
         // then
+        ArgumentCaptor<Set<UUID>> excludedEdgesCaptor = ArgumentCaptor.forClass(Set.class);
+        verify(evacuationRouteService).findShortestRoute(any(), any(), excludedEdgesCaptor.capture());
+        assertThat(excludedEdgesCaptor.getValue()).containsExactly(triggerEdge.getId());
+
         verify(routeRecalculationRepository, times(1)).save(any());
         verify(trainingEventRepository, times(1)).save(any());
         verify(trainingEventPublisher, times(1)).publishRouteRecalculationRequestedAfterCommit(saved);

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -1,0 +1,132 @@
+package com.saferoute.domain.evacuation.recalculation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
+import com.saferoute.domain.evacuation.service.EvacuationRoute;
+import com.saferoute.domain.evacuation.service.EvacuationRouteService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.repository.TrainingEventRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RouteRecalculationServiceTest {
+
+    @InjectMocks
+    private RouteRecalculationService routeRecalculationService;
+
+    @Mock
+    private RouteRecalculationRepository routeRecalculationRepository;
+
+    @Mock
+    private EvacuationRouteService evacuationRouteService;
+
+    @Mock
+    private TrainingEventRepository trainingEventRepository;
+
+    @Mock
+    private TrainingEventPublisher trainingEventPublisher;
+
+    private TrainingSession session;
+    private MapEdge triggerEdge;
+
+    @BeforeEach
+    void setUp() {
+        session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(UUID.randomUUID());
+
+        Floor floor = mock(Floor.class);
+        org.mockito.Mockito.lenient().when(floor.getId()).thenReturn(UUID.randomUUID());
+
+        MapNode fromNode = MapNode.create(floor, "HALLWAY1", NodeType.HALLWAY, "HALLWAY1", 0, 0, false);
+        ReflectionTestUtils.setField(fromNode, "id", UUID.randomUUID());
+
+        triggerEdge = MapEdge.create(floor, fromNode, mock(MapNode.class), 5.0, true);
+        ReflectionTestUtils.setField(triggerEdge, "id", UUID.randomUUID());
+        ReflectionTestUtils.setField(triggerEdge, "floor", floor);
+    }
+
+    @Test
+    @DisplayName("같은 세션+엣지에 이미 PENDING이 있으면 새로 트리거하지 않는다")
+    void trigger_skipsWhenPendingAlreadyExists() {
+        // given
+        given(routeRecalculationRepository.existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+                session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING)).willReturn(true);
+
+        // when
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.HIGH);
+
+        // then
+        verify(evacuationRouteService, never()).findShortestRoute(any(), any(), anySet());
+        verify(routeRecalculationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("우회 경로가 없으면 로그만 남기고 승인 대기 항목을 만들지 않는다")
+    void trigger_skipsWhenNoDetourRouteFound() {
+        // given
+        given(routeRecalculationRepository.existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+                any(), any(), any())).willReturn(false);
+        given(evacuationRouteService.findShortestRoute(any(), any(), anySet()))
+                .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
+
+        // when
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.HIGH);
+
+        // then
+        verify(routeRecalculationRepository, never()).save(any());
+        verify(trainingEventRepository, never()).save(any());
+        verify(trainingEventPublisher, never()).publishRouteRecalculationRequestedAfterCommit(any());
+    }
+
+    @Test
+    @DisplayName("우회 경로를 찾으면 PENDING 저장 + DynamoDB 이력 저장 + WS 발행을 한다")
+    void trigger_createsPendingRecalculationAndPublishesEvent() {
+        // given
+        MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
+        ReflectionTestUtils.setField(exitNode, "id", UUID.randomUUID());
+        EvacuationRoute route = new EvacuationRoute(List.of(exitNode), 12.5);
+
+        given(routeRecalculationRepository.existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+                any(), any(), any())).willReturn(false);
+        given(evacuationRouteService.findShortestRoute(any(), any(), anySet())).willReturn(route);
+
+        RouteRecalculation saved = RouteRecalculation.createPending(
+                session, triggerEdge, CongestionLevel.HIGH, List.of(exitNode.getId()), 12.5);
+        given(routeRecalculationRepository.save(any())).willReturn(saved);
+
+        // when
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.HIGH);
+
+        // then
+        verify(routeRecalculationRepository, times(1)).save(any());
+        verify(trainingEventRepository, times(1)).save(any());
+        verify(trainingEventPublisher, times(1)).publishRouteRecalculationRequestedAfterCommit(saved);
+    }
+}

--- a/src/test/java/com/saferoute/domain/evacuation/service/EvacuationRouteServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/service/EvacuationRouteServiceTest.java
@@ -94,6 +94,30 @@ class EvacuationRouteServiceTest {
     }
 
     @Test
+    @DisplayName("제외된 엣지를 우회해서 다른 EXIT으로 경로를 계산한다")
+    void findShortestRoute_withExcludedEdges_detours() {
+        // given
+        MapEdge e1 = createEdge(room1, door1, 2);
+        MapEdge e2 = createEdge(door1, hallway1, 5);
+        MapEdge e3 = createEdge(hallway1, stair1, 10); // 우회로 (먼 EXIT)
+        MapEdge e4 = createEdge(hallway1, hallway2, 3);
+        MapEdge e5 = createEdge(hallway2, stair2, 2); // 원래 최단 경로에 쓰이는 엣지 - 이번엔 제외
+
+        given(mapGraphRepository.findNodesByFloor(floorId))
+                .willReturn(List.of(room1, door1, hallway1, hallway2, stair1, stair2));
+        given(mapGraphRepository.findEdgesByFloor(floorId))
+                .willReturn(List.of(e1, e2, e3, e4, e5));
+
+        // when
+        EvacuationRoute route = evacuationRouteService.findShortestRoute(
+                floorId, room1.getId(), java.util.Set.of(e5.getId()));
+
+        // then
+        assertThat(route.totalWeight()).isEqualTo(2 + 5 + 10);
+        assertThat(route.path()).containsExactly(room1, door1, hallway1, stair1);
+    }
+
+    @Test
     @DisplayName("도달 가능한 EXIT이 없으면 예외를 던진다")
     void findShortestRoute_noReachableExit_throws() {
         // given


### PR DESCRIPTION
## 🔗 관련 이슈

closes #48

## 📋 작업 내용

혼잡 감지 시 자동 재탐색 트리거 로직 구현

- CCTV 혼잡 이벤트 수신 API 구현 (`POST /api/v1/congestion-events`)
- 혼잡도 요약을 DynamoDB(`CongestionSummaryItem`)에 저장하고 `CONGESTION_UPDATED` WebSocket 이벤트 발행
- HIGH/CRITICAL 수준이면 우회 경로를 자동 재탐색해 "승인 대기(PENDING)" 상태로 저장
  - `EvacuationRouteService`에 제외 엣지 기반 우회 경로 탐색 오버로드 추가 (기존 `findShortestRoute(floorId, startNodeId)` 계약/테스트는 변경 없음)
  - 같은 세션+엣지에 이미 PENDING이 있으면 중복 트리거 방지
  - 우회 경로 자체가 없으면 로그만 남기고 승인 대기 항목을 만들지 않음
  - 재탐색 이력을 DynamoDB(`TrainingEventItem`, `EventType.ROUTE_RECALCULATED`)에 저장
  - `ROUTE_RECALCULATION_REQUESTED` WebSocket 이벤트 발행 (트랜잭션 커밋 후)

승인/거절 API 및 `EVACUATION_ROUTE_UPDATED` 발행은 후속 이슈(#49)에서 별도로 진행 예정

## 📄 API 변경사항

### 신규: `POST /api/v1/congestion-events`

**Request**

```json
{
  "edgeId": "UUID (필수)",
  "cctvCode": "string",
  "avgHeadcount": "number",
  "peakHeadcount": "number",
  "congestionLevel": "LOW | MEDIUM | HIGH | CRITICAL (필수)",
  "windowStart": "long (필수, epoch)",
  "windowEnd": "long (필수, epoch)",
  "s3ImageKey": "string (nullable)"
}
```

**Response**: `200 OK`, 바디 없음 (대상 건물에 RUNNING 세션이 없으면 아무 처리 없이 조용히 200 반환)

**Error**

- `404 EVAC002 (MAP_EDGE_NOT_FOUND)` — edgeId에 해당하는 엣지가 없을 때

**신규 에러 코드 (`EvacuationErrorCode`)**

- `EVAC008 ROUTE_RECALCULATION_NOT_FOUND`
- `EVAC009 INVALID_RECALCULATION_STATUS_TRANSITION`

(둘 다 이번 PR에서는 아직 사용처 없음 — #49에서 승인/거절 API가 소비 예정)

**WebSocket 이벤트** (`/topic/training-sessions/{sessionId}`)

- `CONGESTION_UPDATED` — 혼잡 이벤트 수신 즉시 발행
- `ROUTE_RECALCULATION_REQUESTED` — 재탐색 결과가 PENDING으로 저장된 후(커밋 후) 발행

(`EVACUATION_ROUTE_UPDATED`는 타입만 미리 추가, 발행 로직은 #49)

## 🧪 테스트 결과

- `./gradlew test` 전체 통과 (기존 테스트 포함 회귀 없음)
- 신규/변경 테스트
  - `CongestionEventServiceTest` — 엣지 미존재/RUNNING 세션 없음/LOW·MEDIUM은 트리거 안 함/HIGH·CRITICAL은 트리거함
  - `RouteRecalculationServiceTest` — 중복 PENDING 방지, 우회 경로 없을 때 스킵, 정상 트리거 시 저장+이벤트 발행
  - `CongestionControllerTest` (`@WebMvcTest`) — 정상 요청 200, 필수값 누락 400, 서비스 예외 전파 404
  - `EvacuationRouteServiceTest` — 제외 엣지 기반 우회 경로 계산 케이스 추가, 기존 케이스는 변경 없이 통과
- **실제 EC2(Instance Profile 권한) + RDS + DynamoDB 환경에서 수동 end-to-end 테스트 완료 — 우회 경로 있는 케이스(PENDING 생성 확인)와 없는 케이스(스킵 확인) 둘 다 검증함**

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] 테스트 통과
- [x] `./gradlew build` 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 혼잡 이벤트를 신고하고 혼잡도·인원·발생 시간 정보를 전송할 수 있습니다.
  - 혼잡 현황이 실시간으로 업데이트되며, 높은 혼잡도 감지 시 우회 경로 재계산 요청이 생성됩니다.
  - 재계산된 우회 경로와 처리 상태를 실시간으로 확인할 수 있습니다.
  - 특정 구간을 제외한 대체 대피 경로를 계산할 수 있습니다.

- **개선**
  - 잘못된 요청이나 존재하지 않는 지도 구간에 대해 명확한 오류 응답을 제공합니다.
  - 혼잡 이벤트와 우회 경로 알림의 전달 시점과 안정성이 개선되었습니다.

- **테스트**
  - 혼잡 신고, 경로 재계산, 대체 경로 계산 시나리오를 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->