### PR TITLE
[FEAT] #51: 프론트엔드 연동을 위한 REST API 및 WebSocket Origin 설정

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## 관련 이슈 및 작업 브랜치
+
+- Closes #
+- Branch:
+
+## 주요 내용
+
+-
+
+## ✅ Check List
+
+- [ ] 테스트 통과
+- [ ] ./gradlew build 성공
+- [ ] Reviewers를 등록했나요?
+- [ ] CI가 정상적으로 작동하는지 확인했나요?

--- a/src/main/java/com/saferoute/global/config/CorsProperties.java
+++ b/src/main/java/com/saferoute/global/config/CorsProperties.java
@@ -1,23 +1,71 @@
 package com.saferoute.global.config;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * REST API와 WebSocket handshake의 허용 Origin 설정.
+ * 환경별 값은 app.cors.allowed-origins로 주입하며 최소 하나의 Origin이 필요하다.
+ */
 @ConfigurationProperties(prefix = "app.cors")
 public record CorsProperties(
         List<String> allowedOrigins
 ) {
     public CorsProperties {
-        if (allowedOrigins == null
-                || allowedOrigins.isEmpty()
-                || allowedOrigins.stream()
-                .anyMatch(origin -> origin == null || origin.isBlank())) {
-
+        if (allowedOrigins == null || allowedOrigins.isEmpty()) {
             throw new IllegalStateException(
                     "app.cors.allowed-origins에는 최소 하나의 유효한 Origin이 필요합니다."
             );
         }
 
+        allowedOrigins.forEach(CorsProperties::validateOrigin);
         allowedOrigins = List.copyOf(allowedOrigins);
+    }
+
+    private static void validateOrigin(String origin) {
+        if (origin == null || origin.isBlank()) {
+            throw invalidOrigin(origin);
+        }
+
+        if ("*".equals(origin)) {
+            throw new IllegalStateException(
+                    "app.cors.allowed-origins에는 wildcard(*)를 사용할 수 없습니다."
+            );
+        }
+
+        try {
+            URI uri = new URI(origin);
+            boolean validScheme = "http".equalsIgnoreCase(uri.getScheme())
+                    || "https".equalsIgnoreCase(uri.getScheme());
+            boolean validPort = uri.getPort() == -1
+                    || (uri.getPort() >= 1 && uri.getPort() <= 65535);
+            boolean hasOnlyOriginComponents = uri.getRawUserInfo() == null
+                    && (uri.getRawPath() == null || uri.getRawPath().isEmpty())
+                    && uri.getRawQuery() == null
+                    && uri.getRawFragment() == null;
+
+            if (!validScheme || uri.getHost() == null || !validPort || !hasOnlyOriginComponents) {
+                throw invalidOrigin(origin);
+            }
+        } catch (URISyntaxException exception) {
+            throw invalidOrigin(origin, exception);
+        }
+    }
+
+    private static IllegalStateException invalidOrigin(String origin) {
+        return new IllegalStateException(
+                "유효하지 않은 CORS Origin입니다: " + origin
+                        + ". http(s)://host[:port] 형식만 사용할 수 있습니다."
+        );
+    }
+
+    private static IllegalStateException invalidOrigin(String origin, Exception cause) {
+        return new IllegalStateException(
+                "유효하지 않은 CORS Origin입니다: " + origin
+                        + ". http(s)://host[:port] 형식만 사용할 수 있습니다.",
+                cause
+        );
     }
 }

--- a/src/main/java/com/saferoute/global/config/CorsProperties.java
+++ b/src/main/java/com/saferoute/global/config/CorsProperties.java
@@ -1,0 +1,23 @@
+package com.saferoute.global.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(
+        List<String> allowedOrigins
+) {
+    public CorsProperties {
+        if (allowedOrigins == null
+                || allowedOrigins.isEmpty()
+                || allowedOrigins.stream()
+                .anyMatch(origin -> origin == null || origin.isBlank())) {
+
+            throw new IllegalStateException(
+                    "app.cors.allowed-origins에는 최소 하나의 유효한 Origin이 필요합니다."
+            );
+        }
+
+        allowedOrigins = List.copyOf(allowedOrigins);
+    }
+}

--- a/src/main/java/com/saferoute/global/config/PropertiesConfig.java
+++ b/src/main/java/com/saferoute/global/config/PropertiesConfig.java
@@ -1,0 +1,14 @@
+package com.saferoute.global.config;
+
+import com.saferoute.global.security.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** @ConfigurationProperties 바인딩 대상을 한 곳에서 등록한다. */
+@Configuration
+@EnableConfigurationProperties({
+        JwtProperties.class,
+        CorsProperties.class
+})
+public class PropertiesConfig {
+}

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -4,11 +4,8 @@ import com.saferoute.global.security.CustomUserDetailsService;
 import com.saferoute.global.security.JwtAccessDeniedHandler;
 import com.saferoute.global.security.JwtAuthenticationEntryPoint;
 import com.saferoute.global.security.JwtAuthenticationFilter;
-import com.saferoute.global.security.JwtProperties;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -29,17 +26,11 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-
-    // 프론트 origin이 확정되면 application-{profile}.yml / 배포 환경변수로 채운다.
-    // 콤마로 여러 origin 지정 가능.
-    @Value("${app.cors.allowed-origins:http://localhost:3000,http://localhost:5173}")
-    private List<String> allowedOrigins;
 
     @Bean
     public SecurityFilterChain securityFilterChain(
@@ -70,6 +61,10 @@ public class SecurityConfig {
                 )
 
                 .authorizeHttpRequests(auth -> auth
+                        // 브라우저 preflight만 공개한다.
+                        // 실제 API 요청의 권한 규칙은 아래에서 유지한다.
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
                         .requestMatchers(
                                 "/api/v1/auth/signup",
                                 "/api/v1/auth/login",
@@ -78,10 +73,10 @@ public class SecurityConfig {
                                 "/ws/**"
                         ).permitAll()
 
-                        // /actuator/** 를 명시적으로 분리한다.
+                        // /actuator/**를 명시적으로 분리한다.
                         // health만 공개하고, 그 외(env, beans, metrics 등)는 인증 필요.
-                        // 실제로 어떤 actuator 엔드포인트가 웹에 노출되는지는
-                        // application.yml의 management.endpoints.web.exposure.include로 별도 통제한다.
+                        // 실제로 어떤 actuator endpoint가 웹에 노출되는지는
+                        // application.yml의 management 설정으로 별도 통제한다.
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/actuator/**").authenticated()
 
@@ -108,15 +103,42 @@ public class SecurityConfig {
     }
 
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource(
+            CorsProperties corsProperties
+    ) {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(allowedOrigins);
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+
+        configuration.setAllowedOrigins(
+                corsProperties.allowedOrigins()
+        );
+
+        configuration.setAllowedMethods(
+                List.of(
+                        "GET",
+                        "POST",
+                        "PUT",
+                        "PATCH",
+                        "DELETE",
+                        "OPTIONS"
+                )
+        );
+
+        configuration.setAllowedHeaders(
+                List.of(
+                        "Authorization",
+                        "Content-Type"
+                )
+        );
+
+        // WebSocket handshake에서 쿠키 기반 인증 정보를 전달하므로 유지한다.
+        // allowedOrigins는 "*"가 아닌 명시적인 Origin 목록이어야 한다.
         configuration.setAllowCredentials(true);
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        UrlBasedCorsConfigurationSource source =
+                new UrlBasedCorsConfigurationSource();
+
         source.registerCorsConfiguration("/**", configuration);
+
         return source;
     }
 
@@ -129,6 +151,7 @@ public class SecurityConfig {
                 new DaoAuthenticationProvider(userDetailsService);
 
         provider.setPasswordEncoder(passwordEncoder);
+
         return provider;
     }
 

--- a/src/main/java/com/saferoute/infrastructure/websocket/config/WebSocketConfig.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/config/WebSocketConfig.java
@@ -1,8 +1,8 @@
 package com.saferoute.infrastructure.websocket.config;
 
+import com.saferoute.global.config.CorsProperties;
 import com.saferoute.infrastructure.websocket.security.StompAuthChannelInterceptor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -19,10 +19,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
-
-    // 관리자 대시보드 Origin만 허용
-    @Value("${websocket.allowed-origin-patterns:*}")
-    private String[] allowedOriginPatterns;
+    private final CorsProperties corsProperties;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -30,11 +27,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 핸드셰이크 자체는 인증 없이 열어두고(SecurityConfig에서 permitAll), 인증은
         // StompAuthChannelInterceptor에서 CONNECT 프레임 단계에 수행한다.
         //
-        // 쿠키/세션 기반 인증을 쓰지 않으므로 allowCredentials(true)는 사용하지 않는다.
-        // (allowedOriginPatterns("*")와 allowCredentials(true)를 함께 쓰지 않기 위함)
+        // REST API와 동일한 프론트엔드 Origin만 WebSocket handshake에 허용한다.
+        // 정확한 Origin 목록을 사용하며 wildcard 패턴은 허용하지 않는다.
         // 프론트가 SockJS fallback을 요구하면 이후 .withSockJS()를 추가한다.
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns(allowedOriginPatterns);
+                .setAllowedOrigins(corsProperties.allowedOrigins().toArray(String[]::new));
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,11 @@ springdoc:
     operations-sorter: method
     tags-sorter: alpha
 
+app:
+  cors:
+    # 콤마로 여러 Origin을 지정할 수 있다. 운영 프론트 배포 후 환경변수에 HTTPS Origin을 추가한다.
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
 jwt:
   secret: ${JWT_SECRET}
   issuer: saferoute

--- a/src/test/java/com/saferoute/global/config/CorsPropertiesTest.java
+++ b/src/test/java/com/saferoute/global/config/CorsPropertiesTest.java
@@ -17,13 +17,10 @@ class CorsPropertiesTest {
                 "https://ds-saferoute.site"
         ));
 
-        assertEquals(
-                List.of(
-                        "http://localhost:3000",
-                        "https://ds-saferoute.site"
-                ),
-                properties.allowedOrigins()
-        );
+        assertEquals(List.of(
+                "http://localhost:3000",
+                "https://ds-saferoute.site"
+        ), properties.allowedOrigins());
     }
 
     @Test
@@ -40,12 +37,52 @@ class CorsPropertiesTest {
     void rejectsBlankAllowedOrigin() {
         assertThrows(
                 IllegalStateException.class,
-                () -> new CorsProperties(
-                        List.of(
-                                "http://localhost:3000",
-                                " "
-                        )
-                )
+                () -> new CorsProperties(List.of("http://localhost:3000", " "))
+        );
+    }
+
+    @Test
+    @DisplayName("wildcard Origin은 설정 오류로 처리한다")
+    void rejectsWildcardOrigin() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CorsProperties(List.of("*"))
+        );
+    }
+
+    @Test
+    @DisplayName("경로가 포함된 Origin은 설정 오류로 처리한다")
+    void rejectsOriginWithPath() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CorsProperties(List.of("https://ds-saferoute.site/api"))
+        );
+    }
+
+    @Test
+    @DisplayName("쿼리가 포함된 Origin은 설정 오류로 처리한다")
+    void rejectsOriginWithQuery() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CorsProperties(List.of("https://ds-saferoute.site?source=test"))
+        );
+    }
+
+    @Test
+    @DisplayName("host가 없는 Origin은 설정 오류로 처리한다")
+    void rejectsOriginWithoutHost() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CorsProperties(List.of("https:///missing-host"))
+        );
+    }
+
+    @Test
+    @DisplayName("http 또는 https가 아닌 Origin은 설정 오류로 처리한다")
+    void rejectsUnsupportedScheme() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CorsProperties(List.of("ftp://ds-saferoute.site"))
         );
     }
 }

--- a/src/test/java/com/saferoute/global/config/CorsPropertiesTest.java
+++ b/src/test/java/com/saferoute/global/config/CorsPropertiesTest.java
@@ -1,0 +1,51 @@
+package com.saferoute.global.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CorsPropertiesTest {
+
+    @Test
+    @DisplayName("여러 CORS Origin을 순서대로 보관한다")
+    void keepsMultipleAllowedOrigins() {
+        CorsProperties properties = new CorsProperties(List.of(
+                "http://localhost:3000",
+                "https://ds-saferoute.site"
+        ));
+
+        assertEquals(
+                List.of(
+                        "http://localhost:3000",
+                        "https://ds-saferoute.site"
+                ),
+                properties.allowedOrigins()
+        );
+    }
+
+    @Test
+    @DisplayName("CORS Origin 목록이 비어 있으면 설정 오류로 처리한다")
+    void rejectsEmptyAllowedOrigins() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CorsProperties(List.of())
+        );
+    }
+
+    @Test
+    @DisplayName("빈 문자열 Origin이 포함되면 설정 오류로 처리한다")
+    void rejectsBlankAllowedOrigin() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CorsProperties(
+                        List.of(
+                                "http://localhost:3000",
+                                " "
+                        )
+                )
+        );
+    }
+}

--- a/src/test/java/com/saferoute/global/security/CorsIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/CorsIntegrationTest.java
@@ -1,0 +1,166 @@
+package com.saferoute.global.security;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CorsIntegrationTest {
+
+    private static final String ALLOWED_ORIGIN =
+            "http://localhost:3000";
+
+    private static final String DENIED_ORIGIN =
+            "http://localhost:9999";
+
+    private static final String PROTECTED_ENDPOINT =
+            "/api/v1/buildings";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("허용 Origin의 실제 요청에는 CORS 응답 헤더가 포함된다")
+    void allowedOriginReceivesCorsResponseHeader() throws Exception {
+        mockMvc.perform(
+                        get(PROTECTED_ENDPOINT)
+                                .header(
+                                        HttpHeaders.ORIGIN,
+                                        ALLOWED_ORIGIN
+                                )
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string(
+                        HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                        ALLOWED_ORIGIN
+                ));
+    }
+
+    @Test
+    @DisplayName("OPTIONS preflight 요청은 Security와 JWT 필터에서 차단되지 않는다")
+    void preflightRequestIsAllowed() throws Exception {
+        mockMvc.perform(
+                        options(PROTECTED_ENDPOINT)
+                                .header(
+                                        HttpHeaders.ORIGIN,
+                                        ALLOWED_ORIGIN
+                                )
+                                .header(
+                                        HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                                        "GET"
+                                )
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string(
+                        HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                        ALLOWED_ORIGIN
+                ))
+                .andExpect(header().string(
+                        HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                        containsString("GET")
+                ));
+    }
+
+    @Test
+    @DisplayName("Authorization과 Content-Type 요청 헤더를 사용하는 preflight를 허용한다")
+    void authorizationAndContentTypeHeadersAreAllowed() throws Exception {
+        mockMvc.perform(
+                        options(PROTECTED_ENDPOINT)
+                                .header(
+                                        HttpHeaders.ORIGIN,
+                                        ALLOWED_ORIGIN
+                                )
+                                .header(
+                                        HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                                        "POST"
+                                )
+                                .header(
+                                        HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                                        "Authorization,Content-Type"
+                                )
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string(
+                        HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                        containsString("Authorization")
+                ))
+                .andExpect(header().string(
+                        HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                        containsString("Content-Type")
+                ));
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 Origin의 preflight 요청은 거부한다")
+    void deniedOriginDoesNotReceiveCorsPermission() throws Exception {
+        mockMvc.perform(
+                        options(PROTECTED_ENDPOINT)
+                                .header(
+                                        HttpHeaders.ORIGIN,
+                                        DENIED_ORIGIN
+                                )
+                                .header(
+                                        HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                                        "GET"
+                                )
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(header().doesNotExist(
+                        HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN
+                ));
+    }
+
+    @Test
+    @DisplayName("CORS 적용 후에도 보호 API는 인증 없이 접근할 수 없다")
+    void protectedEndpointStillRequiresAuthentication() throws Exception {
+        mockMvc.perform(
+                        get(PROTECTED_ENDPOINT)
+                                .header(
+                                        HttpHeaders.ORIGIN,
+                                        ALLOWED_ORIGIN
+                                )
+                )
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Swagger와 기존 공개 인증 endpoint는 계속 공개된다")
+    void swaggerAndPublicEndpointRemainPublic() throws Exception {
+        mockMvc.perform(
+                        get("/v3/api-docs")
+                                .header(
+                                        HttpHeaders.ORIGIN,
+                                        ALLOWED_ORIGIN
+                                )
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string(
+                        HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                        ALLOWED_ORIGIN
+                ));
+
+        mockMvc.perform(
+                        post("/api/v1/auth/login")
+                                .header(
+                                        HttpHeaders.ORIGIN,
+                                        ALLOWED_ORIGIN
+                                )
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{}")
+                )
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
@@ -43,6 +43,7 @@ import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 
@@ -351,20 +352,45 @@ class WebSocketIntegrationTest {
                 .isInstanceOfAny(ExecutionException.class, TimeoutException.class);
     }
 
+    @Test
+    @DisplayName("허용된 Origin에서는 WebSocket 연결에 성공한다")
+    void allowedOriginCanConnect() throws Exception {
+        StompSession session = connectRaw(managerToken, "http://localhost:3000");
+
+        assertThat(session.isConnected()).isTrue();
+        session.disconnect();
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 Origin에서는 WebSocket handshake가 거부된다")
+    void disallowedOriginCannotConnect() {
+        assertThatThrownBy(() -> connectRaw(managerToken, "https://evil.example"))
+                .isInstanceOfAny(ExecutionException.class, TimeoutException.class);
+    }
+
     private StompSession connect(String token) throws Exception {
         return connectRaw(token);
     }
 
     private StompSession connectRaw(String token) throws Exception {
+        return connectRaw(token, null);
+    }
+
+    private StompSession connectRaw(String token, String origin) throws Exception {
         StompHeaders connectHeaders = new StompHeaders();
         if (token != null) {
             connectHeaders.add("Authorization", "Bearer " + token);
         }
 
+        WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
+        if (origin != null) {
+            handshakeHeaders.setOrigin(origin);
+        }
+
         return stompClient
                 .connectAsync(
                         "ws://localhost:" + port + "/ws",
-                        (org.springframework.web.socket.WebSocketHttpHeaders) null,
+                        handshakeHeaders,
                         connectHeaders,
                         new org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter() {
                         }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,11 +28,14 @@ saferoute:
 # 실제 S3 호출은 테스트에서 하지 않으므로 아무 값이나 형식만 맞으면 된다.
 aws:
   region: ap-northeast-2
+
   s3:
     bucket: test-bucket
     presigned-url-expiration: 10m
+
   dynamodb:
     table-name: test-saferoute-telemetry
+
   credentials:
     access-key: test
     secret-key: test
@@ -40,3 +43,7 @@ aws:
 springdoc:
   api-docs:
     path: /v3/api-docs
+
+app:
+  cors:
+    allowed-origins: http://localhost:3000


### PR DESCRIPTION
프론트에서 SafeRoute API를 호출할 수 있도록 기존 Spring Security CORS 설정을 보완했습니다. 기존 JWT 필터와 역할 기반 인가 규칙은 유지했습니다.

## 주요 변경

- app.cors.allowed-origins를 CorsProperties에 바인딩하고 PropertiesConfig에서 명시적으로 등록

- 허용 Origin 누락/빈 값에 대한 기동 시점 검증 추가

- 허용 Origin을 CORS_ALLOWED_ORIGINS 환경변수로 외부화

- 기본 허용 Origin을 http://localhost:3000으로 제한

- GET, POST, PUT, PATCH, DELETE, OPTIONS 허용

- Authorization, Content-Type 요청 Header 허용

- OPTIONS preflight를 명시적으로 permitAll 처리

- 허용/비허용 Origin, preflight, Header, 보호 API, Swagger/public endpoint 통합 테스트 추가

- CORS 설정 객체의 다중 Origin 및 잘못된 값 검증 단위 테스트 추가

- WebSocket /ws handshake에도 REST API와 동일한 허용 Origin 목록 적용

- 기존 WebSocket wildcard Origin(*) 설정 제거

- WebSocket 허용/비허용 Origin 연결 통합 테스트 추가

## 보안 영향

- 실제 /api/** 요청의 기존 역할 기반 인가 규칙은 변경하지 않았습니다.

- OPTIONS만 공개되며 모든 API를 permitAll로 변경하지 않았습니다.

- wildcard Origin을 사용하지 않습니다.

- JWT 발급·검증·필터 구조를 변경하지 않았습니다.

- WebSocket은 허용된 Origin의 handshake만 통과하며, 이후 STOMP CONNECT 단계의 JWT·MANAGER 권한 검증도 그대로 수행합니다.

## 테스트 완료

./gradlew test --tests com.saferoute.global.security.CorsIntegrationTest
./gradlew test --tests com.saferoute.global.config.CorsPropertiesTest
./gradlew test --tests com.saferoute.infrastructure.websocket.service.WebSocketIntegrationTest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * CORS 허용 출처를 환경변수로 설정할 수 있습니다.
  * 허용되지 않은 출처의 API 요청 및 WebSocket 연결을 차단합니다.
  * 사전 요청(OPTIONS)은 정상적으로 처리되며, 헬스 엔드포인트 외 API는 인증이 필요합니다.

* **버그 수정**
  * 비어 있거나 잘못된 CORS 설정을 애플리케이션 시작 시 검증합니다.
  * 인증 헤더와 콘텐츠 유형을 포함한 허용된 CORS 요청이 올바르게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->