### PR TITLE
feat(floor): 층 정보 수정(PATCH) API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
+++ b/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.floor.controller;
 
 import com.saferoute.domain.floor.dto.request.CreateFloorRequest;
+import com.saferoute.domain.floor.dto.request.UpdateFloorRequest;
 import com.saferoute.domain.floor.dto.request.UploadFloorRequest;
 import com.saferoute.domain.floor.dto.response.FloorResponse;
 import com.saferoute.domain.floor.service.FloorService;
@@ -61,6 +62,17 @@ public class FloorController {
             @PathVariable UUID floorId
     ) {
         return ResponseEntity.ok(ApiResponse.success(FloorSuccessCode.FLOOR_DETAIL_FOUND, floorService.getFloor(buildingId, floorId)));
+    }
+
+    // 층 정보 수정
+    @PatchMapping("/{floorId}")
+    public ResponseEntity<ApiResponse<FloorResponse>> updateFloor(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID floorId,
+            @Valid @RequestBody UpdateFloorRequest request
+    ) {
+        FloorResponse response = floorService.updateFloor(buildingId, floorId, request);
+        return ResponseEntity.ok(ApiResponse.success(FloorSuccessCode.FLOOR_UPDATED, response));
     }
 
     // 도면 삭제

--- a/src/main/java/com/saferoute/domain/floor/dto/request/UpdateFloorRequest.java
+++ b/src/main/java/com/saferoute/domain/floor/dto/request/UpdateFloorRequest.java
@@ -1,0 +1,8 @@
+package com.saferoute.domain.floor.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+// 층 정보 수정 요청
+public record UpdateFloorRequest(
+        @NotNull Integer floorNum
+) {}

--- a/src/main/java/com/saferoute/domain/floor/entity/Floor.java
+++ b/src/main/java/com/saferoute/domain/floor/entity/Floor.java
@@ -93,6 +93,10 @@ public class Floor {
     return new Floor(building, floorNum);
   }
 
+  public void updateFloorNum(Integer floorNum) {
+    this.floorNum = floorNum;
+  }
+
   public void updateSegmentationStatus(SegmentationStatus status) {
     this.segmentationStatus = status;
   }

--- a/src/main/java/com/saferoute/domain/floor/service/FloorService.java
+++ b/src/main/java/com/saferoute/domain/floor/service/FloorService.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.analysis.service.FloorAnalysisService;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.floor.dto.request.CreateFloorRequest;
+import com.saferoute.domain.floor.dto.request.UpdateFloorRequest;
 import com.saferoute.domain.floor.dto.request.UploadFloorRequest;
 import com.saferoute.domain.floor.dto.response.FloorResponse;
 import com.saferoute.domain.floor.entity.Floor;
@@ -73,6 +74,19 @@ public class FloorService {
             s3Service.upload(request.file());
 
         floor.upload(request.realHeight(), request.realWidth(), uploadResult.key());
+
+        return FloorResponse.from(floor);
+    }
+
+    @Transactional
+    public FloorResponse updateFloor(UUID buildingId, UUID floorId, UpdateFloorRequest request) {
+        Floor floor = findFloor(buildingId, floorId);
+
+        if (!floor.getFloorNum().equals(request.floorNum())) {
+            validateDuplicateFloorNum(buildingId, request.floorNum());
+        }
+
+        floor.updateFloorNum(request.floorNum());
 
         return FloorResponse.from(floor);
     }

--- a/src/main/java/com/saferoute/global/api/response/FloorSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/FloorSuccessCode.java
@@ -12,7 +12,8 @@ public enum FloorSuccessCode implements BaseCode {
     FLOOR_CREATED(HttpStatus.CREATED, "FLOOR_SUCCESS_001", "도면 등록에 성공했습니다."),
     FLOOR_LIST_FOUND(HttpStatus.OK, "FLOOR_SUCCESS_002", "도면 목록 조회에 성공했습니다."),
     FLOOR_DETAIL_FOUND(HttpStatus.OK, "FLOOR_SUCCESS_003", "도면 상세 조회에 성공했습니다."),
-    FLOOR_DELETED(HttpStatus.OK, "FLOOR_SUCCESS_004", "도면이 삭제되었습니다.");
+    FLOOR_DELETED(HttpStatus.OK, "FLOOR_SUCCESS_004", "도면이 삭제되었습니다."),
+    FLOOR_UPDATED(HttpStatus.OK, "FLOOR_SUCCESS_005", "도면 정보 수정에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #66
- Branch: feature/66-floor-update

## 주요 내용

- Floor(층) 정보 수정을 위한 PATCH API 구현 (`PATCH /api/v1/buildings/{buildingId}/floors/{floorId}`)
- `UpdateFloorRequest` DTO 추가
- `Floor` 엔티티에 `updateFloorNum()` 메서드 추가
- `FloorService.updateFloor()` 구현 — floorNum 변경 시에만 중복 검증(`DUPLICATE_FLOOR_NUM`) 수행
- `FloorSuccessCode.FLOOR_UPDATED` 응답 코드 추가

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 건물에 속한 특정 층의 층 번호를 수정할 수 있는 API를 추가했습니다.
  * 층 번호가 누락되지 않도록 요청 검증을 적용했습니다.
  * 동일 건물 내 층 번호 중복을 확인한 후 변경합니다.
  * 층 정보 수정 성공 응답을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->