### PR TITLE
feat: 재탐색 승인/거절 API 및 WebSocket 알림

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/controller/RouteRecalculationController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/RouteRecalculationController.java
@@ -1,0 +1,35 @@
+package com.saferoute.domain.evacuation.controller;
+
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
+import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
+import com.saferoute.global.api.response.ApiResponse;
+import com.saferoute.global.api.response.EvacuationSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "재탐색 승인", description = "혼잡 재탐색 결과 승인/거절 API")
+@RestController
+@RequestMapping("/api/v1/route-recalculations")
+@RequiredArgsConstructor
+public class RouteRecalculationController {
+
+    private final RouteRecalculationService routeRecalculationService;
+
+    @PatchMapping("/{recalculationId}/approve")
+    public ResponseEntity<ApiResponse<RouteRecalculationResponse>> approve(@PathVariable UUID recalculationId) {
+        RouteRecalculationResponse response = routeRecalculationService.approve(recalculationId);
+        return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_APPROVED, response));
+    }
+
+    @PatchMapping("/{recalculationId}/reject")
+    public ResponseEntity<ApiResponse<RouteRecalculationResponse>> reject(@PathVariable UUID recalculationId) {
+        RouteRecalculationResponse response = routeRecalculationService.reject(recalculationId);
+        return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_REJECTED, response));
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationResponse.java
@@ -25,7 +25,10 @@ public record RouteRecalculationResponse(
                 recalculation.getTrainingSession().getId(),
                 recalculation.getTriggerEdge().getId(),
                 recalculation.getCongestionLevel(),
-                recalculation.getRecalculatedNodeIds(),
+                // recalculatedNodeIds는 @ElementCollection(LAZY)이라, open-in-view: false 환경에서
+                // 트랜잭션이 끝난 뒤(JSON 직렬화 시점)에 접근하면 LazyInitializationException이 난다.
+                // 트랜잭션이 살아있는 지금 여기서 List.copyOf로 미리 순회해 즉시 초기화한다.
+                List.copyOf(recalculation.getRecalculatedNodeIds()),
                 recalculation.getTotalWeight(),
                 recalculation.getStatus(),
                 recalculation.getRequestedAt(),

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationResponse.java
@@ -1,0 +1,35 @@
+package com.saferoute.domain.evacuation.recalculation.dto.response;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record RouteRecalculationResponse(
+        UUID id,
+        UUID trainingSessionId,
+        UUID triggerEdgeId,
+        CongestionLevel congestionLevel,
+        List<UUID> recalculatedNodeIds,
+        double totalWeight,
+        RecalculationStatus status,
+        Instant requestedAt,
+        Instant resolvedAt
+) {
+
+    public static RouteRecalculationResponse from(RouteRecalculation recalculation) {
+        return new RouteRecalculationResponse(
+                recalculation.getId(),
+                recalculation.getTrainingSession().getId(),
+                recalculation.getTriggerEdge().getId(),
+                recalculation.getCongestionLevel(),
+                recalculation.getRecalculatedNodeIds(),
+                recalculation.getTotalWeight(),
+                recalculation.getStatus(),
+                recalculation.getRequestedAt(),
+                recalculation.getResolvedAt()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.evacuation.recalculation.service;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
@@ -90,5 +91,39 @@ public class RouteRecalculationService {
         ));
 
         trainingEventPublisher.publishRouteRecalculationRequestedAfterCommit(recalculation);
+    }
+
+    @Transactional
+    public RouteRecalculationResponse approve(UUID recalculationId) {
+        RouteRecalculation recalculation = findOrThrow(recalculationId);
+        validatePending(recalculation);
+
+        recalculation.approve(Instant.now());
+        trainingEventPublisher.publishEvacuationRouteUpdatedAfterCommit(recalculation);
+
+        return RouteRecalculationResponse.from(recalculation);
+    }
+
+    @Transactional
+    public RouteRecalculationResponse reject(UUID recalculationId) {
+        RouteRecalculation recalculation = findOrThrow(recalculationId);
+        validatePending(recalculation);
+
+        recalculation.reject(Instant.now());
+
+        return RouteRecalculationResponse.from(recalculation);
+    }
+
+    private RouteRecalculation findOrThrow(UUID recalculationId) {
+        return routeRecalculationRepository.findById(recalculationId)
+                .orElseThrow(() -> new ApiException(EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND));
+    }
+
+    // 상태 전이 검증은 엔티티가 아니라 여기서 한다
+    // (TrainingSessionService.start()/end()/forceEnd(), IoTLightService와 동일한 컨벤션).
+    private void validatePending(RouteRecalculation recalculation) {
+        if (recalculation.getStatus() != RecalculationStatus.PENDING) {
+            throw new ApiException(EvacuationErrorCode.INVALID_RECALCULATION_STATUS_TRANSITION);
+        }
     }
 }

--- a/src/main/java/com/saferoute/global/api/response/EvacuationSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/EvacuationSuccessCode.java
@@ -12,7 +12,9 @@ public enum EvacuationSuccessCode implements BaseCode {
     MAP_NODE_CREATED(HttpStatus.CREATED, "EVAC_SUCCESS_001", "노드가 생성되었습니다."),
     MAP_NODE_DELETED(HttpStatus.OK, "EVAC_SUCCESS_002", "노드가 삭제되었습니다."),
     MAP_EDGE_CREATED(HttpStatus.CREATED, "EVAC_SUCCESS_003", "엣지가 생성되었습니다."),
-    MAP_EDGE_DELETED(HttpStatus.OK, "EVAC_SUCCESS_004", "엣지가 삭제되었습니다.");
+    MAP_EDGE_DELETED(HttpStatus.OK, "EVAC_SUCCESS_004", "엣지가 삭제되었습니다."),
+    ROUTE_RECALCULATION_APPROVED(HttpStatus.OK, "EVAC_SUCCESS_005", "재탐색 결과가 승인되었습니다."),
+    ROUTE_RECALCULATION_REJECTED(HttpStatus.OK, "EVAC_SUCCESS_006", "재탐색 결과가 거절되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -174,7 +174,30 @@ public class TrainingEventPublisher {
         );
     }
 
-    // approve() 승인 시 발행하는 EVACUATION_ROUTE_UPDATED는 승인/거절 API(이슈 #49)에서 추가한다.
+    // DB 트랜잭션이 실제로 커밋된 이후에만 발행한다 (publishTrainingStatusUpdatedAfterCommit 참고).
+    public void publishEvacuationRouteUpdatedAfterCommit(RouteRecalculation recalculation) {
+        publishAfterCommit(
+                () -> publishEvacuationRouteUpdated(recalculation),
+                "커밋 후 대피 경로 갱신 이벤트 발행 실패: recalculationId=" + recalculation.getId()
+        );
+    }
+
+    public void publishEvacuationRouteUpdated(RouteRecalculation recalculation) {
+        UUID sessionId = recalculation.getTrainingSession().getId();
+        TrainingEventMessage<RouteRecalculationEventData> message = TrainingEventMessage.of(
+                TrainingEventType.EVACUATION_ROUTE_UPDATED,
+                sessionId,
+                RouteRecalculationEventData.from(recalculation)
+        );
+
+        messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
+
+        log.debug(
+                "대피 경로 갱신 이벤트 발행: sessionId={}, recalculationId={}",
+                sessionId,
+                recalculation.getId()
+        );
+    }
 
     private void publishAfterCommit(Runnable publish, String failureLogMessage) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {

--- a/src/test/java/com/saferoute/domain/evacuation/controller/RouteRecalculationControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/controller/RouteRecalculationControllerTest.java
@@ -1,0 +1,94 @@
+package com.saferoute.domain.evacuation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
+import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.config.SecurityConfig;
+import com.saferoute.global.security.JwtAuthenticationFilter;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = RouteRecalculationController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {JwtAuthenticationFilter.class, SecurityConfig.class}
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class RouteRecalculationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RouteRecalculationService routeRecalculationService;
+
+    private final UUID recalculationId = UUID.randomUUID();
+
+    private RouteRecalculationResponse response(RecalculationStatus status) {
+        return new RouteRecalculationResponse(
+                recalculationId, UUID.randomUUID(), UUID.randomUUID(), CongestionLevel.HIGH,
+                List.of(UUID.randomUUID()), 12.5, status, Instant.now(), Instant.now());
+    }
+
+    @Test
+    @DisplayName("승인 성공 시 200과 APPROVED 상태를 반환한다")
+    void approve_returnsOk() throws Exception {
+        given(routeRecalculationService.approve(recalculationId)).willReturn(response(RecalculationStatus.APPROVED));
+
+        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("APPROVED"));
+    }
+
+    @Test
+    @DisplayName("거절 성공 시 200과 REJECTED 상태를 반환한다")
+    void reject_returnsOk() throws Exception {
+        given(routeRecalculationService.reject(recalculationId)).willReturn(response(RecalculationStatus.REJECTED));
+
+        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/reject", recalculationId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("REJECTED"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 재탐색이면 404를 반환한다")
+    void approve_returnsNotFoundWhenMissing() throws Exception {
+        willThrow(new ApiException(EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND))
+                .given(routeRecalculationService).approve(any());
+
+        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("이미 처리된 재탐색이면 409를 반환한다")
+    void approve_returnsConflictWhenAlreadyResolved() throws Exception {
+        willThrow(new ApiException(EvacuationErrorCode.INVALID_RECALCULATION_STATUS_TRANSITION))
+                .given(routeRecalculationService).approve(any());
+
+        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId))
+                .andExpect(status().isConflict());
+    }
+}

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.evacuation.recalculation.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
@@ -13,6 +14,7 @@ import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
@@ -25,6 +27,7 @@ import com.saferoute.global.api.error.EvacuationErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +64,7 @@ class RouteRecalculationServiceTest {
     @BeforeEach
     void setUp() {
         session = mock(TrainingSession.class);
-        given(session.getId()).willReturn(UUID.randomUUID());
+        org.mockito.Mockito.lenient().when(session.getId()).thenReturn(UUID.randomUUID());
 
         Floor floor = mock(Floor.class);
         org.mockito.Mockito.lenient().when(floor.getId()).thenReturn(UUID.randomUUID());
@@ -134,5 +137,77 @@ class RouteRecalculationServiceTest {
         verify(routeRecalculationRepository, times(1)).save(any());
         verify(trainingEventRepository, times(1)).save(any());
         verify(trainingEventPublisher, times(1)).publishRouteRecalculationRequestedAfterCommit(saved);
+    }
+
+    private RouteRecalculation pendingRecalculation() {
+        RouteRecalculation recalculation = RouteRecalculation.createPending(
+                session, triggerEdge, CongestionLevel.HIGH, List.of(UUID.randomUUID()), 12.5);
+        ReflectionTestUtils.setField(recalculation, "id", UUID.randomUUID());
+        return recalculation;
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 재탐색 ID로 승인하면 ROUTE_RECALCULATION_NOT_FOUND를 던진다")
+    void approve_whenNotFound_throws() {
+        UUID recalculationId = UUID.randomUUID();
+        given(routeRecalculationRepository.findById(recalculationId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> routeRecalculationService.approve(recalculationId))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("PENDING이 아니면 승인 시 INVALID_RECALCULATION_STATUS_TRANSITION을 던진다")
+    void approve_whenNotPending_throws() {
+        RouteRecalculation recalculation = pendingRecalculation();
+        recalculation.approve(java.time.Instant.now());
+        given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
+
+        assertThatThrownBy(() -> routeRecalculationService.approve(recalculation.getId()))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EvacuationErrorCode.INVALID_RECALCULATION_STATUS_TRANSITION);
+
+        verify(trainingEventPublisher, never()).publishEvacuationRouteUpdatedAfterCommit(any());
+    }
+
+    @Test
+    @DisplayName("PENDING이면 승인 시 상태를 APPROVED로 바꾸고 WS 이벤트를 발행한다")
+    void approve_whenPending_succeedsAndPublishes() {
+        RouteRecalculation recalculation = pendingRecalculation();
+        given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
+
+        RouteRecalculationResponse response = routeRecalculationService.approve(recalculation.getId());
+
+        assertThat(response.status()).isEqualTo(RecalculationStatus.APPROVED);
+        assertThat(recalculation.getStatus()).isEqualTo(RecalculationStatus.APPROVED);
+        assertThat(recalculation.getResolvedAt()).isNotNull();
+        verify(trainingEventPublisher, times(1)).publishEvacuationRouteUpdatedAfterCommit(recalculation);
+    }
+
+    @Test
+    @DisplayName("PENDING이 아니면 거절 시 INVALID_RECALCULATION_STATUS_TRANSITION을 던진다")
+    void reject_whenNotPending_throws() {
+        RouteRecalculation recalculation = pendingRecalculation();
+        recalculation.reject(java.time.Instant.now());
+        given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
+
+        assertThatThrownBy(() -> routeRecalculationService.reject(recalculation.getId()))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EvacuationErrorCode.INVALID_RECALCULATION_STATUS_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("PENDING이면 거절 시 상태를 REJECTED로 바꾸고 WS 이벤트는 발행하지 않는다")
+    void reject_whenPending_succeedsWithoutPublishing() {
+        RouteRecalculation recalculation = pendingRecalculation();
+        given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
+
+        RouteRecalculationResponse response = routeRecalculationService.reject(recalculation.getId());
+
+        assertThat(response.status()).isEqualTo(RecalculationStatus.REJECTED);
+        assertThat(recalculation.getStatus()).isEqualTo(RecalculationStatus.REJECTED);
+        verify(trainingEventPublisher, never()).publishEvacuationRouteUpdatedAfterCommit(any());
+        verify(trainingEventPublisher, never()).publishRouteRecalculationRequested(any());
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

closes #49

## 📋 작업 내용

혼잡 재탐색 결과(PENDING) 승인/거절 API 구현 (이슈 #48 에서 만든 `RouteRecalculation` 도메인의 후속)

- `PATCH /api/v1/route-recalculations/{recalculationId}/approve` — PENDING을 APPROVED로 전이하고 `EVACUATION_ROUTE_UPDATED` WebSocket 이벤트 발행
- `PATCH /api/v1/route-recalculations/{recalculationId}/reject` — PENDING을 REJECTED로 전이 (WebSocket 발행 없음, 설계 의도)
- 상태 전이 검증(이미 처리된 건이면 409)은 엔티티가 아니라 `RouteRecalculationService`에서 수행 — `TrainingSessionService.start()/end()/forceEnd()`, `IoTLightService`와 동일한 컨벤션 (엔티티는 가드 없는 단순 세터)
- 존재하지 않는 재탐색 ID 요청 시 404

버그 수정 1건 포함:
- `RouteRecalculationResponse`의 `recalculatedNodeIds`(`@ElementCollection`, LAZY)가 트랜잭션 종료 후 JSON 직렬화 시점에 `LazyInitializationException`을 던지는 문제 발견 및 수정 (`List.copyOf`로 트랜잭션 내에서 즉시 초기화). 단위 테스트(Mockito)로는 안 잡히고 실제 EC2+RDS 환경 수동 테스트 중 발견됨.

## 📄 API 변경사항

### 신규: 
- `PATCH /api/v1/route-recalculations/{recalculationId}/approve`
- `PATCH /api/v1/route-recalculations/{recalculationId}/reject`

## 🧪 테스트 결과
- ./gradlew test 전체 통과 (기존 테스트 포함 회귀 없음)
신규/변경 테스트
- RouteRecalculationServiceTest — 승인/거절 성공(상태 전이, resolvedAt 반영, WS 발행 여부), 이미 처리된 건 재시도 시 409, 존재하지 않는 ID 404
- RouteRecalculationControllerTest (@WebMvcTest) — 200/404/409 HTTP 상태 코드 매핑 검증
- 실제 EC2(Instance Profile 권한) + RDS 환경에서 수동 end-to-end 테스트 완료 — 승인 시 상태 전이·WS 이벤트 수신·DB 반영 확인, 거절 시 상태 전이만 되고 WS는 안 오는 것 확인, 이미 처리된 건 재시도 409·존재하지 않는 ID 404 확인

##✅ 체크리스트
- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] 테스트 통과
- [x] ./gradlew build 성공


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 대피 경로 재탐색 결과를 승인하거나 거절할 수 있습니다.
  - 처리 결과와 재탐색 상태, 경로 관련 정보를 확인할 수 있습니다.
  - 재탐색 승인 시 최신 대피 경로가 실시간으로 갱신됩니다.
  - 이미 처리되었거나 존재하지 않는 재탐색 요청에는 적절한 오류 응답이 제공됩니다.
  - 승인 및 거절 결과를 구분된 성공 메시지로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->