### PR TITLE
[FEAT] #77: Raspberry Pi 디바이스 인증 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionController.java
@@ -3,30 +3,36 @@ package com.saferoute.domain.congestion.controller;
 import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
 import com.saferoute.domain.congestion.dto.response.ObservationResponse;
 import com.saferoute.domain.congestion.service.CongestionEventService;
+import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
+import com.saferoute.global.security.DevicePrincipal;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 @Tag(name = "혼잡도", description = "CCTV 혼잡 이벤트 수신 API")
 @RestController
-@RequestMapping("/api/v1/congestion-events")
+@RequestMapping("/api/v1/device/congestion-events")
 @RequiredArgsConstructor
 public class CongestionController {
 
     private final CongestionEventService congestionEventService;
+    private final DeviceAuthorizationService deviceAuthorizationService;
 
     @PostMapping
     public ResponseEntity<ObservationResponse> reportCongestion(
+            @AuthenticationPrincipal DevicePrincipal principal,
             @Valid @RequestBody ReportCongestionRequest request
     ) {
+        deviceAuthorizationService.validateCctv(principal, request.cctvCode());
         IdempotentSaveResult<ObservationItem> saveResult = congestionEventService.reportCongestion(request);
         ObservationResponse response = ObservationResponse.from(saveResult.item());
         HttpStatus status = saveResult.created() ? HttpStatus.CREATED : HttpStatus.OK;

--- a/src/main/java/com/saferoute/domain/device/controller/CctvController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/CctvController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.device.controller;
 import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.service.CctvService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.CctvSuccessCode;
@@ -31,10 +32,10 @@ public class CctvController {
     private final CctvService cctvService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<CctvResponse>> createCctv(
+    public ResponseEntity<ApiResponse<CctvRegistrationResponse>> createCctv(
             @Valid @RequestBody CreateCctvRequest request
     ) {
-        CctvResponse response = cctvService.createCctv(request);
+        CctvRegistrationResponse response = cctvService.createCctv(request);
         return ResponseEntity.status(CctvSuccessCode.CCTV_CREATED.getHttpStatus())
                 .body(ApiResponse.success(CctvSuccessCode.CCTV_CREATED, response));
     }

--- a/src/main/java/com/saferoute/domain/device/controller/CctvController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/CctvController.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
 import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
+import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
 import com.saferoute.domain.device.service.CctvService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.CctvSuccessCode;
@@ -38,6 +39,13 @@ public class CctvController {
         CctvRegistrationResponse response = cctvService.createCctv(request);
         return ResponseEntity.status(CctvSuccessCode.CCTV_CREATED.getHttpStatus())
                 .body(ApiResponse.success(CctvSuccessCode.CCTV_CREATED, response));
+    }
+
+    @PostMapping("/{cctvId}/device-token")
+    public ResponseEntity<ApiResponse<DeviceTokenIssueResponse>> issueDeviceToken(
+            @PathVariable UUID cctvId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(cctvService.issueDeviceToken(cctvId)));
     }
 
     @GetMapping

--- a/src/main/java/com/saferoute/domain/device/dto/response/CctvRegistrationResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/CctvRegistrationResponse.java
@@ -1,0 +1,7 @@
+package com.saferoute.domain.device.dto.response;
+
+public record CctvRegistrationResponse(
+        CctvResponse cctv,
+        String deviceToken
+) {
+}

--- a/src/main/java/com/saferoute/domain/device/dto/response/DeviceTokenIssueResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/DeviceTokenIssueResponse.java
@@ -1,0 +1,6 @@
+package com.saferoute.domain.device.dto.response;
+
+public record DeviceTokenIssueResponse(
+        String deviceToken
+) {
+}

--- a/src/main/java/com/saferoute/domain/device/entity/Cctv.java
+++ b/src/main/java/com/saferoute/domain/device/entity/Cctv.java
@@ -48,6 +48,9 @@ public class Cctv {
     @Column(name = "enabled", nullable = false)
     private boolean enabled;
 
+    @Column(name = "device_token_hash", length = 64, unique = true)
+    private String deviceTokenHash;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -85,6 +88,16 @@ public class Cctv {
 
     public void enable() {
         this.enabled = true;
+    }
+
+    public void issueDeviceToken(String deviceTokenHash) {
+        if (deviceTokenHash == null || deviceTokenHash.isBlank()) {
+            throw new IllegalArgumentException("디바이스 토큰 해시는 필수입니다.");
+        }
+        if (this.deviceTokenHash != null) {
+            throw new IllegalStateException("디바이스 토큰은 이미 발급되었습니다.");
+        }
+        this.deviceTokenHash = deviceTokenHash;
     }
 
     // FK만으로는 NodeType을 강제할 수 없으므로 생성/변경 시점에 도메인 레벨에서 검증한다.

--- a/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
@@ -27,6 +27,8 @@ public interface CctvJpaRepository extends JpaRepository<Cctv, UUID> {
     // 라즈베리파이가 보내온 code 로 기기 식별 (전역 unique)
     Optional<Cctv> findByCode(String code);
 
+    Optional<Cctv> findByDeviceTokenHash(String deviceTokenHash);
+
     boolean existsByCode(String code);
 
     Optional<Cctv> findByCustomNode_Id(UUID customNodeId);

--- a/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
@@ -1,11 +1,13 @@
 package com.saferoute.domain.device.repository;
 
 import com.saferoute.domain.device.entity.Cctv;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,6 +30,10 @@ public interface CctvJpaRepository extends JpaRepository<Cctv, UUID> {
     Optional<Cctv> findByCode(String code);
 
     Optional<Cctv> findByDeviceTokenHash(String deviceTokenHash);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select cctv from Cctv cctv where cctv.id = :cctvId")
+    Optional<Cctv> findByIdForDeviceTokenIssue(@Param("cctvId") UUID cctvId);
 
     boolean existsByCode(String code);
 

--- a/src/main/java/com/saferoute/domain/device/service/CctvRegistrationService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvRegistrationService.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.device.service;
 
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
@@ -16,6 +17,7 @@ import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.CctvErrorCode;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DeviceTokenService;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -34,11 +36,12 @@ public class CctvRegistrationService {
     private final FloorGridCellRepository floorGridCellRepository;
     private final MapNodeJpaRepository mapNodeJpaRepository;
     private final FloorRepository floorRepository;
+    private final DeviceTokenService deviceTokenService;
 
     // MapNode/Cctv/매핑 저장은 하나의 트랜잭션으로 처리한다.
     // CCTV 코드는 호출 전에 독립 트랜잭션의 DB sequence로 이미 발급된다.
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public CctvResponse register(CreateCctvRequest request, String code) {
+    public CctvRegistrationResponse register(CreateCctvRequest request, String code) {
         Floor floor = floorRepository.findById(request.floorId())
                 .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
         validateGridConfigured(floor);
@@ -55,14 +58,20 @@ public class CctvRegistrationService {
                         CustomDeviceType.CCTV
                 )
         );
-        Cctv cctv = cctvJpaRepository.save(Cctv.create(code, request.name(), customNode));
+        DeviceTokenService.IssuedDeviceToken issuedToken = deviceTokenService.issue();
+        Cctv cctv = Cctv.create(code, request.name(), customNode);
+        cctv.issueDeviceToken(issuedToken.hash());
+        Cctv savedCctv = cctvJpaRepository.save(cctv);
         cctvGridCellRepository.saveAll(
                 gridCells.stream()
-                        .map(cell -> CctvGridCell.create(cctv, cell))
+                        .map(cell -> CctvGridCell.create(savedCctv, cell))
                         .toList()
         );
 
-        return CctvResponse.of(cctv, gridCells);
+        return new CctvRegistrationResponse(
+                CctvResponse.of(savedCctv, gridCells),
+                issuedToken.rawToken()
+        );
     }
 
     private List<FloorGridCell> findAndValidateGridCells(

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -44,7 +44,7 @@ public class CctvService {
 
     @Transactional
     public DeviceTokenIssueResponse issueDeviceToken(UUID cctvId) {
-        Cctv cctv = cctvJpaRepository.findById(cctvId)
+        Cctv cctv = cctvJpaRepository.findByIdForDeviceTokenIssue(cctvId)
                 .orElseThrow(() -> new ApiException(CctvErrorCode.CCTV_NOT_FOUND));
         if (cctv.getDeviceTokenHash() != null) {
             throw new ApiException(DeviceErrorCode.DEVICE_TOKEN_ALREADY_ISSUED);

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.device.service;
 import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
@@ -33,7 +34,7 @@ public class CctvService {
     private final CctvCodeAllocator cctvCodeAllocator;
     private final CctvRegistrationService cctvRegistrationService;
 
-    public CctvResponse createCctv(CreateCctvRequest request) {
+    public CctvRegistrationResponse createCctv(CreateCctvRequest request) {
         return cctvRegistrationService.register(request, cctvCodeAllocator.allocate());
     }
 

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
 import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
+import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
@@ -12,7 +13,9 @@ import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.global.api.error.CctvErrorCode;
+import com.saferoute.global.api.error.DeviceErrorCode;
 import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DeviceTokenService;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
@@ -33,9 +36,23 @@ public class CctvService {
     private final FloorGridCellRepository floorGridCellRepository;
     private final CctvCodeAllocator cctvCodeAllocator;
     private final CctvRegistrationService cctvRegistrationService;
+    private final DeviceTokenService deviceTokenService;
 
     public CctvRegistrationResponse createCctv(CreateCctvRequest request) {
         return cctvRegistrationService.register(request, cctvCodeAllocator.allocate());
+    }
+
+    @Transactional
+    public DeviceTokenIssueResponse issueDeviceToken(UUID cctvId) {
+        Cctv cctv = cctvJpaRepository.findById(cctvId)
+                .orElseThrow(() -> new ApiException(CctvErrorCode.CCTV_NOT_FOUND));
+        if (cctv.getDeviceTokenHash() != null) {
+            throw new ApiException(DeviceErrorCode.DEVICE_TOKEN_ALREADY_ISSUED);
+        }
+
+        DeviceTokenService.IssuedDeviceToken issuedToken = deviceTokenService.issue();
+        cctv.issueDeviceToken(issuedToken.hash());
+        return new DeviceTokenIssueResponse(issuedToken.rawToken());
     }
 
     public List<CctvResponse> getCctvs(UUID floorId) {

--- a/src/main/java/com/saferoute/domain/device/service/DeviceAuthorizationService.java
+++ b/src/main/java/com/saferoute/domain/device/service/DeviceAuthorizationService.java
@@ -1,0 +1,28 @@
+package com.saferoute.domain.device.service;
+
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.global.api.error.CctvErrorCode;
+import com.saferoute.global.api.error.DeviceErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DevicePrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeviceAuthorizationService {
+
+    private final CctvJpaRepository cctvJpaRepository;
+
+    public void validateCctv(DevicePrincipal principal, String requestedCctvCode) {
+        Cctv requestedCctv = cctvJpaRepository.findByCode(requestedCctvCode)
+                .orElseThrow(() -> new ApiException(CctvErrorCode.CCTV_NOT_FOUND));
+
+        if (!requestedCctv.getId().equals(principal.cctvId())) {
+            throw new ApiException(DeviceErrorCode.CCTV_CODE_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/service/DeviceAuthorizationService.java
+++ b/src/main/java/com/saferoute/domain/device/service/DeviceAuthorizationService.java
@@ -24,5 +24,8 @@ public class DeviceAuthorizationService {
         if (!requestedCctv.getId().equals(principal.cctvId())) {
             throw new ApiException(DeviceErrorCode.CCTV_CODE_MISMATCH);
         }
+        if (!requestedCctv.isEnabled()) {
+            throw new ApiException(DeviceErrorCode.CCTV_DISABLED);
+        }
     }
 }

--- a/src/main/java/com/saferoute/global/api/error/DeviceErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/DeviceErrorCode.java
@@ -12,7 +12,8 @@ public enum DeviceErrorCode implements BaseErrorCode {
     DEVICE_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "DEVICE001", "디바이스 토큰이 필요합니다."),
     INVALID_DEVICE_TOKEN(HttpStatus.UNAUTHORIZED, "DEVICE002", "유효하지 않은 디바이스 토큰입니다."),
     CCTV_CODE_MISMATCH(HttpStatus.FORBIDDEN, "DEVICE003", "인증된 CCTV와 요청한 CCTV가 일치하지 않습니다."),
-    CCTV_DISABLED(HttpStatus.FORBIDDEN, "DEVICE004", "비활성화된 CCTV입니다.");
+    CCTV_DISABLED(HttpStatus.FORBIDDEN, "DEVICE004", "비활성화된 CCTV입니다."),
+    DEVICE_TOKEN_ALREADY_ISSUED(HttpStatus.CONFLICT, "DEVICE005", "디바이스 토큰이 이미 발급되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/api/error/DeviceErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/DeviceErrorCode.java
@@ -1,0 +1,20 @@
+package com.saferoute.global.api.error;
+
+import com.saferoute.global.api.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum DeviceErrorCode implements BaseErrorCode {
+
+    DEVICE_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "DEVICE001", "디바이스 토큰이 필요합니다."),
+    INVALID_DEVICE_TOKEN(HttpStatus.UNAUTHORIZED, "DEVICE002", "유효하지 않은 디바이스 토큰입니다."),
+    CCTV_CODE_MISMATCH(HttpStatus.FORBIDDEN, "DEVICE003", "인증된 CCTV와 요청한 CCTV가 일치하지 않습니다."),
+    CCTV_DISABLED(HttpStatus.FORBIDDEN, "DEVICE004", "비활성화된 CCTV입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
@@ -14,7 +14,7 @@ public enum TrainingErrorCode implements BaseErrorCode {
     TRAINING_SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "TRAINING003", "훈련 시나리오를 찾을 수 없습니다."),
     INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, "TRAINING004", "현재 상태에서는 요청한 전이를 수행할 수 없습니다."),
     UNSUPPORTED_STATUS(HttpStatus.CONFLICT, "TRAINING005", "지원하지 않는 훈련 상태입니다."),
-    RUNNING_TRAINING_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND,"TRAINING006", "진행 중인 훈련 세션을 찾을 수 없습니다.");
+    RUNNING_TRAINING_SESSION_NOT_FOUND(HttpStatus.CONFLICT,"TRAINING006", "진행 중인 훈련 세션을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -1,7 +1,10 @@
 package com.saferoute.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
 import com.saferoute.global.security.CustomUserDetailsService;
 import com.saferoute.global.security.DeviceAuthenticationFilter;
+import com.saferoute.global.security.DeviceTokenService;
 import com.saferoute.global.security.JwtAccessDeniedHandler;
 import com.saferoute.global.security.JwtAuthenticationEntryPoint;
 import com.saferoute.global.security.JwtAuthenticationFilter;
@@ -30,7 +33,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final DeviceAuthenticationFilter deviceAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
@@ -38,8 +40,18 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
             AuthenticationProvider authenticationProvider,
-            CorsConfigurationSource corsConfigurationSource
+            CorsConfigurationSource corsConfigurationSource,
+            DeviceTokenService deviceTokenService,
+            CctvJpaRepository cctvJpaRepository,
+            ObjectMapper objectMapper
     ) throws Exception {
+
+        DeviceAuthenticationFilter deviceAuthenticationFilter =
+                new DeviceAuthenticationFilter(
+                        deviceTokenService,
+                        cctvJpaRepository,
+                        objectMapper
+                );
 
         return http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.saferoute.global.config;
 
 import com.saferoute.global.security.CustomUserDetailsService;
+import com.saferoute.global.security.DeviceAuthenticationFilter;
 import com.saferoute.global.security.JwtAccessDeniedHandler;
 import com.saferoute.global.security.JwtAuthenticationEntryPoint;
 import com.saferoute.global.security.JwtAuthenticationFilter;
@@ -29,6 +30,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final DeviceAuthenticationFilter deviceAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
@@ -80,6 +82,8 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/actuator/**").authenticated()
 
+                        .requestMatchers("/api/v1/device/**").hasRole("DEVICE")
+
                         .requestMatchers(
                                 HttpMethod.PATCH,
                                 "/api/v1/users/me"
@@ -109,6 +113,11 @@ public class SecurityConfig {
                 )
 
                 .authenticationProvider(authenticationProvider)
+
+                .addFilterBefore(
+                        deviceAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class
+                )
 
                 .addFilterBefore(
                         jwtAuthenticationFilter,

--- a/src/main/java/com/saferoute/global/security/DeviceAuthenticationFilter.java
+++ b/src/main/java/com/saferoute/global/security/DeviceAuthenticationFilter.java
@@ -1,0 +1,92 @@
+package com.saferoute.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.global.api.code.BaseErrorCode;
+import com.saferoute.global.api.error.DeviceErrorCode;
+import com.saferoute.global.api.response.ApiResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class DeviceAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String DEVICE_PATH_PREFIX = "/api/v1/device/";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final DeviceTokenService deviceTokenService;
+    private final CctvJpaRepository cctvJpaRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return HttpMethod.OPTIONS.matches(request.getMethod())
+                || !request.getRequestURI().startsWith(DEVICE_PATH_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String rawToken = resolveToken(request);
+        if (rawToken == null) {
+            writeFailure(response, DeviceErrorCode.DEVICE_TOKEN_REQUIRED);
+            return;
+        }
+
+        Cctv cctv = cctvJpaRepository.findByDeviceTokenHash(deviceTokenService.hash(rawToken))
+                .orElse(null);
+        if (cctv == null) {
+            writeFailure(response, DeviceErrorCode.INVALID_DEVICE_TOKEN);
+            return;
+        }
+        if (!cctv.isEnabled()) {
+            writeFailure(response, DeviceErrorCode.CCTV_DISABLED);
+            return;
+        }
+
+        DevicePrincipal principal = new DevicePrincipal(cctv.getId(), cctv.getCode());
+        UsernamePasswordAuthenticationToken authentication =
+                UsernamePasswordAuthenticationToken.authenticated(
+                        principal,
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_DEVICE"))
+                );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        String token = authorization.substring(BEARER_PREFIX.length()).trim();
+        return token.isEmpty() ? null : token;
+    }
+
+    private void writeFailure(HttpServletResponse response, BaseErrorCode errorCode)
+            throws IOException {
+        SecurityContextHolder.clearContext();
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), ApiResponse.failure(errorCode));
+    }
+}

--- a/src/main/java/com/saferoute/global/security/DeviceAuthenticationFilter.java
+++ b/src/main/java/com/saferoute/global/security/DeviceAuthenticationFilter.java
@@ -12,17 +12,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
-@RequiredArgsConstructor
 public class DeviceAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String DEVICE_PATH_PREFIX = "/api/v1/device/";
@@ -31,6 +27,16 @@ public class DeviceAuthenticationFilter extends OncePerRequestFilter {
     private final DeviceTokenService deviceTokenService;
     private final CctvJpaRepository cctvJpaRepository;
     private final ObjectMapper objectMapper;
+
+    public DeviceAuthenticationFilter(
+            DeviceTokenService deviceTokenService,
+            CctvJpaRepository cctvJpaRepository,
+            ObjectMapper objectMapper
+    ) {
+        this.deviceTokenService = deviceTokenService;
+        this.cctvJpaRepository = cctvJpaRepository;
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {

--- a/src/main/java/com/saferoute/global/security/DevicePrincipal.java
+++ b/src/main/java/com/saferoute/global/security/DevicePrincipal.java
@@ -1,0 +1,9 @@
+package com.saferoute.global.security;
+
+import java.util.UUID;
+
+public record DevicePrincipal(
+        UUID cctvId,
+        String cctvCode
+) {
+}

--- a/src/main/java/com/saferoute/global/security/DeviceTokenService.java
+++ b/src/main/java/com/saferoute/global/security/DeviceTokenService.java
@@ -1,0 +1,37 @@
+package com.saferoute.global.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeviceTokenService {
+
+    private static final int TOKEN_BYTES = 32;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public IssuedDeviceToken issue() {
+        byte[] tokenBytes = new byte[TOKEN_BYTES];
+        secureRandom.nextBytes(tokenBytes);
+        String rawToken = Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes);
+        return new IssuedDeviceToken(rawToken, hash(rawToken));
+    }
+
+    public String hash(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(
+                    digest.digest(rawToken.getBytes(StandardCharsets.UTF_8))
+            );
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", exception);
+        }
+    }
+
+    public record IssuedDeviceToken(String rawToken, String hash) {
+    }
+}

--- a/src/main/java/com/saferoute/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/saferoute/global/security/JwtAuthenticationFilter.java
@@ -23,6 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String WEBSOCKET_PATH_PREFIX = "/ws";
+    private static final String DEVICE_PATH_PREFIX = "/api/v1/device/";
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AccessTokenRevocationService accessTokenRevocationService;
@@ -34,7 +35,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // STOMP 레이어까지 요청이 도달하지 못한다.
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return request.getRequestURI().startsWith(WEBSOCKET_PATH_PREFIX);
+        String requestUri = request.getRequestURI();
+        return requestUri.startsWith(WEBSOCKET_PATH_PREFIX)
+                || requestUri.startsWith(DEVICE_PATH_PREFIX);
     }
 
     @Override

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.congestion.service.CongestionEventService;
+import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.global.api.error.EvacuationErrorCode;
@@ -18,6 +19,7 @@ import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.global.config.SecurityConfig;
 import com.saferoute.global.security.JwtAuthenticationFilter;
+import com.saferoute.global.security.DeviceAuthenticationFilter;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +36,11 @@ import org.springframework.test.web.servlet.MockMvc;
         controllers = CongestionController.class,
         excludeFilters = @ComponentScan.Filter(
                 type = FilterType.ASSIGNABLE_TYPE,
-                classes = {JwtAuthenticationFilter.class, SecurityConfig.class}
+                classes = {
+                        JwtAuthenticationFilter.class,
+                        DeviceAuthenticationFilter.class,
+                        SecurityConfig.class
+                }
         )
 )
 @AutoConfigureMockMvc(addFilters = false)
@@ -52,6 +58,9 @@ class CongestionControllerTest {
     @MockitoBean
     private CongestionEventService congestionEventService;
 
+    @MockitoBean
+    private DeviceAuthorizationService deviceAuthorizationService;
+
     private ReportCongestionRequest validRequest() {
         return new ReportCongestionRequest(
                 UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
@@ -66,7 +75,7 @@ class CongestionControllerTest {
         given(congestionEventService.reportCongestion(any()))
                 .willReturn(IdempotentSaveResult.created(observation()));
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validRequest())))
                 .andExpect(status().isCreated())
@@ -80,7 +89,7 @@ class CongestionControllerTest {
         given(congestionEventService.reportCongestion(any()))
                 .willReturn(IdempotentSaveResult.existing(observation()));
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validRequest())))
                 .andExpect(status().isOk())
@@ -93,7 +102,7 @@ class CongestionControllerTest {
         ObjectNode body = objectMapper.valueToTree(validRequest());
         body.put("trainingSessionId", "123");
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isBadRequest());
@@ -105,7 +114,7 @@ class CongestionControllerTest {
         ObjectNode body = objectMapper.valueToTree(validRequest());
         body.remove("trainingSessionId");
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isBadRequest());
@@ -120,7 +129,7 @@ class CongestionControllerTest {
                 CongestionLevel.CROWDED, 1_000L, 2_000L, 2_000L, 1L, null
         );
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalid)))
                 .andExpect(status().isBadRequest());
@@ -135,7 +144,7 @@ class CongestionControllerTest {
                 CongestionLevel.CROWDED, 1_000L, 2_000L, 2_000L, 1L, null
         );
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalid)))
                 .andExpect(status().isBadRequest());
@@ -150,7 +159,7 @@ class CongestionControllerTest {
                 CongestionLevel.CROWDED, 1_000L, 2_000L, 2_000L, 1L, null
         );
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalid)))
                 .andExpect(status().isBadRequest());
@@ -165,7 +174,7 @@ class CongestionControllerTest {
                 CongestionLevel.CROWDED, 1_000L, 2_000L, 2_000L, 1L, null
         );
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalid)))
                 .andExpect(status().isBadRequest());
@@ -180,7 +189,7 @@ class CongestionControllerTest {
                 CongestionLevel.CROWDED, 2_000L, 1_000L, 2_000L, 1L, null
         );
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalid)))
                 .andExpect(status().isBadRequest());
@@ -192,22 +201,22 @@ class CongestionControllerTest {
         given(congestionEventService.reportCongestion(any()))
                 .willThrow(new ApiException(EvacuationErrorCode.MAP_EDGE_NOT_FOUND));
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validRequest())))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    @DisplayName("진행 중인 훈련 세션이 없으면 공통 에러 코드와 404를 반환한다")
-    void reportCongestion_returnsNotFoundWhenRunningSessionMissing() throws Exception {
+    @DisplayName("진행 중인 훈련 세션이 없으면 공통 에러 코드와 409를 반환한다")
+    void reportCongestion_returnsConflictWhenRunningSessionMissing() throws Exception {
         given(congestionEventService.reportCongestion(any()))
                 .willThrow(new ApiException(TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND));
 
-        mockMvc.perform(post("/api/v1/congestion-events")
+        mockMvc.perform(post("/api/v1/device/congestion-events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validRequest())))
-                .andExpect(status().isNotFound())
+                .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.isSuccess").value(false))
                 .andExpect(jsonPath("$.code").value("TRAINING006"));
     }

--- a/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
@@ -16,6 +16,7 @@ import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvGridCellResponse;
 import com.saferoute.domain.device.dto.response.CctvResponse;
 import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
+import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
 import com.saferoute.domain.device.service.CctvService;
 import com.saferoute.global.config.SecurityConfig;
 import com.saferoute.global.security.JwtAuthenticationFilter;
@@ -76,6 +77,16 @@ class CctvControllerTest {
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void issueDeviceToken_returnsRawTokenOnce() throws Exception {
+        given(cctvService.issueDeviceToken(cctvId))
+                .willReturn(new DeviceTokenIssueResponse("device-token"));
+
+        mockMvc.perform(post("/api/v1/cctvs/{cctvId}/device-token", cctvId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.deviceToken").value("device-token"));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
@@ -15,6 +15,7 @@ import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvGridCellResponse;
 import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.service.CctvService;
 import com.saferoute.global.config.SecurityConfig;
 import com.saferoute.global.security.JwtAuthenticationFilter;
@@ -51,16 +52,19 @@ class CctvControllerTest {
     void createCctv_returnsCreatedCoverage() throws Exception {
         CreateCctvRequest request = new CreateCctvRequest(
                 "3층 복도 CCTV", floorId, 0.6, 0.4, List.of(cellId));
-        given(cctvService.createCctv(any())).willReturn(response(true));
+        given(cctvService.createCctv(any())).willReturn(
+                new CctvRegistrationResponse(response(true), "device-token")
+        );
 
         mockMvc.perform(post("/api/v1/cctvs")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.isSuccess").value(true))
-                .andExpect(jsonPath("$.result.x").value(0.6))
-                .andExpect(jsonPath("$.result.gridCells[0].id").value(cellId.toString()))
-                .andExpect(jsonPath("$.result.monitoredAreaM2").value(0.25));
+                .andExpect(jsonPath("$.result.cctv.x").value(0.6))
+                .andExpect(jsonPath("$.result.cctv.gridCells[0].id").value(cellId.toString()))
+                .andExpect(jsonPath("$.result.cctv.monitoredAreaM2").value(0.25))
+                .andExpect(jsonPath("$.result.deviceToken").value("device-token"));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/device/service/CctvDeviceTokenConcurrencyIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvDeviceTokenConcurrencyIntegrationTest.java
@@ -1,0 +1,133 @@
+package com.saferoute.domain.device.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.code.BaseErrorCode;
+import com.saferoute.global.api.error.DeviceErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DeviceTokenService;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CctvDeviceTokenConcurrencyIntegrationTest {
+
+    @Autowired CctvService cctvService;
+    @Autowired DeviceTokenService deviceTokenService;
+    @Autowired CctvJpaRepository cctvJpaRepository;
+    @Autowired MapNodeJpaRepository mapNodeJpaRepository;
+    @Autowired FloorRepository floorRepository;
+    @Autowired BuildingRepository buildingRepository;
+
+    @AfterEach
+    void cleanUp() {
+        cctvJpaRepository.deleteAllInBatch();
+        mapNodeJpaRepository.deleteAllInBatch();
+        floorRepository.deleteAllInBatch();
+        buildingRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void onlyOneConcurrentInitialTokenIssueSucceeds() throws Exception {
+        UUID cctvId = saveCctvWithoutToken().getId();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Callable<IssueAttempt> issue = () -> {
+            barrier.await(5, TimeUnit.SECONDS);
+            try {
+                return IssueAttempt.success(cctvService.issueDeviceToken(cctvId));
+            } catch (ApiException exception) {
+                return IssueAttempt.failure(exception.getErrorCode());
+            }
+        };
+
+        try {
+            Future<IssueAttempt> first = executor.submit(issue);
+            Future<IssueAttempt> second = executor.submit(issue);
+            List<IssueAttempt> attempts = List.of(
+                    first.get(10, TimeUnit.SECONDS),
+                    second.get(10, TimeUnit.SECONDS)
+            );
+
+            assertThat(attempts).filteredOn(IssueAttempt::succeeded).hasSize(1);
+            assertThat(attempts).filteredOn(attempt -> !attempt.succeeded())
+                    .singleElement()
+                    .extracting(IssueAttempt::errorCode)
+                    .isEqualTo(DeviceErrorCode.DEVICE_TOKEN_ALREADY_ISSUED);
+
+            String issuedRawToken = attempts.stream()
+                    .filter(IssueAttempt::succeeded)
+                    .findFirst()
+                    .orElseThrow()
+                    .response()
+                    .deviceToken();
+            Cctv savedCctv = cctvJpaRepository.findById(cctvId).orElseThrow();
+            assertThat(savedCctv.getDeviceTokenHash())
+                    .isEqualTo(deviceTokenService.hash(issuedRawToken));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private Cctv saveCctvWithoutToken() {
+        Building building = buildingRepository.saveAndFlush(Building.create(
+                "동시성관",
+                "서울특별시 안전구 동시성로 123",
+                1,
+                BuildingType.CLASSROOM
+        ));
+        Floor floor = floorRepository.saveAndFlush(Floor.create(building, 1));
+        MapNode node = mapNodeJpaRepository.saveAndFlush(MapNode.createCustom(
+                floor,
+                "CCTV_LOCK_TEST",
+                "동시성 테스트 CCTV",
+                0.5,
+                0.5,
+                CustomDeviceType.CCTV
+        ));
+        return cctvJpaRepository.saveAndFlush(Cctv.create(
+                "CCTV_LOCK_TEST",
+                "동시성 테스트 CCTV",
+                node
+        ));
+    }
+
+    private record IssueAttempt(
+            DeviceTokenIssueResponse response,
+            BaseErrorCode errorCode
+    ) {
+        static IssueAttempt success(DeviceTokenIssueResponse response) {
+            return new IssueAttempt(response, null);
+        }
+
+        static IssueAttempt failure(BaseErrorCode errorCode) {
+            return new IssueAttempt(null, errorCode);
+        }
+
+        boolean succeeded() {
+            return response != null;
+        }
+    }
+}

--- a/src/test/java/com/saferoute/domain/device/service/CctvRegistrationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvRegistrationServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
-import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
@@ -19,6 +19,7 @@ import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.CctvErrorCode;
 import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DeviceTokenService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,6 +39,7 @@ class CctvRegistrationServiceTest {
     @Mock FloorGridCellRepository floorGridCellRepository;
     @Mock MapNodeJpaRepository mapNodeJpaRepository;
     @Mock FloorRepository floorRepository;
+    @Mock DeviceTokenService deviceTokenService;
 
     private CctvRegistrationService service;
     private Floor floor;
@@ -50,7 +52,8 @@ class CctvRegistrationServiceTest {
                 cctvGridCellRepository,
                 floorGridCellRepository,
                 mapNodeJpaRepository,
-                floorRepository
+                floorRepository,
+                deviceTokenService
         );
         floor = org.mockito.Mockito.mock(Floor.class);
         floorId = UUID.randomUUID();
@@ -71,12 +74,16 @@ class CctvRegistrationServiceTest {
                 .willReturn(List.of(second, first));
         given(mapNodeJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
         given(cctvJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(deviceTokenService.issue()).willReturn(
+                new DeviceTokenService.IssuedDeviceToken("raw-token", "hashed-token")
+        );
 
-        CctvResponse response = service.register(request, "CCTV_001");
+        CctvRegistrationResponse response = service.register(request, "CCTV_001");
 
-        assertThat(response.code()).isEqualTo("CCTV_001");
-        assertThat(response.monitoredGridCellCount()).isEqualTo(2);
-        assertThat(response.gridCells()).extracting("id").containsExactly(firstId, secondId);
+        assertThat(response.cctv().code()).isEqualTo("CCTV_001");
+        assertThat(response.cctv().monitoredGridCellCount()).isEqualTo(2);
+        assertThat(response.cctv().gridCells()).extracting("id").containsExactly(firstId, secondId);
+        assertThat(response.deviceToken()).isEqualTo("raw-token");
         ArgumentCaptor<List<CctvGridCell>> mappings = ArgumentCaptor.forClass(List.class);
         verify(cctvGridCellRepository).saveAll(mappings.capture());
         assertThat(mappings.getValue()).hasSize(2);

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -79,7 +79,8 @@ class CctvServiceTest {
     void issueDeviceToken_success() {
         UUID cctvId = UUID.randomUUID();
         Cctv cctv = cctv(cctvId);
-        given(cctvJpaRepository.findById(cctvId)).willReturn(Optional.of(cctv));
+        given(cctvJpaRepository.findByIdForDeviceTokenIssue(cctvId))
+                .willReturn(Optional.of(cctv));
         given(deviceTokenService.issue()).willReturn(
                 new DeviceTokenService.IssuedDeviceToken("raw-token", "hashed-token")
         );
@@ -96,7 +97,8 @@ class CctvServiceTest {
         UUID cctvId = UUID.randomUUID();
         Cctv cctv = cctv(cctvId);
         given(cctv.getDeviceTokenHash()).willReturn("existing-hash");
-        given(cctvJpaRepository.findById(cctvId)).willReturn(Optional.of(cctv));
+        given(cctvJpaRepository.findByIdForDeviceTokenIssue(cctvId))
+                .willReturn(Optional.of(cctv));
 
         org.assertj.core.api.Assertions.assertThatThrownBy(
                         () -> cctvService.issueDeviceToken(cctvId)

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -11,6 +11,7 @@ import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
 import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
+import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
@@ -19,6 +20,9 @@ import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
 import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.global.api.error.DeviceErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DeviceTokenService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,6 +41,7 @@ class CctvServiceTest {
     @Mock FloorGridCellRepository floorGridCellRepository;
     @Mock CctvCodeAllocator cctvCodeAllocator;
     @Mock CctvRegistrationService cctvRegistrationService;
+    @Mock DeviceTokenService deviceTokenService;
 
     private CctvService cctvService;
 
@@ -47,7 +52,8 @@ class CctvServiceTest {
                 cctvGridCellRepository,
                 floorGridCellRepository,
                 cctvCodeAllocator,
-                cctvRegistrationService
+                cctvRegistrationService,
+                deviceTokenService
         );
     }
 
@@ -66,6 +72,41 @@ class CctvServiceTest {
                 org.mockito.ArgumentMatchers.eq(request),
                 org.mockito.ArgumentMatchers.eq("CCTV_001")
         );
+    }
+
+    @Test
+    @DisplayName("토큰이 없는 기존 CCTV에는 디바이스 토큰을 최초 1회 발급한다")
+    void issueDeviceToken_success() {
+        UUID cctvId = UUID.randomUUID();
+        Cctv cctv = cctv(cctvId);
+        given(cctvJpaRepository.findById(cctvId)).willReturn(Optional.of(cctv));
+        given(deviceTokenService.issue()).willReturn(
+                new DeviceTokenService.IssuedDeviceToken("raw-token", "hashed-token")
+        );
+
+        DeviceTokenIssueResponse response = cctvService.issueDeviceToken(cctvId);
+
+        assertThat(response.deviceToken()).isEqualTo("raw-token");
+        verify(cctv).issueDeviceToken("hashed-token");
+    }
+
+    @Test
+    @DisplayName("이미 토큰이 있는 CCTV에는 토큰을 다시 발급하지 않는다")
+    void issueDeviceToken_rejectsAlreadyIssuedToken() {
+        UUID cctvId = UUID.randomUUID();
+        Cctv cctv = cctv(cctvId);
+        given(cctv.getDeviceTokenHash()).willReturn("existing-hash");
+        given(cctvJpaRepository.findById(cctvId)).willReturn(Optional.of(cctv));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> cctvService.issueDeviceToken(cctvId)
+                )
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        DeviceErrorCode.DEVICE_TOKEN_ALREADY_ISSUED
+                );
+        verify(deviceTokenService, never()).issue();
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
+import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
@@ -54,11 +55,11 @@ class CctvServiceTest {
     @DisplayName("CCTV 등록 시 생성한 코드를 별도 트랜잭션 등록 서비스에 전달한다")
     void createCctv_success() {
         CreateCctvRequest request = request();
-        CctvResponse expected = org.mockito.Mockito.mock(CctvResponse.class);
+        CctvRegistrationResponse expected = org.mockito.Mockito.mock(CctvRegistrationResponse.class);
         given(cctvCodeAllocator.allocate()).willReturn("CCTV_001");
         given(cctvRegistrationService.register(any(), any())).willReturn(expected);
 
-        CctvResponse response = cctvService.createCctv(request);
+        CctvRegistrationResponse response = cctvService.createCctv(request);
 
         assertThat(response).isSameAs(expected);
         verify(cctvRegistrationService).register(

--- a/src/test/java/com/saferoute/domain/device/service/DeviceAuthorizationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/DeviceAuthorizationServiceTest.java
@@ -1,0 +1,63 @@
+package com.saferoute.domain.device.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.global.api.error.CctvErrorCode;
+import com.saferoute.global.api.error.DeviceErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DevicePrincipal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class DeviceAuthorizationServiceTest {
+
+    private final CctvJpaRepository repository = mock(CctvJpaRepository.class);
+    private final DeviceAuthorizationService service = new DeviceAuthorizationService(repository);
+
+    @Test
+    void allowsMatchingCctv() {
+        UUID cctvId = UUID.randomUUID();
+        Cctv cctv = cctv(cctvId);
+        given(repository.findByCode("CCTV_001")).willReturn(Optional.of(cctv));
+
+        assertThatCode(() -> service.validateCctv(
+                new DevicePrincipal(cctvId, "CCTV_001"),
+                "CCTV_001"
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsUnknownCctvCode() {
+        given(repository.findByCode("CCTV_999")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.validateCctv(
+                new DevicePrincipal(UUID.randomUUID(), "CCTV_001"),
+                "CCTV_999"
+        )).isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CctvErrorCode.CCTV_NOT_FOUND);
+    }
+
+    @Test
+    void rejectsDifferentCctv() {
+        Cctv requestedCctv = cctv(UUID.randomUUID());
+        given(repository.findByCode("CCTV_002")).willReturn(Optional.of(requestedCctv));
+
+        assertThatThrownBy(() -> service.validateCctv(
+                new DevicePrincipal(UUID.randomUUID(), "CCTV_001"),
+                "CCTV_002"
+        )).isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", DeviceErrorCode.CCTV_CODE_MISMATCH);
+    }
+
+    private Cctv cctv(UUID id) {
+        Cctv cctv = mock(Cctv.class);
+        given(cctv.getId()).willReturn(id);
+        return cctv;
+    }
+}

--- a/src/test/java/com/saferoute/domain/device/service/DeviceAuthorizationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/DeviceAuthorizationServiceTest.java
@@ -55,9 +55,24 @@ class DeviceAuthorizationServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", DeviceErrorCode.CCTV_CODE_MISMATCH);
     }
 
+    @Test
+    void rejectsCctvDisabledAfterAuthentication() {
+        UUID cctvId = UUID.randomUUID();
+        Cctv requestedCctv = cctv(cctvId);
+        given(requestedCctv.isEnabled()).willReturn(false);
+        given(repository.findByCode("CCTV_001")).willReturn(Optional.of(requestedCctv));
+
+        assertThatThrownBy(() -> service.validateCctv(
+                new DevicePrincipal(cctvId, "CCTV_001"),
+                "CCTV_001"
+        )).isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", DeviceErrorCode.CCTV_DISABLED);
+    }
+
     private Cctv cctv(UUID id) {
         Cctv cctv = mock(Cctv.class);
         given(cctv.getId()).willReturn(id);
+        given(cctv.isEnabled()).willReturn(true);
         return cctv;
     }
 }

--- a/src/test/java/com/saferoute/global/security/DeviceAuthenticationFilterTest.java
+++ b/src/test/java/com/saferoute/global/security/DeviceAuthenticationFilterTest.java
@@ -1,0 +1,121 @@
+package com.saferoute.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import jakarta.servlet.FilterChain;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class DeviceAuthenticationFilterTest {
+
+    private DeviceTokenService deviceTokenService;
+    private CctvJpaRepository cctvJpaRepository;
+    private DeviceAuthenticationFilter filter;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        deviceTokenService = mock(DeviceTokenService.class);
+        cctvJpaRepository = mock(CctvJpaRepository.class);
+        filter = new DeviceAuthenticationFilter(
+                deviceTokenService,
+                cctvJpaRepository,
+                new ObjectMapper()
+        );
+        filterChain = mock(FilterChain.class);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void rejectsRequestWithoutToken() throws Exception {
+        MockHttpServletResponse response = execute(null);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("DEVICE001");
+        verify(filterChain, never()).doFilter(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void rejectsUnknownToken() throws Exception {
+        given(deviceTokenService.hash("unknown")).willReturn("hash");
+        given(cctvJpaRepository.findByDeviceTokenHash("hash")).willReturn(Optional.empty());
+
+        MockHttpServletResponse response = execute("Bearer unknown");
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("DEVICE002");
+    }
+
+    @Test
+    void rejectsDisabledCctv() throws Exception {
+        Cctv cctv = cctv(false);
+        given(deviceTokenService.hash("token")).willReturn("hash");
+        given(cctvJpaRepository.findByDeviceTokenHash("hash")).willReturn(Optional.of(cctv));
+
+        MockHttpServletResponse response = execute("Bearer token");
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentAsString()).contains("DEVICE004");
+    }
+
+    @Test
+    void authenticatesEnabledCctv() throws Exception {
+        UUID cctvId = UUID.randomUUID();
+        Cctv cctv = cctv(true);
+        given(cctv.getId()).willReturn(cctvId);
+        given(cctv.getCode()).willReturn("CCTV_001");
+        given(deviceTokenService.hash("token")).willReturn("hash");
+        given(cctvJpaRepository.findByDeviceTokenHash("hash")).willReturn(Optional.of(cctv));
+
+        MockHttpServletResponse response = execute("Bearer token");
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        DevicePrincipal principal = (DevicePrincipal) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        assertThat(principal.cctvId()).isEqualTo(cctvId);
+        assertThat(principal.cctvCode()).isEqualTo("CCTV_001");
+        verify(filterChain).doFilter(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    private MockHttpServletResponse execute(String authorization) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                "POST",
+                "/api/v1/device/congestion-events"
+        );
+        if (authorization != null) {
+            request.addHeader("Authorization", authorization);
+        }
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, filterChain);
+        return response;
+    }
+
+    private Cctv cctv(boolean enabled) {
+        Cctv cctv = mock(Cctv.class);
+        given(cctv.isEnabled()).willReturn(enabled);
+        return cctv;
+    }
+}

--- a/src/test/java/com/saferoute/global/security/DeviceSecurityIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/DeviceSecurityIntegrationTest.java
@@ -1,0 +1,204 @@
+package com.saferoute.global.security;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.congestion.service.CongestionEventService;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class DeviceSecurityIntegrationTest {
+
+    private static final String DEVICE_API = "/api/v1/device/congestion-events";
+    private static final String RAW_TOKEN = "test-device-token";
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired DeviceTokenService deviceTokenService;
+    @Autowired BuildingRepository buildingRepository;
+    @Autowired FloorRepository floorRepository;
+    @Autowired MapNodeJpaRepository mapNodeJpaRepository;
+    @Autowired CctvJpaRepository cctvJpaRepository;
+
+    @MockitoBean CongestionEventService congestionEventService;
+
+    private Cctv authenticatedCctv;
+
+    @BeforeEach
+    void setUp() {
+        authenticatedCctv = saveCctv("CCTV_001", RAW_TOKEN, true);
+        given(congestionEventService.reportCongestion(any())).willAnswer(invocation -> {
+            ReportCongestionRequest request = invocation.getArgument(0);
+            ObservationItem item = ObservationItem.create(
+                    request.eventId(),
+                    request.trainingSessionId(),
+                    request.cctvCode(),
+                    request.avgHeadcount(),
+                    request.peakHeadcount(),
+                    request.sampleCount(),
+                    request.density(),
+                    request.congestionLevel(),
+                    request.windowStart(),
+                    request.windowEnd(),
+                    request.capturedAt(),
+                    request.monitoringImageKey(),
+                    request.configVersion()
+            );
+            return IdempotentSaveResult.created(item);
+        });
+    }
+
+    @Test
+    @DisplayName("정상 디바이스 토큰과 일치하는 CCTV 코드는 요청을 허용한다")
+    void allowsMatchingDeviceTokenAndCctvCode() throws Exception {
+        mockMvc.perform(post(DEVICE_API)
+                        .header("Authorization", "Bearer " + RAW_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request("CCTV_001")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.cctvCode").value("CCTV_001"));
+    }
+
+    @Test
+    @DisplayName("디바이스 토큰이 없으면 401을 반환한다")
+    void rejectsMissingToken() throws Exception {
+        mockMvc.perform(post(DEVICE_API)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request("CCTV_001")))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("DEVICE001"));
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 디바이스 토큰이면 401을 반환한다")
+    void rejectsUnknownToken() throws Exception {
+        mockMvc.perform(post(DEVICE_API)
+                        .header("Authorization", "Bearer unknown-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request("CCTV_001")))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("DEVICE002"));
+    }
+
+    @Test
+    @DisplayName("다른 CCTV 코드로 요청하면 403을 반환한다")
+    void rejectsDifferentCctvCode() throws Exception {
+        saveCctv("CCTV_002", "second-device-token", true);
+
+        mockMvc.perform(post(DEVICE_API)
+                        .header("Authorization", "Bearer " + RAW_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request("CCTV_002")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("DEVICE003"));
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 CCTV 코드로 요청하면 404를 반환한다")
+    void rejectsUnknownCctvCode() throws Exception {
+        mockMvc.perform(post(DEVICE_API)
+                        .header("Authorization", "Bearer " + RAW_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request("CCTV_999")))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CCTV001"));
+    }
+
+    @Test
+    @DisplayName("비활성 CCTV의 토큰이면 403을 반환한다")
+    void rejectsDisabledCctv() throws Exception {
+        authenticatedCctv.disable();
+        cctvJpaRepository.flush();
+
+        mockMvc.perform(post(DEVICE_API)
+                        .header("Authorization", "Bearer " + RAW_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request("CCTV_001")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("DEVICE004"));
+    }
+
+    @Test
+    @DisplayName("디바이스 토큰으로 관리자 API에 접근할 수 없다")
+    void deviceTokenCannotAccessAdminApi() throws Exception {
+        mockMvc.perform(get("/api/v1/buildings")
+                        .header("Authorization", "Bearer " + RAW_TOKEN))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("COMMON401"));
+    }
+
+    private Cctv saveCctv(String code, String rawToken, boolean enabled) {
+        Building building = buildingRepository.save(Building.create(
+                "테스트관",
+                "서울특별시 안전구 테스트로 123",
+                1,
+                BuildingType.CLASSROOM
+        ));
+        Floor floor = floorRepository.save(Floor.create(building, 1));
+        MapNode node = mapNodeJpaRepository.save(MapNode.createCustom(
+                floor,
+                code,
+                code,
+                0.5,
+                0.5,
+                CustomDeviceType.CCTV
+        ));
+        Cctv cctv = Cctv.create(code, code, node);
+        cctv.issueDeviceToken(deviceTokenService.hash(rawToken));
+        if (!enabled) {
+            cctv.disable();
+        }
+        return cctvJpaRepository.saveAndFlush(cctv);
+    }
+
+    private String request(String cctvCode) throws Exception {
+        ReportCongestionRequest request = new ReportCongestionRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                cctvCode,
+                5.0,
+                8,
+                25,
+                2.5,
+                CongestionLevel.CROWDED,
+                1_000L,
+                2_000L,
+                2_000L,
+                1L,
+                null
+        );
+        return objectMapper.writeValueAsString(request);
+    }
+}

--- a/src/test/java/com/saferoute/global/security/DeviceTokenServiceTest.java
+++ b/src/test/java/com/saferoute/global/security/DeviceTokenServiceTest.java
@@ -1,0 +1,25 @@
+package com.saferoute.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DeviceTokenServiceTest {
+
+    private final DeviceTokenService service = new DeviceTokenService();
+
+    @Test
+    void issueReturnsRawTokenAndOnlyItsHash() {
+        DeviceTokenService.IssuedDeviceToken issued = service.issue();
+
+        assertThat(issued.rawToken()).isNotBlank();
+        assertThat(issued.hash()).hasSize(64);
+        assertThat(issued.hash()).isEqualTo(service.hash(issued.rawToken()));
+        assertThat(issued.hash()).isNotEqualTo(issued.rawToken());
+    }
+
+    @Test
+    void issueGeneratesDifferentTokens() {
+        assertThat(service.issue().rawToken()).isNotEqualTo(service.issue().rawToken());
+    }
+}


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #77
- Branch: feat/#77

## 주요 내용

- CCTV별 고정 디바이스 토큰 발급 기능을 추가했습니다.
- 토큰은 256비트 난수로 생성하고 DB에는 SHA-256 해시만 저장하도록 구현했습니다.
- CCTV 등록 시 토큰 원문을 최초 1회만 반환하도록 전용 응답 DTO를 추가했습니다.
- 기존 CCTV는 `POST /api/v1/cctvs/{cctvId}/device-token`을 통해 토큰이 없는 경우에만 최초 발급할 수 있도록 구현했습니다.
- `/api/v1/device/**` 전용 디바이스 인증 필터를 추가했습니다.
- 관리자 JWT 필터가 Pi API를 처리하지 않도록 JWT 인증과 디바이스 인증 경로를 분리했습니다.
- Pi 혼잡 전송 API를 `POST /api/v1/device/congestion-events`로 변경했습니다.
- 인증된 CCTV와 요청의 `cctvCode`가 일치하는지 검증하도록 구현했습니다.
- 토큰 누락·오류, CCTV 불일치, 미등록 CCTV, 비활성 CCTV에 대한 오류 응답을 추가했습니다.
- 종료되거나 올바르지 않은 훈련 세션은 409를 반환하도록 변경했습니다.
- 일반 CCTV 조회 응답에는 디바이스 토큰과 해시가 노출되지 않도록 유지했습니다.
- Pi용 Presigned PUT URL 및 관리자 도면 업로드 방식은 이번 작업에서 변경하지 않았습니다.
- 디바이스 인증 단위·통합 테스트와 기존 인증 회귀 테스트를 추가했습니다.
- 전체 테스트 265개가 통과하는 것을 확인했습니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * CCTV 등록 시 디바이스 인증 토큰이 발급됩니다.
  * 발급된 토큰을 다시 조회할 수 있는 디바이스 토큰 API가 추가되었습니다.
  * 디바이스 전용 혼잡도 이벤트 등록 API가 제공됩니다.
  * 인증된 CCTV만 혼잡도 이벤트를 등록할 수 있습니다.

* **개선 사항**
  * 유효하지 않거나 비활성화된 CCTV 및 토큰 요청이 적절한 오류로 거부됩니다.
  * 진행 중인 훈련 세션이 없을 때의 응답 상태가 충돌로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->