### PR TITLE
[Fix] #72 배포 환경 프록시 HTTPS 및 업로드 설정 개선

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,12 +9,15 @@ services:
       ai:
         condition: service_healthy
     ports:
-      - "8080:8080"
+      # 호스트 Nginx만 애플리케이션에 접근하도록 외부 인터페이스 노출을 차단한다.
+      - "127.0.0.1:8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
 
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       JWT_ACCESS_TOKEN_EXPIRATION: ${JWT_ACCESS_TOKEN_EXPIRATION:-1h}
+      MAX_FILE_SIZE: ${MAX_FILE_SIZE:-50MB}
+      MAX_REQUEST_SIZE: ${MAX_REQUEST_SIZE:-50MB}
 
       DB_URL: ${DB_URL:?DB_URL is required}
       DB_USERNAME: ${DB_USERNAME:?DB_USERNAME is required}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,6 @@
+server:
+  forward-headers-strategy: framework
+
 spring:
   datasource:
     url: ${DB_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
   profiles:
     default: local
 
+  servlet:
+    multipart:
+      max-file-size: ${MAX_FILE_SIZE:50MB}
+      max-request-size: ${MAX_REQUEST_SIZE:50MB}
+
   jpa:
     open-in-view: false
     properties:

--- a/src/test/java/com/saferoute/global/config/ForwardedHeaderIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/config/ForwardedHeaderIntegrationTest.java
@@ -1,0 +1,32 @@
+package com.saferoute.global.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = "server.forward-headers-strategy=framework")
+@AutoConfigureMockMvc
+class ForwardedHeaderIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("OpenAPI 서버 URL은 리버스 프록시가 전달한 HTTPS 주소를 사용한다")
+    void openApiUsesForwardedHttpsOrigin() throws Exception {
+        mockMvc.perform(get("/v3/api-docs")
+                        .header("X-Forwarded-Proto", "https")
+                        .header("X-Forwarded-Host", "api.ds-saferoute.site")
+                        .header("X-Forwarded-Port", "443"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.servers[0].url")
+                        .value("https://api.ds-saferoute.site"));
+    }
+}


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #72
- Branch: `fix/#72`

## 주요 내용

- 운영 환경에서 Forwarded Header 처리 활성화
  - `server.forward-headers-strategy: framework`
  - Nginx에서 전달한 HTTPS 프로토콜과 호스트 정보를 Spring Boot가 인식하도록 설정
  - Swagger API 요청이 `http://`로 생성되어 Mixed Content로 차단되는 문제 해결
- multipart 업로드 제한을 50MB로 설정
  - `MAX_FILE_SIZE`
  - `MAX_REQUEST_SIZE`
  - 환경변수를 통해 제한 크기 변경 가능
- 운영 애플리케이션 포트를 루프백 인터페이스로 제한
  - 기존: `8080:8080`
  - 변경: `127.0.0.1:8080:8080`
  - 외부에서 Nginx를 우회해 Spring Boot에 직접 접근하는 경로 차단
- Forwarded Header 통합 테스트 추가
  - `X-Forwarded-Proto: https`
  - `X-Forwarded-Host: api.ds-saferoute.site`
  - OpenAPI 서버 URL이 `https://api.ds-saferoute.site`로 생성되는지 검증

## 테스트

- Forwarded Header OpenAPI 통합 테스트 통과
- Docker Compose 설정 검사 통과
- `./gradlew clean build` 성공
- 전체 241개 테스트 통과
- 실패 테스트 0개

## 확인 사항

- [x] Swagger API 요청 URL이 HTTPS로 생성되는지 테스트
- [x] multipart 업로드 제한 설정
- [x] 운영 애플리케이션 포트 외부 노출 제한
- [x] Docker Compose 설정 검사
- [x] 전체 테스트 통과
- [x] `./gradlew clean build` 성공
- [x] Reviewers 등록
- [ ] CI 정상 동작 확인