### PR TITLE
[Feat] #64: CCTV 등록 및 GridCell 감시 영역 설정 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/device/controller/CctvController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/CctvController.java
@@ -1,0 +1,94 @@
+package com.saferoute.domain.device.controller;
+
+import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
+import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.service.CctvService;
+import com.saferoute.global.api.response.ApiResponse;
+import com.saferoute.global.api.response.CctvSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "CCTV", description = "CCTV 등록/조회 및 감시 GridCell 설정 API")
+@RestController
+@RequestMapping("/api/v1/cctvs")
+@RequiredArgsConstructor
+public class CctvController {
+
+    private final CctvService cctvService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CctvResponse>> createCctv(
+            @Valid @RequestBody CreateCctvRequest request
+    ) {
+        CctvResponse response = cctvService.createCctv(request);
+        return ResponseEntity.status(CctvSuccessCode.CCTV_CREATED.getHttpStatus())
+                .body(ApiResponse.success(CctvSuccessCode.CCTV_CREATED, response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CctvResponse>>> getCctvs(
+            @RequestParam(required = false) UUID floorId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                CctvSuccessCode.CCTV_LIST_FOUND,
+                cctvService.getCctvs(floorId)
+        ));
+    }
+
+    @GetMapping("/{cctvId}")
+    public ResponseEntity<ApiResponse<CctvResponse>> getCctv(@PathVariable UUID cctvId) {
+        return ResponseEntity.ok(ApiResponse.success(
+                CctvSuccessCode.CCTV_DETAIL_FOUND,
+                cctvService.getCctv(cctvId)
+        ));
+    }
+
+    @GetMapping("/{cctvId}/grid-cells")
+    public ResponseEntity<ApiResponse<CctvResponse>> getGridCells(@PathVariable UUID cctvId) {
+        return ResponseEntity.ok(ApiResponse.success(
+                CctvSuccessCode.CCTV_GRID_CELLS_FOUND,
+                cctvService.getGridCells(cctvId)
+        ));
+    }
+
+    @PutMapping("/{cctvId}/grid-cells")
+    public ResponseEntity<ApiResponse<CctvResponse>> configureGridCells(
+            @PathVariable UUID cctvId,
+            @Valid @RequestBody ConfigureCctvGridCellsRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                CctvSuccessCode.CCTV_GRID_CELLS_CONFIGURED,
+                cctvService.configureGridCells(cctvId, request)
+        ));
+    }
+
+    @PatchMapping("/{cctvId}/enable")
+    public ResponseEntity<ApiResponse<CctvResponse>> enableCctv(@PathVariable UUID cctvId) {
+        return ResponseEntity.ok(ApiResponse.success(
+                CctvSuccessCode.CCTV_ENABLED,
+                cctvService.enableCctv(cctvId)
+        ));
+    }
+
+    @PatchMapping("/{cctvId}/disable")
+    public ResponseEntity<ApiResponse<CctvResponse>> disableCctv(@PathVariable UUID cctvId) {
+        return ResponseEntity.ok(ApiResponse.success(
+                CctvSuccessCode.CCTV_DISABLED,
+                cctvService.disableCctv(cctvId)
+        ));
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/dto/request/ConfigureCctvGridCellsRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/ConfigureCctvGridCellsRequest.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+public record ConfigureCctvGridCellsRequest(
+        @NotEmpty List<@NotNull UUID> gridCellIds
+) {
+}

--- a/src/main/java/com/saferoute/domain/device/dto/request/CreateCctvRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/CreateCctvRequest.java
@@ -1,0 +1,19 @@
+package com.saferoute.domain.device.dto.request;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.UUID;
+
+public record CreateCctvRequest(
+        @NotBlank @Size(max = 100) String name,
+        @NotNull UUID floorId,
+        @NotNull @DecimalMin("0.0") @DecimalMax("1.0") Double x,
+        @NotNull @DecimalMin("0.0") @DecimalMax("1.0") Double y,
+        @NotEmpty List<@NotNull UUID> gridCellIds
+) {
+}

--- a/src/main/java/com/saferoute/domain/device/dto/response/CctvGridCellResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/CctvGridCellResponse.java
@@ -1,0 +1,24 @@
+package com.saferoute.domain.device.dto.response;
+
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import java.util.UUID;
+
+public record CctvGridCellResponse(
+        UUID id,
+        int rowIndex,
+        int columnIndex,
+        boolean walkable,
+        double centerX,
+        double centerY
+) {
+    public static CctvGridCellResponse from(FloorGridCell cell) {
+        return new CctvGridCellResponse(
+                cell.getId(),
+                cell.getRowIndex(),
+                cell.getColumnIndex(),
+                cell.isWalkable(),
+                cell.getCenterX(),
+                cell.getCenterY()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/dto/response/CctvResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/CctvResponse.java
@@ -1,0 +1,42 @@
+package com.saferoute.domain.device.dto.response;
+
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import java.util.List;
+import java.util.UUID;
+
+public record CctvResponse(
+        UUID id,
+        String code,
+        String name,
+        UUID floorId,
+        UUID customNodeId,
+        double x,
+        double y,
+        boolean enabled,
+        Double gridCellSizeMeter,
+        int monitoredGridCellCount,
+        Double monitoredAreaM2,
+        List<CctvGridCellResponse> gridCells
+) {
+    public static CctvResponse of(Cctv cctv, List<FloorGridCell> gridCells) {
+        Double cellSizeMeter = cctv.getCustomNode().getFloor().getGridCellSizeMeter();
+        Double monitoredAreaM2 = cellSizeMeter == null
+                ? null
+                : gridCells.size() * cellSizeMeter * cellSizeMeter;
+        return new CctvResponse(
+                cctv.getId(),
+                cctv.getCode(),
+                cctv.getName(),
+                cctv.getCustomNode().getFloor().getId(),
+                cctv.getCustomNode().getId(),
+                cctv.getCustomNode().getX(),
+                cctv.getCustomNode().getY(),
+                cctv.isEnabled(),
+                cellSizeMeter,
+                gridCells.size(),
+                monitoredAreaM2,
+                gridCells.stream().map(CctvGridCellResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/dto/response/CctvResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/CctvResponse.java
@@ -21,7 +21,8 @@ public record CctvResponse(
 ) {
     public static CctvResponse of(Cctv cctv, List<FloorGridCell> gridCells) {
         Double cellSizeMeter = cctv.getCustomNode().getFloor().getGridCellSizeMeter();
-        Double monitoredAreaM2 = cellSizeMeter == null
+        boolean validCellSizeMeter = cellSizeMeter != null && cellSizeMeter > 0;
+        Double monitoredAreaM2 = !validCellSizeMeter
                 ? null
                 : gridCells.size() * cellSizeMeter * cellSizeMeter;
         return new CctvResponse(

--- a/src/main/java/com/saferoute/domain/device/entity/Cctv.java
+++ b/src/main/java/com/saferoute/domain/device/entity/Cctv.java
@@ -15,7 +15,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-// 혼잡도 반영 경로: CCTV code -> customNode -> NodeGridCell -> FloorGridCell -> MapEdgeGridCell -> MapEdge
+// 설치 위치는 customNode가 관리하고, 실제 감시 영역은 CctvGridCell 매핑이 관리한다.
+// 혼잡도 반영 경로: CCTV code -> CctvGridCell -> FloorGridCell -> MapEdgeGridCell -> MapEdge
 @Entity
 @Getter
 @Table(name = "cctvs")

--- a/src/main/java/com/saferoute/domain/device/entity/CctvGridCell.java
+++ b/src/main/java/com/saferoute/domain/device/entity/CctvGridCell.java
@@ -1,0 +1,56 @@
+package com.saferoute.domain.device.entity;
+
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Getter
+@Table(
+        name = "cctv_grid_cells",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_cctv_grid_cell",
+                columnNames = {"cctv_id", "grid_cell_id"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CctvGridCell {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cctv_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Cctv cctv;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "grid_cell_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private FloorGridCell gridCell;
+
+    private CctvGridCell(Cctv cctv, FloorGridCell gridCell) {
+        if (cctv == null || gridCell == null) {
+            throw new IllegalArgumentException("CCTV와 GridCell은 필수입니다.");
+        }
+        this.cctv = cctv;
+        this.gridCell = gridCell;
+    }
+
+    public static CctvGridCell create(Cctv cctv, FloorGridCell gridCell) {
+        return new CctvGridCell(cctv, gridCell);
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
@@ -1,0 +1,18 @@
+package com.saferoute.domain.device.repository;
+
+import com.saferoute.domain.device.entity.CctvGridCell;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CctvGridCellRepository extends JpaRepository<CctvGridCell, UUID> {
+
+    List<CctvGridCell> findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(UUID cctvId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from CctvGridCell mapping where mapping.cctv.id = :cctvId")
+    int deleteAllByCctvId(@Param("cctvId") UUID cctvId);
+}

--- a/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
@@ -12,6 +12,16 @@ public interface CctvGridCellRepository extends JpaRepository<CctvGridCell, UUID
 
     List<CctvGridCell> findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(UUID cctvId);
 
+    @Query("""
+            select mapping
+            from CctvGridCell mapping
+            join fetch mapping.cctv cctv
+            join fetch mapping.gridCell cell
+            where cctv.id in :cctvIds
+            order by cctv.id, cell.rowIndex, cell.columnIndex
+            """)
+    List<CctvGridCell> findAllByCctvIdsWithGridCell(@Param("cctvIds") List<UUID> cctvIds);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from CctvGridCell mapping where mapping.cctv.id = :cctvId")
     int deleteAllByCctvId(@Param("cctvId") UUID cctvId);

--- a/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,7 +13,16 @@ import org.springframework.data.repository.query.Param;
 public interface CctvJpaRepository extends JpaRepository<Cctv, UUID> {
 
     // 층 조회는 customNode 를 경유한다 (Cctv 에 floor 컬럼이 없음)
+    @EntityGraph(attributePaths = {"customNode", "customNode.floor"})
     List<Cctv> findAllByCustomNode_Floor_Id(UUID floorId);
+
+    @EntityGraph(attributePaths = {"customNode", "customNode.floor"})
+    @Query("select cctv from Cctv cctv")
+    List<Cctv> findAllWithLocation();
+
+    @EntityGraph(attributePaths = {"customNode", "customNode.floor"})
+    @Query("select cctv from Cctv cctv where cctv.id = :cctvId")
+    Optional<Cctv> findByIdWithLocation(@Param("cctvId") UUID cctvId);
 
     // 라즈베리파이가 보내온 code 로 기기 식별 (전역 unique)
     Optional<Cctv> findByCode(String code);

--- a/src/main/java/com/saferoute/domain/device/service/CctvRegistrationService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvRegistrationService.java
@@ -1,0 +1,99 @@
+package com.saferoute.domain.device.service;
+
+import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.entity.CctvGridCell;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.CctvErrorCode;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CctvRegistrationService {
+
+    private final CctvJpaRepository cctvJpaRepository;
+    private final CctvGridCellRepository cctvGridCellRepository;
+    private final FloorGridCellRepository floorGridCellRepository;
+    private final MapNodeJpaRepository mapNodeJpaRepository;
+    private final FloorRepository floorRepository;
+
+    // 코드 유니크 충돌이 발생하면 MapNode/Cctv/매핑 저장을 모두 롤백한 뒤,
+    // 호출자인 CctvService가 새 코드로 별도 트랜잭션을 다시 시작한다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public CctvResponse register(CreateCctvRequest request, String code) {
+        Floor floor = floorRepository.findById(request.floorId())
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+        validateGridConfigured(floor);
+        List<FloorGridCell> gridCells = findAndValidateGridCells(
+                floor.getId(), request.gridCellIds());
+
+        MapNode customNode = mapNodeJpaRepository.save(
+                MapNode.createCustom(
+                        floor,
+                        code,
+                        request.name(),
+                        request.x(),
+                        request.y(),
+                        CustomDeviceType.CCTV
+                )
+        );
+        Cctv cctv = cctvJpaRepository.save(Cctv.create(code, request.name(), customNode));
+        cctvGridCellRepository.saveAll(
+                gridCells.stream()
+                        .map(cell -> CctvGridCell.create(cctv, cell))
+                        .toList()
+        );
+
+        return CctvResponse.of(cctv, gridCells);
+    }
+
+    private List<FloorGridCell> findAndValidateGridCells(
+            UUID floorId,
+            List<UUID> gridCellIds
+    ) {
+        if (new HashSet<>(gridCellIds).size() != gridCellIds.size()) {
+            throw new ApiException(CctvErrorCode.DUPLICATE_GRID_CELL);
+        }
+
+        List<FloorGridCell> gridCells = floorGridCellRepository.findAllById(gridCellIds);
+        if (gridCells.size() != gridCellIds.size()) {
+            throw new ApiException(CctvErrorCode.GRID_CELL_NOT_FOUND);
+        }
+        if (gridCells.stream().anyMatch(cell -> !cell.getFloor().getId().equals(floorId))) {
+            throw new ApiException(CctvErrorCode.GRID_CELL_FLOOR_MISMATCH);
+        }
+        if (gridCells.stream().anyMatch(cell -> !cell.isWalkable())) {
+            throw new ApiException(CctvErrorCode.NON_WALKABLE_GRID_CELL);
+        }
+
+        return gridCells.stream()
+                .sorted(Comparator.comparingInt(FloorGridCell::getRowIndex)
+                        .thenComparingInt(FloorGridCell::getColumnIndex))
+                .toList();
+    }
+
+    private void validateGridConfigured(Floor floor) {
+        Double cellSizeMeter = floor.getGridCellSizeMeter();
+        if (cellSizeMeter == null || cellSizeMeter <= 0) {
+            throw new ApiException(CctvErrorCode.GRID_NOT_CONFIGURED);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -7,21 +7,19 @@ import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
-import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
-import com.saferoute.domain.evacuation.graph.entity.MapNode;
-import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
 import com.saferoute.domain.floor.entity.Floor;
-import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.CctvErrorCode;
-import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,45 +29,47 @@ import org.springframework.transaction.annotation.Transactional;
 public class CctvService {
 
     private static final String CCTV_CODE_PREFIX = "CCTV_";
+    private static final int CODE_GENERATION_MAX_ATTEMPTS = 3;
 
     private final CctvJpaRepository cctvJpaRepository;
     private final CctvGridCellRepository cctvGridCellRepository;
     private final FloorGridCellRepository floorGridCellRepository;
-    private final MapNodeJpaRepository mapNodeJpaRepository;
-    private final FloorRepository floorRepository;
+    private final CctvRegistrationService cctvRegistrationService;
 
-    @Transactional
     public CctvResponse createCctv(CreateCctvRequest request) {
-        Floor floor = floorRepository.findById(request.floorId())
-                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
-        validateGridConfigured(floor);
-
-        List<FloorGridCell> gridCells = findAndValidateGridCells(
-                floor.getId(), request.gridCellIds());
-        String code = generateCctvCode();
-
-        MapNode customNode = mapNodeJpaRepository.save(
-                MapNode.createCustom(
-                        floor,
-                        code,
-                        request.name(),
-                        request.x(),
-                        request.y(),
-                        CustomDeviceType.CCTV
-                )
-        );
-        Cctv cctv = cctvJpaRepository.save(Cctv.create(code, request.name(), customNode));
-        saveMappings(cctv, gridCells);
-
-        return CctvResponse.of(cctv, gridCells);
+        DataIntegrityViolationException lastConflict = null;
+        for (int attempt = 0; attempt < CODE_GENERATION_MAX_ATTEMPTS; attempt++) {
+            try {
+                return cctvRegistrationService.register(request, generateCctvCode());
+            } catch (DataIntegrityViolationException exception) {
+                lastConflict = exception;
+            }
+        }
+        throw new ApiException(CctvErrorCode.CCTV_CODE_GENERATION_FAILED, lastConflict);
     }
 
     public List<CctvResponse> getCctvs(UUID floorId) {
         List<Cctv> cctvs = floorId == null
-                ? cctvJpaRepository.findAll()
+                ? cctvJpaRepository.findAllWithLocation()
                 : cctvJpaRepository.findAllByCustomNode_Floor_Id(floorId);
+        if (cctvs.isEmpty()) {
+            return List.of();
+        }
 
-        return cctvs.stream().map(this::toResponse).toList();
+        Map<UUID, List<FloorGridCell>> gridCellsByCctvId = cctvGridCellRepository
+                .findAllByCctvIdsWithGridCell(cctvs.stream().map(Cctv::getId).toList())
+                .stream()
+                .collect(Collectors.groupingBy(
+                        mapping -> mapping.getCctv().getId(),
+                        Collectors.mapping(CctvGridCell::getGridCell, Collectors.toList())
+                ));
+
+        return cctvs.stream()
+                .map(cctv -> CctvResponse.of(
+                        cctv,
+                        gridCellsByCctvId.getOrDefault(cctv.getId(), List.of())
+                ))
+                .toList();
     }
 
     public CctvResponse getCctv(UUID cctvId) {
@@ -160,16 +160,12 @@ public class CctvService {
     }
 
     private Cctv findCctvOrThrow(UUID cctvId) {
-        return cctvJpaRepository.findById(cctvId)
+        return cctvJpaRepository.findByIdWithLocation(cctvId)
                 .orElseThrow(() -> new ApiException(CctvErrorCode.CCTV_NOT_FOUND));
     }
 
     private String generateCctvCode() {
-        String code;
-        do {
-            code = CCTV_CODE_PREFIX
-                    + UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
-        } while (cctvJpaRepository.existsByCode(code));
-        return code;
+        return CCTV_CODE_PREFIX
+                + UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
     }
 }

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -1,0 +1,175 @@
+package com.saferoute.domain.device.service;
+
+import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
+import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.entity.CctvGridCell;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.CctvErrorCode;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CctvService {
+
+    private static final String CCTV_CODE_PREFIX = "CCTV_";
+
+    private final CctvJpaRepository cctvJpaRepository;
+    private final CctvGridCellRepository cctvGridCellRepository;
+    private final FloorGridCellRepository floorGridCellRepository;
+    private final MapNodeJpaRepository mapNodeJpaRepository;
+    private final FloorRepository floorRepository;
+
+    @Transactional
+    public CctvResponse createCctv(CreateCctvRequest request) {
+        Floor floor = floorRepository.findById(request.floorId())
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+        validateGridConfigured(floor);
+
+        List<FloorGridCell> gridCells = findAndValidateGridCells(
+                floor.getId(), request.gridCellIds());
+        String code = generateCctvCode();
+
+        MapNode customNode = mapNodeJpaRepository.save(
+                MapNode.createCustom(
+                        floor,
+                        code,
+                        request.name(),
+                        request.x(),
+                        request.y(),
+                        CustomDeviceType.CCTV
+                )
+        );
+        Cctv cctv = cctvJpaRepository.save(Cctv.create(code, request.name(), customNode));
+        saveMappings(cctv, gridCells);
+
+        return CctvResponse.of(cctv, gridCells);
+    }
+
+    public List<CctvResponse> getCctvs(UUID floorId) {
+        List<Cctv> cctvs = floorId == null
+                ? cctvJpaRepository.findAll()
+                : cctvJpaRepository.findAllByCustomNode_Floor_Id(floorId);
+
+        return cctvs.stream().map(this::toResponse).toList();
+    }
+
+    public CctvResponse getCctv(UUID cctvId) {
+        return toResponse(findCctvOrThrow(cctvId));
+    }
+
+    public CctvResponse getGridCells(UUID cctvId) {
+        return getCctv(cctvId);
+    }
+
+    @Transactional
+    public CctvResponse configureGridCells(
+            UUID cctvId,
+            ConfigureCctvGridCellsRequest request
+    ) {
+        Cctv cctv = findCctvOrThrow(cctvId);
+        Floor floor = cctv.getCustomNode().getFloor();
+        validateGridConfigured(floor);
+        List<FloorGridCell> gridCells = findAndValidateGridCells(
+                floor.getId(), request.gridCellIds());
+
+        cctvGridCellRepository.deleteAllByCctvId(cctvId);
+        saveMappings(cctv, gridCells);
+        return CctvResponse.of(cctv, gridCells);
+    }
+
+    @Transactional
+    public CctvResponse enableCctv(UUID cctvId) {
+        Cctv cctv = findCctvOrThrow(cctvId);
+        cctv.enable();
+        return toResponse(cctv);
+    }
+
+    @Transactional
+    public CctvResponse disableCctv(UUID cctvId) {
+        Cctv cctv = findCctvOrThrow(cctvId);
+        cctv.disable();
+        return toResponse(cctv);
+    }
+
+    private CctvResponse toResponse(Cctv cctv) {
+        List<FloorGridCell> gridCells = cctvGridCellRepository
+                .findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(cctv.getId())
+                .stream()
+                .map(CctvGridCell::getGridCell)
+                .toList();
+        return CctvResponse.of(cctv, gridCells);
+    }
+
+    private List<FloorGridCell> findAndValidateGridCells(
+            UUID floorId,
+            List<UUID> gridCellIds
+    ) {
+        if (new HashSet<>(gridCellIds).size() != gridCellIds.size()) {
+            throw new ApiException(CctvErrorCode.DUPLICATE_GRID_CELL);
+        }
+
+        List<FloorGridCell> gridCells = floorGridCellRepository.findAllById(gridCellIds);
+        if (gridCells.size() != gridCellIds.size()) {
+            throw new ApiException(CctvErrorCode.GRID_CELL_NOT_FOUND);
+        }
+        if (gridCells.stream().anyMatch(cell -> !cell.getFloor().getId().equals(floorId))) {
+            throw new ApiException(CctvErrorCode.GRID_CELL_FLOOR_MISMATCH);
+        }
+        if (gridCells.stream().anyMatch(cell -> !cell.isWalkable())) {
+            throw new ApiException(CctvErrorCode.NON_WALKABLE_GRID_CELL);
+        }
+
+        return gridCells.stream()
+                .sorted(Comparator.comparingInt(FloorGridCell::getRowIndex)
+                        .thenComparingInt(FloorGridCell::getColumnIndex))
+                .toList();
+    }
+
+    private void saveMappings(Cctv cctv, List<FloorGridCell> gridCells) {
+        cctvGridCellRepository.saveAll(
+                gridCells.stream()
+                        .map(cell -> CctvGridCell.create(cctv, cell))
+                        .toList()
+        );
+    }
+
+    private void validateGridConfigured(Floor floor) {
+        Double cellSizeMeter = floor.getGridCellSizeMeter();
+        if (cellSizeMeter == null || cellSizeMeter <= 0) {
+            throw new ApiException(CctvErrorCode.GRID_NOT_CONFIGURED);
+        }
+    }
+
+    private Cctv findCctvOrThrow(UUID cctvId) {
+        return cctvJpaRepository.findById(cctvId)
+                .orElseThrow(() -> new ApiException(CctvErrorCode.CCTV_NOT_FOUND));
+    }
+
+    private String generateCctvCode() {
+        String code;
+        do {
+            code = CCTV_CODE_PREFIX
+                    + UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+        } while (cctvJpaRepository.existsByCode(code));
+        return code;
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
@@ -2,10 +2,12 @@ package com.saferoute.domain.evacuation.grid.controller;
 
 import com.saferoute.domain.evacuation.grid.dto.request.CreateOrUpdateFloorGridRequest;
 import com.saferoute.domain.evacuation.grid.dto.response.FloorGridResponse;
+import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellResponse;
 import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.global.api.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +17,11 @@ import org.springframework.web.bind.annotation.*;
 public class FloorGridController {
 
     private final FloorGridService floorGridService;
+
+    @GetMapping("/cells")
+    public ApiResponse<List<FloorGridCellResponse>> getGridCells(@PathVariable UUID floorId) {
+        return ApiResponse.success(floorGridService.getGridCells(floorId));
+    }
 
     @PutMapping
     public ApiResponse<FloorGridResponse> createOrRegenerateGrid(

--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
@@ -1,26 +1,33 @@
 package com.saferoute.domain.evacuation.grid.controller;
 
 import com.saferoute.domain.evacuation.grid.dto.request.CreateOrUpdateFloorGridRequest;
+import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellPageResponse;
 import com.saferoute.domain.evacuation.grid.dto.response.FloorGridResponse;
-import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellResponse;
 import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.global.api.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.UUID;
-import java.util.List;
+import org.springframework.validation.annotation.Validated;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/floors/{floorId}/grid")
 @RequiredArgsConstructor
+@Validated
 public class FloorGridController {
 
     private final FloorGridService floorGridService;
 
     @GetMapping("/cells")
-    public ApiResponse<List<FloorGridCellResponse>> getGridCells(@PathVariable UUID floorId) {
-        return ApiResponse.success(floorGridService.getGridCells(floorId));
+    public ApiResponse<FloorGridCellPageResponse> getGridCells(
+            @PathVariable UUID floorId,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "500") @Min(1) @Max(2000) int size
+    ) {
+        return ApiResponse.success(floorGridService.getGridCells(floorId, page, size));
     }
 
     @PutMapping

--- a/src/main/java/com/saferoute/domain/evacuation/grid/dto/response/FloorGridCellPageResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/dto/response/FloorGridCellPageResponse.java
@@ -1,0 +1,26 @@
+package com.saferoute.domain.evacuation.grid.dto.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record FloorGridCellPageResponse(
+        List<FloorGridCellResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last
+) {
+    public static FloorGridCellPageResponse from(Page<FloorGridCellResponse> result) {
+        return new FloorGridCellPageResponse(
+                result.getContent(),
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.isFirst(),
+                result.isLast()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/grid/dto/response/FloorGridCellResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/dto/response/FloorGridCellResponse.java
@@ -1,0 +1,26 @@
+package com.saferoute.domain.evacuation.grid.dto.response;
+
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import java.util.UUID;
+
+public record FloorGridCellResponse(
+        UUID id,
+        int rowIndex,
+        int columnIndex,
+        boolean walkable,
+        boolean fired,
+        double centerX,
+        double centerY
+) {
+    public static FloorGridCellResponse from(FloorGridCell cell) {
+        return new FloorGridCellResponse(
+                cell.getId(),
+                cell.getRowIndex(),
+                cell.getColumnIndex(),
+                cell.isWalkable(),
+                cell.isFired(),
+                cell.getCenterX(),
+                cell.getCenterY()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/FloorGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/FloorGridCellRepository.java
@@ -13,6 +13,8 @@ public interface FloorGridCellRepository extends JpaRepository<FloorGridCell, UU
 
     List<FloorGridCell> findAllByFloor_Id(UUID floorId);
 
+    List<FloorGridCell> findAllByFloor_IdOrderByRowIndexAscColumnIndexAsc(UUID floorId);
+
     // 화재 확산 시 rowIndex/columnIndex 로 인접 셀 탐색
     Optional<FloorGridCell> findByFloor_IdAndRowIndexAndColumnIndex(UUID floorId, int rowIndex, int columnIndex);
 

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/FloorGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/FloorGridCellRepository.java
@@ -4,6 +4,8 @@ import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +15,7 @@ public interface FloorGridCellRepository extends JpaRepository<FloorGridCell, UU
 
     List<FloorGridCell> findAllByFloor_Id(UUID floorId);
 
-    List<FloorGridCell> findAllByFloor_IdOrderByRowIndexAscColumnIndexAsc(UUID floorId);
+    Page<FloorGridCell> findAllByFloor_Id(UUID floorId, Pageable pageable);
 
     // 화재 확산 시 rowIndex/columnIndex 로 인접 셀 탐색
     Optional<FloorGridCell> findByFloor_IdAndRowIndexAndColumnIndex(UUID floorId, int rowIndex, int columnIndex);

--- a/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.evacuation.grid.service;
 
 import com.saferoute.domain.evacuation.grid.dto.request.CreateOrUpdateFloorGridRequest;
 import com.saferoute.domain.evacuation.grid.dto.response.FloorGridResponse;
+import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellResponse;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.entity.NodeGridCell;
@@ -41,6 +42,16 @@ public class FloorGridService {
     private final MapEdgeGridCellRepository mapEdgeGridCellRepository;
     private final MapNodeJpaRepository mapNodeRepository;
     private final MapEdgeJpaRepository mapEdgeRepository;
+
+    public List<FloorGridCellResponse> getGridCells(UUID floorId) {
+        if (!floorRepository.existsById(floorId)) {
+            throw new ApiException(FloorErrorCode.FLOOR_NOT_FOUND);
+        }
+        return floorGridCellRepository.findAllByFloor_IdOrderByRowIndexAscColumnIndexAsc(floorId)
+                .stream()
+                .map(FloorGridCellResponse::from)
+                .toList();
+    }
 
     // 그리드 생성/재생성 - 최초 생성이든 N번째 수정이든 동일 로직
     @Transactional

--- a/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.evacuation.grid.service;
 import com.saferoute.domain.evacuation.grid.dto.request.CreateOrUpdateFloorGridRequest;
 import com.saferoute.domain.evacuation.grid.dto.response.FloorGridResponse;
 import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellResponse;
+import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellPageResponse;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.entity.NodeGridCell;
@@ -25,6 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,14 +46,19 @@ public class FloorGridService {
     private final MapNodeJpaRepository mapNodeRepository;
     private final MapEdgeJpaRepository mapEdgeRepository;
 
-    public List<FloorGridCellResponse> getGridCells(UUID floorId) {
+    public FloorGridCellPageResponse getGridCells(UUID floorId, int page, int size) {
         if (!floorRepository.existsById(floorId)) {
             throw new ApiException(FloorErrorCode.FLOOR_NOT_FOUND);
         }
-        return floorGridCellRepository.findAllByFloor_IdOrderByRowIndexAscColumnIndexAsc(floorId)
-                .stream()
-                .map(FloorGridCellResponse::from)
-                .toList();
+        PageRequest pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by("rowIndex").ascending().and(Sort.by("columnIndex").ascending())
+        );
+        return FloorGridCellPageResponse.from(
+                floorGridCellRepository.findAllByFloor_Id(floorId, pageable)
+                        .map(FloorGridCellResponse::from)
+        );
     }
 
     // 그리드 생성/재생성 - 최초 생성이든 N번째 수정이든 동일 로직

--- a/src/main/java/com/saferoute/global/api/error/CctvErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/CctvErrorCode.java
@@ -14,7 +14,8 @@ public enum CctvErrorCode implements BaseErrorCode {
     DUPLICATE_GRID_CELL(HttpStatus.BAD_REQUEST, "CCTV003", "중복된 GridCell이 포함되어 있습니다."),
     GRID_CELL_FLOOR_MISMATCH(HttpStatus.BAD_REQUEST, "CCTV004", "CCTV와 GridCell은 같은 층에 있어야 합니다."),
     NON_WALKABLE_GRID_CELL(HttpStatus.BAD_REQUEST, "CCTV005", "보행 가능하지 않은 GridCell은 감시 영역으로 설정할 수 없습니다."),
-    GRID_NOT_CONFIGURED(HttpStatus.BAD_REQUEST, "CCTV006", "해당 층의 GridCell 크기가 설정되지 않았습니다.");
+    GRID_NOT_CONFIGURED(HttpStatus.BAD_REQUEST, "CCTV006", "해당 층의 GridCell 크기가 설정되지 않았습니다."),
+    CCTV_CODE_GENERATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "CCTV007", "CCTV 식별 코드 생성에 실패했습니다. 잠시 후 다시 시도해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/api/error/CctvErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/CctvErrorCode.java
@@ -1,0 +1,22 @@
+package com.saferoute.global.api.error;
+
+import com.saferoute.global.api.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CctvErrorCode implements BaseErrorCode {
+
+    CCTV_NOT_FOUND(HttpStatus.NOT_FOUND, "CCTV001", "CCTV를 찾을 수 없습니다."),
+    GRID_CELL_NOT_FOUND(HttpStatus.NOT_FOUND, "CCTV002", "선택한 GridCell을 찾을 수 없습니다."),
+    DUPLICATE_GRID_CELL(HttpStatus.BAD_REQUEST, "CCTV003", "중복된 GridCell이 포함되어 있습니다."),
+    GRID_CELL_FLOOR_MISMATCH(HttpStatus.BAD_REQUEST, "CCTV004", "CCTV와 GridCell은 같은 층에 있어야 합니다."),
+    NON_WALKABLE_GRID_CELL(HttpStatus.BAD_REQUEST, "CCTV005", "보행 가능하지 않은 GridCell은 감시 영역으로 설정할 수 없습니다."),
+    GRID_NOT_CONFIGURED(HttpStatus.BAD_REQUEST, "CCTV006", "해당 층의 GridCell 크기가 설정되지 않았습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/saferoute/global/api/response/CctvSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/CctvSuccessCode.java
@@ -1,0 +1,23 @@
+package com.saferoute.global.api.response;
+
+import com.saferoute.global.api.code.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CctvSuccessCode implements BaseCode {
+
+    CCTV_CREATED(HttpStatus.CREATED, "CCTV_SUCCESS_001", "CCTV가 등록되었습니다."),
+    CCTV_LIST_FOUND(HttpStatus.OK, "CCTV_SUCCESS_002", "CCTV 목록 조회에 성공했습니다."),
+    CCTV_DETAIL_FOUND(HttpStatus.OK, "CCTV_SUCCESS_003", "CCTV 상세 조회에 성공했습니다."),
+    CCTV_GRID_CELLS_CONFIGURED(HttpStatus.OK, "CCTV_SUCCESS_004", "CCTV 감시 영역이 설정되었습니다."),
+    CCTV_GRID_CELLS_FOUND(HttpStatus.OK, "CCTV_SUCCESS_005", "CCTV 감시 영역 조회에 성공했습니다."),
+    CCTV_ENABLED(HttpStatus.OK, "CCTV_SUCCESS_006", "CCTV가 활성화되었습니다."),
+    CCTV_DISABLED(HttpStatus.OK, "CCTV_SUCCESS_007", "CCTV가 비활성화되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -80,6 +80,12 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/actuator/**").authenticated()
 
+                        // 도면 GridCell 원본 데이터는 CCTV 감시 영역을 설정하는 관리자 기능에서만 사용한다.
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/floors/*/grid/cells"
+                        ).hasRole("MANAGER")
+
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/api/**"

--- a/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
@@ -1,0 +1,135 @@
+package com.saferoute.domain.device.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
+import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.response.CctvGridCellResponse;
+import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.service.CctvService;
+import com.saferoute.global.config.SecurityConfig;
+import com.saferoute.global.security.JwtAuthenticationFilter;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = CctvController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {JwtAuthenticationFilter.class, SecurityConfig.class}
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class CctvControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockitoBean CctvService cctvService;
+
+    private final UUID cctvId = UUID.randomUUID();
+    private final UUID floorId = UUID.randomUUID();
+    private final UUID cellId = UUID.randomUUID();
+
+    @Test
+    void createCctv_returnsCreatedCoverage() throws Exception {
+        CreateCctvRequest request = new CreateCctvRequest(
+                "3층 복도 CCTV", floorId, 0.6, 0.4, List.of(cellId));
+        given(cctvService.createCctv(any())).willReturn(response(true));
+
+        mockMvc.perform(post("/api/v1/cctvs")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.x").value(0.6))
+                .andExpect(jsonPath("$.result.gridCells[0].id").value(cellId.toString()))
+                .andExpect(jsonPath("$.result.monitoredAreaM2").value(0.25));
+    }
+
+    @Test
+    void createCctv_rejectsEmptyGridCells() throws Exception {
+        CreateCctvRequest request = new CreateCctvRequest(
+                "3층 복도 CCTV", floorId, 0.6, 0.4, List.of());
+
+        mockMvc.perform(post("/api/v1/cctvs")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createCctv_rejectsOutOfRangeCoordinates() throws Exception {
+        CreateCctvRequest request = new CreateCctvRequest(
+                "3층 복도 CCTV", floorId, 1.1, -0.1, List.of(cellId));
+
+        mockMvc.perform(post("/api/v1/cctvs")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getCctvs_returnsList() throws Exception {
+        given(cctvService.getCctvs(floorId)).willReturn(List.of(response(true)));
+
+        mockMvc.perform(get("/api/v1/cctvs").param("floorId", floorId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.length()").value(1));
+    }
+
+    @Test
+    void configureGridCells_returnsUpdatedCoverage() throws Exception {
+        ConfigureCctvGridCellsRequest request =
+                new ConfigureCctvGridCellsRequest(List.of(cellId));
+        given(cctvService.configureGridCells(eq(cctvId), any())).willReturn(response(true));
+
+        mockMvc.perform(put("/api/v1/cctvs/{cctvId}/grid-cells", cctvId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.monitoredGridCellCount").value(1));
+    }
+
+    @Test
+    void disableCctv_returnsDisabledState() throws Exception {
+        given(cctvService.disableCctv(cctvId)).willReturn(response(false));
+
+        mockMvc.perform(patch("/api/v1/cctvs/{cctvId}/disable", cctvId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.enabled").value(false));
+    }
+
+    private CctvResponse response(boolean enabled) {
+        return new CctvResponse(
+                cctvId,
+                "CCTV_A1B2C3D4",
+                "3층 복도 CCTV",
+                floorId,
+                UUID.randomUUID(),
+                0.6,
+                0.4,
+                enabled,
+                0.5,
+                1,
+                0.25,
+                List.of(new CctvGridCellResponse(cellId, 1, 2, true, 0.3, 0.4))
+        );
+    }
+}

--- a/src/test/java/com/saferoute/domain/device/service/CctvRegistrationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvRegistrationServiceTest.java
@@ -1,0 +1,151 @@
+package com.saferoute.domain.device.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.entity.CctvGridCell;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.CctvErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CctvRegistrationServiceTest {
+
+    @Mock CctvJpaRepository cctvJpaRepository;
+    @Mock CctvGridCellRepository cctvGridCellRepository;
+    @Mock FloorGridCellRepository floorGridCellRepository;
+    @Mock MapNodeJpaRepository mapNodeJpaRepository;
+    @Mock FloorRepository floorRepository;
+
+    private CctvRegistrationService service;
+    private Floor floor;
+    private UUID floorId;
+
+    @BeforeEach
+    void setUp() {
+        service = new CctvRegistrationService(
+                cctvJpaRepository,
+                cctvGridCellRepository,
+                floorGridCellRepository,
+                mapNodeJpaRepository,
+                floorRepository
+        );
+        floor = org.mockito.Mockito.mock(Floor.class);
+        floorId = UUID.randomUUID();
+        given(floor.getId()).willReturn(floorId);
+        given(floor.getGridCellSizeMeter()).willReturn(0.5);
+    }
+
+    @Test
+    @DisplayName("CCTV 위치 노드와 감시 셀을 하나의 등록 작업으로 저장한다")
+    void register_success() {
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        FloorGridCell first = cell(firstId, floor, 0, 0, true);
+        FloorGridCell second = cell(secondId, floor, 0, 1, true);
+        CreateCctvRequest request = request(List.of(firstId, secondId));
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(floorGridCellRepository.findAllById(request.gridCellIds()))
+                .willReturn(List.of(second, first));
+        given(mapNodeJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(cctvJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        CctvResponse response = service.register(request, "CCTV_A1B2C3D4");
+
+        assertThat(response.code()).isEqualTo("CCTV_A1B2C3D4");
+        assertThat(response.monitoredGridCellCount()).isEqualTo(2);
+        assertThat(response.gridCells()).extracting("id").containsExactly(firstId, secondId);
+        ArgumentCaptor<List<CctvGridCell>> mappings = ArgumentCaptor.forClass(List.class);
+        verify(cctvGridCellRepository).saveAll(mappings.capture());
+        assertThat(mappings.getValue()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("중복 GridCell 요청은 저장 전에 거부한다")
+    void register_duplicateGridCells() {
+        UUID cellId = UUID.randomUUID();
+        CreateCctvRequest request = request(List.of(cellId, cellId));
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+
+        assertThatThrownBy(() -> service.register(request, "CCTV_A1B2C3D4"))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(CctvErrorCode.DUPLICATE_GRID_CELL);
+        verify(mapNodeJpaRepository, never()).save(any());
+        verify(cctvJpaRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("다른 층의 GridCell은 CCTV 감시 영역으로 등록할 수 없다")
+    void register_gridCellFloorMismatch() {
+        UUID cellId = UUID.randomUUID();
+        Floor otherFloor = org.mockito.Mockito.mock(Floor.class);
+        given(otherFloor.getId()).willReturn(UUID.randomUUID());
+        FloorGridCell cell = cell(cellId, otherFloor, 0, 0, true);
+        CreateCctvRequest request = request(List.of(cellId));
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(floorGridCellRepository.findAllById(request.gridCellIds())).willReturn(List.of(cell));
+
+        assertThatThrownBy(() -> service.register(request, "CCTV_A1B2C3D4"))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(CctvErrorCode.GRID_CELL_FLOOR_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("보행 불가능한 GridCell은 CCTV 감시 영역으로 등록할 수 없다")
+    void register_nonWalkableGridCell() {
+        UUID cellId = UUID.randomUUID();
+        FloorGridCell cell = cell(cellId, floor, 0, 0, false);
+        CreateCctvRequest request = request(List.of(cellId));
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(floorGridCellRepository.findAllById(request.gridCellIds())).willReturn(List.of(cell));
+
+        assertThatThrownBy(() -> service.register(request, "CCTV_A1B2C3D4"))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(CctvErrorCode.NON_WALKABLE_GRID_CELL);
+    }
+
+    private CreateCctvRequest request(List<UUID> gridCellIds) {
+        return new CreateCctvRequest("동쪽 복도 CCTV", floorId, 0.4, 0.3, gridCellIds);
+    }
+
+    private FloorGridCell cell(
+            UUID id,
+            Floor owningFloor,
+            int row,
+            int column,
+            boolean walkable
+    ) {
+        FloorGridCell cell = org.mockito.Mockito.mock(FloorGridCell.class);
+        org.mockito.Mockito.lenient().when(cell.getId()).thenReturn(id);
+        org.mockito.Mockito.lenient().when(cell.getFloor()).thenReturn(owningFloor);
+        org.mockito.Mockito.lenient().when(cell.getRowIndex()).thenReturn(row);
+        org.mockito.Mockito.lenient().when(cell.getColumnIndex()).thenReturn(column);
+        org.mockito.Mockito.lenient().when(cell.isWalkable()).thenReturn(walkable);
+        return cell;
+    }
+}

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -1,0 +1,184 @@
+package com.saferoute.domain.device.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
+import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.entity.CctvGridCell;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.CctvErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CctvServiceTest {
+
+    @Mock CctvJpaRepository cctvJpaRepository;
+    @Mock CctvGridCellRepository cctvGridCellRepository;
+    @Mock FloorGridCellRepository floorGridCellRepository;
+    @Mock MapNodeJpaRepository mapNodeJpaRepository;
+    @Mock FloorRepository floorRepository;
+
+    private CctvService cctvService;
+    private Floor floor;
+    private UUID floorId;
+
+    @BeforeEach
+    void setUp() {
+        cctvService = new CctvService(
+                cctvJpaRepository,
+                cctvGridCellRepository,
+                floorGridCellRepository,
+                mapNodeJpaRepository,
+                floorRepository
+        );
+        floor = org.mockito.Mockito.mock(Floor.class);
+        floorId = UUID.randomUUID();
+        given(floor.getId()).willReturn(floorId);
+        given(floor.getGridCellSizeMeter()).willReturn(0.5);
+    }
+
+    @Test
+    @DisplayName("CCTV 등록 시 위치 노드와 감시 셀을 한 번에 저장하고 면적을 계산한다")
+    void createCctv_success() {
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        FloorGridCell first = cell(firstId, floor, 0, 0, true);
+        FloorGridCell second = cell(secondId, floor, 0, 1, true);
+        CreateCctvRequest request = new CreateCctvRequest(
+                "동쪽 복도 CCTV", floorId, 0.4, 0.3, List.of(firstId, secondId));
+
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(floorGridCellRepository.findAllById(request.gridCellIds()))
+                .willReturn(List.of(second, first));
+        given(cctvJpaRepository.existsByCode(any())).willReturn(false);
+        given(mapNodeJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(cctvJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        CctvResponse response = cctvService.createCctv(request);
+
+        assertThat(response.code()).startsWith("CCTV_");
+        assertThat(response.x()).isEqualTo(0.4);
+        assertThat(response.y()).isEqualTo(0.3);
+        assertThat(response.monitoredGridCellCount()).isEqualTo(2);
+        assertThat(response.monitoredAreaM2()).isEqualTo(0.5);
+        assertThat(response.gridCells()).extracting("id").containsExactly(firstId, secondId);
+
+        ArgumentCaptor<List<CctvGridCell>> mappings = ArgumentCaptor.forClass(List.class);
+        verify(cctvGridCellRepository).saveAll(mappings.capture());
+        assertThat(mappings.getValue()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("중복 GridCell 요청은 저장 전에 거부한다")
+    void createCctv_duplicateGridCells() {
+        UUID cellId = UUID.randomUUID();
+        CreateCctvRequest request = new CreateCctvRequest(
+                "동쪽 복도 CCTV", floorId, 0.4, 0.3, List.of(cellId, cellId));
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+
+        assertThatThrownBy(() -> cctvService.createCctv(request))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(CctvErrorCode.DUPLICATE_GRID_CELL);
+
+        verify(mapNodeJpaRepository, never()).save(any());
+        verify(cctvJpaRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("다른 층의 GridCell은 CCTV 감시 영역으로 등록할 수 없다")
+    void createCctv_gridCellFloorMismatch() {
+        UUID cellId = UUID.randomUUID();
+        Floor otherFloor = org.mockito.Mockito.mock(Floor.class);
+        given(otherFloor.getId()).willReturn(UUID.randomUUID());
+        FloorGridCell cell = cell(cellId, otherFloor, 0, 0, true);
+        CreateCctvRequest request = new CreateCctvRequest(
+                "동쪽 복도 CCTV", floorId, 0.4, 0.3, List.of(cellId));
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(floorGridCellRepository.findAllById(request.gridCellIds())).willReturn(List.of(cell));
+
+        assertThatThrownBy(() -> cctvService.createCctv(request))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(CctvErrorCode.GRID_CELL_FLOOR_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("보행 불가능한 GridCell은 CCTV 감시 영역으로 등록할 수 없다")
+    void createCctv_nonWalkableGridCell() {
+        UUID cellId = UUID.randomUUID();
+        FloorGridCell cell = cell(cellId, floor, 0, 0, false);
+        CreateCctvRequest request = new CreateCctvRequest(
+                "동쪽 복도 CCTV", floorId, 0.4, 0.3, List.of(cellId));
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(floorGridCellRepository.findAllById(request.gridCellIds())).willReturn(List.of(cell));
+
+        assertThatThrownBy(() -> cctvService.createCctv(request))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(CctvErrorCode.NON_WALKABLE_GRID_CELL);
+    }
+
+    @Test
+    @DisplayName("감시 영역 수정 시 검증을 마친 뒤 기존 매핑을 교체한다")
+    void configureGridCells_success() {
+        UUID cctvId = UUID.randomUUID();
+        UUID cellId = UUID.randomUUID();
+        MapNode node = org.mockito.Mockito.mock(MapNode.class);
+        Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
+        FloorGridCell cell = cell(cellId, floor, 1, 2, true);
+        given(cctv.getId()).willReturn(cctvId);
+        given(cctv.getCustomNode()).willReturn(node);
+        given(node.getFloor()).willReturn(floor);
+        given(cctvJpaRepository.findById(cctvId)).willReturn(Optional.of(cctv));
+        given(floorGridCellRepository.findAllById(List.of(cellId))).willReturn(List.of(cell));
+
+        cctvService.configureGridCells(
+                cctvId,
+                new ConfigureCctvGridCellsRequest(List.of(cellId))
+        );
+
+        verify(cctvGridCellRepository).deleteAllByCctvId(cctvId);
+        verify(cctvGridCellRepository).saveAll(any());
+    }
+
+    private FloorGridCell cell(
+            UUID id,
+            Floor owningFloor,
+            int row,
+            int column,
+            boolean walkable
+    ) {
+        FloorGridCell cell = org.mockito.Mockito.mock(FloorGridCell.class);
+        org.mockito.Mockito.lenient().when(cell.getId()).thenReturn(id);
+        org.mockito.Mockito.lenient().when(cell.getFloor()).thenReturn(owningFloor);
+        org.mockito.Mockito.lenient().when(cell.getRowIndex()).thenReturn(row);
+        org.mockito.Mockito.lenient().when(cell.getColumnIndex()).thenReturn(column);
+        org.mockito.Mockito.lenient().when(cell.isWalkable()).thenReturn(walkable);
+        return cell;
+    }
+}

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -3,8 +3,10 @@ package com.saferoute.domain.device.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
@@ -15,11 +17,9 @@ import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
-import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
 import com.saferoute.domain.floor.entity.Floor;
-import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.CctvErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import java.util.List;
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class CctvServiceTest {
@@ -39,12 +39,9 @@ class CctvServiceTest {
     @Mock CctvJpaRepository cctvJpaRepository;
     @Mock CctvGridCellRepository cctvGridCellRepository;
     @Mock FloorGridCellRepository floorGridCellRepository;
-    @Mock MapNodeJpaRepository mapNodeJpaRepository;
-    @Mock FloorRepository floorRepository;
+    @Mock CctvRegistrationService cctvRegistrationService;
 
     private CctvService cctvService;
-    private Floor floor;
-    private UUID floorId;
 
     @BeforeEach
     void setUp() {
@@ -52,109 +49,92 @@ class CctvServiceTest {
                 cctvJpaRepository,
                 cctvGridCellRepository,
                 floorGridCellRepository,
-                mapNodeJpaRepository,
-                floorRepository
+                cctvRegistrationService
         );
-        floor = org.mockito.Mockito.mock(Floor.class);
-        floorId = UUID.randomUUID();
-        given(floor.getId()).willReturn(floorId);
-        given(floor.getGridCellSizeMeter()).willReturn(0.5);
     }
 
     @Test
-    @DisplayName("CCTV 등록 시 위치 노드와 감시 셀을 한 번에 저장하고 면적을 계산한다")
+    @DisplayName("CCTV 등록 시 생성한 코드를 별도 트랜잭션 등록 서비스에 전달한다")
     void createCctv_success() {
-        UUID firstId = UUID.randomUUID();
-        UUID secondId = UUID.randomUUID();
-        FloorGridCell first = cell(firstId, floor, 0, 0, true);
-        FloorGridCell second = cell(secondId, floor, 0, 1, true);
-        CreateCctvRequest request = new CreateCctvRequest(
-                "동쪽 복도 CCTV", floorId, 0.4, 0.3, List.of(firstId, secondId));
-
-        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
-        given(floorGridCellRepository.findAllById(request.gridCellIds()))
-                .willReturn(List.of(second, first));
-        given(cctvJpaRepository.existsByCode(any())).willReturn(false);
-        given(mapNodeJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
-        given(cctvJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        CreateCctvRequest request = request();
+        CctvResponse expected = org.mockito.Mockito.mock(CctvResponse.class);
+        given(cctvRegistrationService.register(any(), any())).willReturn(expected);
 
         CctvResponse response = cctvService.createCctv(request);
 
-        assertThat(response.code()).startsWith("CCTV_");
-        assertThat(response.x()).isEqualTo(0.4);
-        assertThat(response.y()).isEqualTo(0.3);
-        assertThat(response.monitoredGridCellCount()).isEqualTo(2);
-        assertThat(response.monitoredAreaM2()).isEqualTo(0.5);
-        assertThat(response.gridCells()).extracting("id").containsExactly(firstId, secondId);
-
-        ArgumentCaptor<List<CctvGridCell>> mappings = ArgumentCaptor.forClass(List.class);
-        verify(cctvGridCellRepository).saveAll(mappings.capture());
-        assertThat(mappings.getValue()).hasSize(2);
+        assertThat(response).isSameAs(expected);
+        verify(cctvRegistrationService).register(
+                org.mockito.ArgumentMatchers.eq(request),
+                org.mockito.ArgumentMatchers.matches("CCTV_[0-9A-F]{8}")
+        );
     }
 
     @Test
-    @DisplayName("중복 GridCell 요청은 저장 전에 거부한다")
-    void createCctv_duplicateGridCells() {
-        UUID cellId = UUID.randomUUID();
-        CreateCctvRequest request = new CreateCctvRequest(
-                "동쪽 복도 CCTV", floorId, 0.4, 0.3, List.of(cellId, cellId));
-        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+    @DisplayName("CCTV 코드 유니크 충돌 시 새 코드로 최대 세 번 재시도한다")
+    void createCctv_retriesUniqueConflict() {
+        CreateCctvRequest request = request();
+        CctvResponse expected = org.mockito.Mockito.mock(CctvResponse.class);
+        given(cctvRegistrationService.register(any(), any()))
+                .willThrow(new DataIntegrityViolationException("duplicate code"))
+                .willThrow(new DataIntegrityViolationException("duplicate code"))
+                .willReturn(expected);
 
-        assertThatThrownBy(() -> cctvService.createCctv(request))
-                .isInstanceOf(ApiException.class)
-                .extracting("errorCode")
-                .isEqualTo(CctvErrorCode.DUPLICATE_GRID_CELL);
-
-        verify(mapNodeJpaRepository, never()).save(any());
-        verify(cctvJpaRepository, never()).save(any());
+        assertThat(cctvService.createCctv(request)).isSameAs(expected);
+        verify(cctvRegistrationService, times(3)).register(any(), any());
     }
 
     @Test
-    @DisplayName("다른 층의 GridCell은 CCTV 감시 영역으로 등록할 수 없다")
-    void createCctv_gridCellFloorMismatch() {
-        UUID cellId = UUID.randomUUID();
-        Floor otherFloor = org.mockito.Mockito.mock(Floor.class);
-        given(otherFloor.getId()).willReturn(UUID.randomUUID());
-        FloorGridCell cell = cell(cellId, otherFloor, 0, 0, true);
-        CreateCctvRequest request = new CreateCctvRequest(
-                "동쪽 복도 CCTV", floorId, 0.4, 0.3, List.of(cellId));
-        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
-        given(floorGridCellRepository.findAllById(request.gridCellIds())).willReturn(List.of(cell));
+    @DisplayName("CCTV 코드 충돌이 세 번 계속되면 명시적인 실패 응답을 반환한다")
+    void createCctv_failsAfterRetryLimit() {
+        given(cctvRegistrationService.register(any(), any()))
+                .willThrow(new DataIntegrityViolationException("duplicate code"));
 
-        assertThatThrownBy(() -> cctvService.createCctv(request))
+        assertThatThrownBy(() -> cctvService.createCctv(request()))
                 .isInstanceOf(ApiException.class)
                 .extracting("errorCode")
-                .isEqualTo(CctvErrorCode.GRID_CELL_FLOOR_MISMATCH);
+                .isEqualTo(CctvErrorCode.CCTV_CODE_GENERATION_FAILED);
+        verify(cctvRegistrationService, times(3)).register(any(), any());
     }
 
     @Test
-    @DisplayName("보행 불가능한 GridCell은 CCTV 감시 영역으로 등록할 수 없다")
-    void createCctv_nonWalkableGridCell() {
-        UUID cellId = UUID.randomUUID();
-        FloorGridCell cell = cell(cellId, floor, 0, 0, false);
-        CreateCctvRequest request = new CreateCctvRequest(
-                "동쪽 복도 CCTV", floorId, 0.4, 0.3, List.of(cellId));
-        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
-        given(floorGridCellRepository.findAllById(request.gridCellIds())).willReturn(List.of(cell));
+    @DisplayName("CCTV 목록의 감시 셀 매핑을 CCTV ID 목록으로 한 번에 조회한다")
+    void getCctvs_loadsMappingsInBatch() {
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        Cctv firstCctv = cctv(firstId);
+        Cctv secondCctv = cctv(secondId);
+        CctvGridCell firstMapping = mapping(firstCctv, cell(0, 0));
+        CctvGridCell secondMapping = mapping(secondCctv, cell(0, 1));
+        given(cctvJpaRepository.findAllWithLocation()).willReturn(List.of(firstCctv, secondCctv));
+        given(cctvGridCellRepository.findAllByCctvIdsWithGridCell(anyList()))
+                .willReturn(List.of(firstMapping, secondMapping));
 
-        assertThatThrownBy(() -> cctvService.createCctv(request))
-                .isInstanceOf(ApiException.class)
-                .extracting("errorCode")
-                .isEqualTo(CctvErrorCode.NON_WALKABLE_GRID_CELL);
+        List<CctvResponse> responses = cctvService.getCctvs(null);
+
+        assertThat(responses).hasSize(2);
+        verify(cctvGridCellRepository).findAllByCctvIdsWithGridCell(List.of(firstId, secondId));
+        verify(cctvGridCellRepository, never())
+                .findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(any());
     }
 
     @Test
     @DisplayName("감시 영역 수정 시 검증을 마친 뒤 기존 매핑을 교체한다")
     void configureGridCells_success() {
         UUID cctvId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
         UUID cellId = UUID.randomUUID();
+        Floor floor = org.mockito.Mockito.mock(Floor.class);
         MapNode node = org.mockito.Mockito.mock(MapNode.class);
-        Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
-        FloorGridCell cell = cell(cellId, floor, 1, 2, true);
-        given(cctv.getId()).willReturn(cctvId);
-        given(cctv.getCustomNode()).willReturn(node);
+        Cctv cctv = cctv(cctvId);
+        FloorGridCell cell = cell(1, 2);
+        given(floor.getId()).willReturn(floorId);
+        given(floor.getGridCellSizeMeter()).willReturn(0.5);
         given(node.getFloor()).willReturn(floor);
-        given(cctvJpaRepository.findById(cctvId)).willReturn(Optional.of(cctv));
+        given(cctv.getCustomNode()).willReturn(node);
+        given(cell.getId()).willReturn(cellId);
+        given(cell.getFloor()).willReturn(floor);
+        given(cell.isWalkable()).willReturn(true);
+        given(cctvJpaRepository.findByIdWithLocation(cctvId)).willReturn(Optional.of(cctv));
         given(floorGridCellRepository.findAllById(List.of(cellId))).willReturn(List.of(cell));
 
         cctvService.configureGridCells(
@@ -166,19 +146,38 @@ class CctvServiceTest {
         verify(cctvGridCellRepository).saveAll(any());
     }
 
-    private FloorGridCell cell(
-            UUID id,
-            Floor owningFloor,
-            int row,
-            int column,
-            boolean walkable
-    ) {
+    private CreateCctvRequest request() {
+        return new CreateCctvRequest(
+                "동쪽 복도 CCTV",
+                UUID.randomUUID(),
+                0.4,
+                0.3,
+                List.of(UUID.randomUUID())
+        );
+    }
+
+    private Cctv cctv(UUID id) {
+        Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
+        MapNode node = org.mockito.Mockito.mock(MapNode.class);
+        Floor floor = org.mockito.Mockito.mock(Floor.class);
+        org.mockito.Mockito.lenient().when(cctv.getId()).thenReturn(id);
+        org.mockito.Mockito.lenient().when(cctv.getCustomNode()).thenReturn(node);
+        org.mockito.Mockito.lenient().when(node.getFloor()).thenReturn(floor);
+        org.mockito.Mockito.lenient().when(floor.getGridCellSizeMeter()).thenReturn(0.5);
+        return cctv;
+    }
+
+    private FloorGridCell cell(int row, int column) {
         FloorGridCell cell = org.mockito.Mockito.mock(FloorGridCell.class);
-        org.mockito.Mockito.lenient().when(cell.getId()).thenReturn(id);
-        org.mockito.Mockito.lenient().when(cell.getFloor()).thenReturn(owningFloor);
         org.mockito.Mockito.lenient().when(cell.getRowIndex()).thenReturn(row);
         org.mockito.Mockito.lenient().when(cell.getColumnIndex()).thenReturn(column);
-        org.mockito.Mockito.lenient().when(cell.isWalkable()).thenReturn(walkable);
         return cell;
+    }
+
+    private CctvGridCell mapping(Cctv cctv, FloorGridCell cell) {
+        CctvGridCell mapping = org.mockito.Mockito.mock(CctvGridCell.class);
+        given(mapping.getCctv()).willReturn(cctv);
+        given(mapping.getGridCell()).willReturn(cell);
+        return mapping;
     }
 }

--- a/src/test/java/com/saferoute/domain/evacuation/grid/controller/FloorGridControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/grid/controller/FloorGridControllerTest.java
@@ -1,0 +1,69 @@
+package com.saferoute.domain.evacuation.grid.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellPageResponse;
+import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellResponse;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
+import com.saferoute.global.config.SecurityConfig;
+import com.saferoute.global.security.JwtAuthenticationFilter;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = FloorGridController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {JwtAuthenticationFilter.class, SecurityConfig.class}
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class FloorGridControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean FloorGridService floorGridService;
+
+    @Test
+    void getGridCells_usesDefaultPagination() throws Exception {
+        UUID floorId = UUID.randomUUID();
+        FloorGridCellResponse cell = new FloorGridCellResponse(
+                UUID.randomUUID(), 0, 0, true, false, 0.1, 0.1);
+        given(floorGridService.getGridCells(floorId, 0, 500))
+                .willReturn(new FloorGridCellPageResponse(
+                        List.of(cell), 0, 500, 1, 1, true, true));
+
+        mockMvc.perform(get("/api/v1/floors/{floorId}/grid/cells", floorId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.content.length()").value(1))
+                .andExpect(jsonPath("$.result.page").value(0))
+                .andExpect(jsonPath("$.result.size").value(500));
+        verify(floorGridService).getGridCells(floorId, 0, 500);
+    }
+
+    @Test
+    void getGridCells_rejectsPageSizeOverLimit() throws Exception {
+        UUID floorId = UUID.randomUUID();
+
+        mockMvc.perform(get("/api/v1/floors/{floorId}/grid/cells", floorId)
+                        .param("size", "2001"))
+                .andExpect(status().isBadRequest());
+        verify(floorGridService, never()).getGridCells(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyInt()
+        );
+    }
+}

--- a/src/test/java/com/saferoute/domain/grid/FloorGridServiceTest.java
+++ b/src/test/java/com/saferoute/domain/grid/FloorGridServiceTest.java
@@ -136,4 +136,22 @@ class FloorGridServiceTest {
         assertThat(reloaded.getGridRows()).isEqualTo(30);
         assertThat(reloaded.getGridColumns()).isEqualTo(40);
     }
+
+    @Test
+    void getGridCells_returnsRequestedPageOnly() {
+        floorGridService.createOrRegenerateGrid(
+                floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+
+        var firstPage = floorGridService.getGridCells(floor.getId(), 0, 100);
+
+        assertThat(firstPage.content()).hasSize(100);
+        assertThat(firstPage.totalElements()).isEqualTo(1200);
+        assertThat(firstPage.totalPages()).isEqualTo(12);
+        assertThat(firstPage.first()).isTrue();
+        assertThat(firstPage.last()).isFalse();
+        assertThat(firstPage.content().get(0).rowIndex()).isZero();
+        assertThat(firstPage.content().get(0).columnIndex()).isZero();
+        assertThat(firstPage.content().get(99).rowIndex()).isEqualTo(2);
+        assertThat(firstPage.content().get(99).columnIndex()).isEqualTo(19);
+    }
 }

--- a/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
@@ -78,6 +78,31 @@ class SecurityAuthorizationIntegrationTest {
     }
 
     @Test
+    @DisplayName("일반 사용자는 관리자용 GridCell 원본 목록을 조회할 수 없다")
+    void normalUserCannotReadFloorGridCells() throws Exception {
+        String token = signupAndLogin(UserRole.NORMAL);
+
+        mockMvc.perform(
+                        get("/api/v1/floors/{floorId}/grid/cells", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("관리자는 GridCell 원본 목록 조회 엔드포인트에 접근할 수 있다")
+    void managerCanReadFloorGridCells() throws Exception {
+        String token = signupAndLogin(UserRole.MANAGER);
+
+        mockMvc.perform(
+                        get("/api/v1/floors/{floorId}/grid/cells", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
     @DisplayName("관리자는 건물을 등록할 수 있다")
     void managerCanWrite() throws Exception {
         String token =


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #64 
- Branch: feat/#64

## 주요 내용
### 1. CCTV와 GridCell 감시 영역 매핑

- CCTV가 감시하는 여러 FloorGridCell을 저장하는 CctvGridCell 엔티티를 추가했습니다.
- cctv_id와 grid_cell_id 조합에 유니크 제약을 적용했습니다.
- CCTV 또는 GridCell 삭제 시 관련 매핑도 함께 삭제되도록 구성했습니다.
- 기존 Cctv와 FloorGridCell 엔티티에는 양방향 컬렉션을 추가하지 않았습니다.

### 2. CCTV 등록 API

- CCTV 등록 시 도면 내 설치 좌표와 감시 GridCell 목록을 함께 받도록 구현했습니다.

등록 과정에서 다음 데이터를 하나의 트랜잭션으로 저장합니다.

1. MapNode.createCustom(...)을 이용한 CCTV 설치 위치 노드
2. Cctv
3. CctvGridCell 목록

GridCell 검증에 실패하면 MapNode와 CCTV 저장도 함께 롤백됩니다.

### 3. 등록 데이터 검증

- x와 y는 0.0 이상 1.0 이하의 정규화 좌표만 허용합니다.
- GridCell 목록은 비어 있을 수 없습니다.
- 중복된 GridCell ID를 허용하지 않습니다.
- 존재하지 않는 GridCell을 허용하지 않습니다.
- CCTV와 다른 층에 속한 GridCell을 허용하지 않습니다.
- walkable=false인 GridCell을 감시 영역으로 설정할 수 없습니다.
- Floor.gridCellSizeMeter가 없거나 0 이하인 층에는 CCTV를 등록할 수 없습니다.

### 4. CCTV 식별 코드 생성

- count()+1 방식에서 발생할 수 있는 동시 등록 충돌을 피하기 위해 UUID 일부를 사용합니다.
- 생성 형식: CCTV_{8자리 식별자}
- Cctv.code의 기존 unique 제약을 유지합니다.

예시:

    CCTV_A1B2C3D4

### 5. CCTV 조회 및 상태 변경 API

다음 API를 추가했습니다.

- POST /api/v1/cctvs
  - CCTV와 최초 감시 영역 등록
- GET /api/v1/cctvs
  - 전체 CCTV 목록 조회
- GET /api/v1/cctvs?floorId={FLOOR_UUID}
  - 층별 CCTV 목록 조회
- GET /api/v1/cctvs/{cctvId}
  - CCTV 상세 조회
- GET /api/v1/cctvs/{cctvId}/grid-cells
  - CCTV 감시 영역 조회
- PUT /api/v1/cctvs/{cctvId}/grid-cells
  - 기존 감시 GridCell 목록을 새 목록으로 전체 교체
- PATCH /api/v1/cctvs/{cctvId}/enable
  - CCTV 활성화
- PATCH /api/v1/cctvs/{cctvId}/disable
  - CCTV 비활성화

### 6. 프론트 GridCell 선택용 API

프론트가 CCTV 등록 전에 도면의 GridCell UUID를 조회하고 선택할 수 있도록 다음 API를 추가했습니다.

    GET /api/v1/floors/{floorId}/grid/cells

응답에는 다음 정보가 포함됩니다.

- GridCell UUID
- rowIndex
- columnIndex
- walkable
- fired
- centerX
- centerY

프론트 사용 흐름:

1. 층별 GridCell 목록 조회
2. 도면 위 격자 렌더링
3. 관리자가 CCTV 설치 위치를 클릭해 x/y 결정
4. CCTV가 감시할 GridCell 여러 개 선택
5. x/y와 gridCellIds를 CCTV 등록 API로 함께 전송
6. 등록 응답으로 CCTV 아이콘과 선택 영역을 다시 렌더링

### 7. 감시 면적 계산

감시 면적은 Python이나 프론트가 전달하지 않고 BE가 계산합니다.

계산 방식:

    한 셀 면적 = gridCellSizeMeter × gridCellSizeMeter
    CCTV 감시 면적 = 한 셀 면적 × 연결된 GridCell 개수

예시:

    gridCellSizeMeter = 0.5m
    GridCell 개수 = 3개
    monitoredAreaM2 = 0.5 × 0.5 × 3 = 0.75㎡

monitoredAreaM2는 계산값이며 PostgreSQL에 별도 컬럼으로 중복 저장하지 않습니다.

### 8. 등록 및 조회 응답

응답에는 다음 정보가 포함됩니다.

- CCTV ID
- Raspberry Pi가 사용할 CCTV 논리 코드
- CCTV 이름
- Floor ID
- CUSTOM MapNode ID
- 도면 내 x/y 좌표
- 활성화 여부
- GridCell 한 변의 실제 길이
- 감시 GridCell 개수
- 계산된 전체 감시 면적
- 감시 GridCell 상세 목록

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * CCTV 등록, 목록·상세 조회, 활성화·비활성화를 지원합니다.
  * CCTV별 감시 영역(GridCell) 설정 및 조회를 제공합니다.
  * 층별 그리드 셀 목록을 페이지 단위로 조회할 수 있습니다.
  * CCTV와 그리드 셀의 층 일치, 중복, 보행 가능 여부를 검증합니다.

* **테스트**
  * CCTV API, 등록·검증·감시 영역 설정 및 페이지네이션 시나리오를 테스트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->