### PR TITLE
[FIX] #79: 중복 관측 요청의 상태 기반 후속 처리 복구

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -18,6 +18,7 @@ import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -59,6 +60,7 @@ public class CongestionEventService {
         ObservationItem item = ObservationItem.create(
                 request.eventId(),
                 session.getId(),
+                edge.getId(),
                 request.cctvCode(),
                 request.avgHeadcount(),
                 request.peakHeadcount(),
@@ -72,6 +74,7 @@ public class CongestionEventService {
                 request.configVersion()
         );
         IdempotentSaveResult<ObservationItem> saveResult = observationRepository.saveIfAbsent(item);
+        validateEventIdentity(saveResult.item(), request);
         String processingOwner = UUID.randomUUID().toString();
         long processingStartedAt = Instant.now().toEpochMilli();
         boolean claimed = observationRepository.claimProcessing(
@@ -100,6 +103,15 @@ public class CongestionEventService {
             throw new ApiException(CongestionErrorCode.EVENT_PROCESSING_FAILED, exception);
         }
         return saveResult;
+    }
+
+    private void validateEventIdentity(ObservationItem item, ReportCongestionRequest request) {
+        boolean sameIdentity = Objects.equals(item.getTrainingSessionId(), request.trainingSessionId().toString())
+                && Objects.equals(item.getEdgeId(), request.edgeId().toString())
+                && Objects.equals(item.getCctvCode(), request.cctvCode());
+        if (!sameIdentity) {
+            throw new ApiException(CongestionErrorCode.EVENT_IDENTITY_MISMATCH);
+        }
     }
 
     private void completeAfterCommit(String eventId, String processingOwner) {

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -88,13 +88,16 @@ public class CongestionEventService {
         }
 
         try {
-            trainingEventPublisher.publishCongestionUpdated(session.getId(), edge.getId(), saveResult.item());
-
             CongestionLevel level = saveResult.item().getCongestionLevel();
             if (level.requiresRouteRecalculation()) {
                 routeRecalculationService.trigger(session, edge, level);
             }
-            completeAfterCommit(saveResult.item().getEventId(), processingOwner);
+            publishAndCompleteAfterCommit(
+                    session.getId(),
+                    edge.getId(),
+                    saveResult.item(),
+                    processingOwner
+            );
         } catch (ApiException exception) {
             failProcessing(saveResult.item().getEventId(), processingOwner, exception);
             throw exception;
@@ -114,22 +117,34 @@ public class CongestionEventService {
         }
     }
 
-    private void completeAfterCommit(String eventId, String processingOwner) {
+    private void publishAndCompleteAfterCommit(
+            UUID sessionId,
+            UUID edgeId,
+            ObservationItem item,
+            String processingOwner
+    ) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            completeProcessing(eventId, processingOwner);
+            trainingEventPublisher.publishCongestionUpdated(sessionId, edgeId, item);
+            completeProcessing(item.getEventId(), processingOwner);
             return;
         }
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                completeProcessing(eventId, processingOwner);
+                try {
+                    trainingEventPublisher.publishCongestionUpdated(sessionId, edgeId, item);
+                    completeProcessing(item.getEventId(), processingOwner);
+                } catch (RuntimeException exception) {
+                    failProcessing(item.getEventId(), processingOwner, exception);
+                    throw new ApiException(CongestionErrorCode.EVENT_PROCESSING_FAILED, exception);
+                }
             }
 
             @Override
             public void afterCompletion(int status) {
                 if (status != TransactionSynchronization.STATUS_COMMITTED) {
-                    failProcessing(eventId, processingOwner, null);
+                    failProcessing(item.getEventId(), processingOwner, null);
                 }
             }
         });

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -11,20 +11,28 @@ import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.global.api.error.CongestionErrorCode;
 import com.saferoute.global.api.error.EvacuationErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CongestionEventService {
+
+    static final Duration PROCESSING_LEASE = Duration.ofMinutes(1);
 
     private final MapEdgeJpaRepository mapEdgeJpaRepository;
     private final TrainingSessionRepository trainingSessionRepository;
@@ -64,16 +72,77 @@ public class CongestionEventService {
                 request.configVersion()
         );
         IdempotentSaveResult<ObservationItem> saveResult = observationRepository.saveIfAbsent(item);
-        if (!saveResult.created()) {
+        String processingOwner = UUID.randomUUID().toString();
+        long processingStartedAt = Instant.now().toEpochMilli();
+        boolean claimed = observationRepository.claimProcessing(
+                saveResult.item().getEventId(),
+                processingOwner,
+                processingStartedAt,
+                processingStartedAt + PROCESSING_LEASE.toMillis()
+        );
+        if (!claimed) {
             return saveResult;
         }
 
-        trainingEventPublisher.publishCongestionUpdated(session.getId(), edge.getId(), saveResult.item());
+        try {
+            trainingEventPublisher.publishCongestionUpdated(session.getId(), edge.getId(), saveResult.item());
 
-        CongestionLevel level = request.congestionLevel();
-        if (level.requiresRouteRecalculation()) {
-            routeRecalculationService.trigger(session, edge, level);
+            CongestionLevel level = saveResult.item().getCongestionLevel();
+            if (level.requiresRouteRecalculation()) {
+                routeRecalculationService.trigger(session, edge, level);
+            }
+            completeAfterCommit(saveResult.item().getEventId(), processingOwner);
+        } catch (ApiException exception) {
+            failProcessing(saveResult.item().getEventId(), processingOwner, exception);
+            throw exception;
+        } catch (RuntimeException exception) {
+            failProcessing(saveResult.item().getEventId(), processingOwner, exception);
+            throw new ApiException(CongestionErrorCode.EVENT_PROCESSING_FAILED, exception);
         }
         return saveResult;
+    }
+
+    private void completeAfterCommit(String eventId, String processingOwner) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            completeProcessing(eventId, processingOwner);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                completeProcessing(eventId, processingOwner);
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+                if (status != TransactionSynchronization.STATUS_COMMITTED) {
+                    failProcessing(eventId, processingOwner, null);
+                }
+            }
+        });
+    }
+
+    private void completeProcessing(String eventId, String processingOwner) {
+        try {
+            if (!observationRepository.completeProcessing(eventId, processingOwner)) {
+                log.warn("혼잡 관측 처리 완료 상태 갱신 실패: eventId={}", eventId);
+            }
+        } catch (RuntimeException exception) {
+            log.error("혼잡 관측 처리 완료 상태 저장 중 오류: eventId={}", eventId, exception);
+        }
+    }
+
+    private void failProcessing(String eventId, String processingOwner, RuntimeException cause) {
+        try {
+            if (!observationRepository.failProcessing(eventId, processingOwner)) {
+                log.warn("혼잡 관측 처리 실패 상태 갱신 실패: eventId={}", eventId);
+            }
+        } catch (RuntimeException statusException) {
+            if (cause != null) {
+                cause.addSuppressed(statusException);
+            }
+            log.error("혼잡 관측 처리 실패 상태 저장 중 오류: eventId={}", eventId, statusException);
+        }
     }
 }

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
@@ -21,6 +21,7 @@ public class ObservationItem {
     private String gsi1Sk;
     private String eventId;
     private String trainingSessionId;
+    private String edgeId;
     private String cctvCode;
     private Double avgHeadcount;
     private Integer peakHeadcount;
@@ -44,6 +45,7 @@ public class ObservationItem {
     public static ObservationItem create(
             UUID eventId,
             UUID trainingSessionId,
+            UUID edgeId,
             String cctvCode,
             Double avgHeadcount,
             Integer peakHeadcount,
@@ -59,6 +61,7 @@ public class ObservationItem {
         ObservationItem item = new ObservationItem();
         item.eventId = eventId.toString();
         item.trainingSessionId = trainingSessionId.toString();
+        item.edgeId = edgeId.toString();
         item.cctvCode = cctvCode;
         item.avgHeadcount = avgHeadcount;
         item.peakHeadcount = peakHeadcount;
@@ -143,6 +146,14 @@ public class ObservationItem {
 
     public void setTrainingSessionId(String trainingSessionId) {
         this.trainingSessionId = trainingSessionId;
+    }
+
+    public String getEdgeId() {
+        return edgeId;
+    }
+
+    public void setEdgeId(String edgeId) {
+        this.edgeId = edgeId;
     }
 
     public String getCctvCode() {

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
@@ -33,6 +33,10 @@ public class ObservationItem {
     private String monitoringImageKey;
     private Long configVersion;
     private Long expiresAt;
+    private EventProcessingStatus eventStatus;
+    private Long processingStartedAt;
+    private Long processingExpiresAt;
+    private String processingOwner;
 
     public ObservationItem() {
     }
@@ -67,6 +71,7 @@ public class ObservationItem {
         item.monitoringImageKey = monitoringImageKey;
         item.configVersion = configVersion;
         item.expiresAt = Math.floorDiv(capturedAt, 1_000L) + TTL_SECONDS;
+        item.eventStatus = EventProcessingStatus.RECEIVED;
         item.pk = buildPk(item.eventId);
         item.sk = "META";
         item.gsi1Pk = buildGsi1Pk(item.trainingSessionId, cctvCode);
@@ -234,5 +239,37 @@ public class ObservationItem {
 
     public void setExpiresAt(Long expiresAt) {
         this.expiresAt = expiresAt;
+    }
+
+    public EventProcessingStatus getEventStatus() {
+        return eventStatus;
+    }
+
+    public void setEventStatus(EventProcessingStatus eventStatus) {
+        this.eventStatus = eventStatus;
+    }
+
+    public Long getProcessingStartedAt() {
+        return processingStartedAt;
+    }
+
+    public void setProcessingStartedAt(Long processingStartedAt) {
+        this.processingStartedAt = processingStartedAt;
+    }
+
+    public Long getProcessingExpiresAt() {
+        return processingExpiresAt;
+    }
+
+    public void setProcessingExpiresAt(Long processingExpiresAt) {
+        this.processingExpiresAt = processingExpiresAt;
+    }
+
+    public String getProcessingOwner() {
+        return processingOwner;
+    }
+
+    public void setProcessingOwner(String processingOwner) {
+        this.processingOwner = processingOwner;
     }
 }

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
@@ -83,10 +83,11 @@ public class ObservationRepository {
         item.setProcessingExpiresAt(processingExpiresAt);
 
         Expression condition = Expression.builder()
-                .expression("attribute_not_exists(#status)"
+                .expression("attribute_exists(#pk) AND (attribute_not_exists(#status)"
                         + " OR #status = :received"
                         + " OR #status = :failed"
-                        + " OR (#status = :processing AND #processingExpiresAt <= :now)")
+                        + " OR (#status = :processing AND #processingExpiresAt <= :now))")
+                .putExpressionName("#pk", "pk")
                 .putExpressionName("#status", "eventStatus")
                 .putExpressionName("#processingExpiresAt", "processingExpiresAt")
                 .putExpressionValue(":received", AttributeValue.fromS("RECEIVED"))

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
@@ -1,5 +1,6 @@
 package com.saferoute.domain.telemetry.dynamo.repository;
 
+import com.saferoute.domain.telemetry.dynamo.entity.EventProcessingStatus;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import java.util.List;
 import java.util.Optional;
@@ -12,9 +13,12 @@ import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.IgnoreNullsMode;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 
 @Repository
@@ -66,6 +70,49 @@ public class ObservationRepository {
         return Optional.ofNullable(table.getItem(request));
     }
 
+    public boolean claimProcessing(
+            String eventId,
+            String processingOwner,
+            long processingStartedAt,
+            long processingExpiresAt
+    ) {
+        ObservationItem item = processingUpdateItem(eventId);
+        item.setEventStatus(EventProcessingStatus.PROCESSING);
+        item.setProcessingOwner(processingOwner);
+        item.setProcessingStartedAt(processingStartedAt);
+        item.setProcessingExpiresAt(processingExpiresAt);
+
+        Expression condition = Expression.builder()
+                .expression("attribute_not_exists(#status)"
+                        + " OR #status = :received"
+                        + " OR #status = :failed"
+                        + " OR (#status = :processing AND #processingExpiresAt <= :now)")
+                .putExpressionName("#status", "eventStatus")
+                .putExpressionName("#processingExpiresAt", "processingExpiresAt")
+                .putExpressionValue(":received", AttributeValue.fromS("RECEIVED"))
+                .putExpressionValue(":failed", AttributeValue.fromS("FAILED"))
+                .putExpressionValue(":processing", AttributeValue.fromS("PROCESSING"))
+                .putExpressionValue(":now", AttributeValue.fromN(Long.toString(processingStartedAt)))
+                .build();
+        return updateConditionally(item, condition);
+    }
+
+    public boolean completeProcessing(String eventId, String processingOwner) {
+        return finishProcessing(
+                eventId,
+                processingOwner,
+                EventProcessingStatus.PROCESSED
+        );
+    }
+
+    public boolean failProcessing(String eventId, String processingOwner) {
+        return finishProcessing(
+                eventId,
+                processingOwner,
+                EventProcessingStatus.FAILED
+        );
+    }
+
     public List<ObservationItem> findAllBySessionIdAndCctvCode(
             String trainingSessionId,
             String cctvCode
@@ -96,6 +143,45 @@ public class ObservationRepository {
     private void validateLimit(int limit) {
         if (limit <= 0) {
             throw new IllegalArgumentException("limit은 0보다 커야합니다.");
+        }
+    }
+
+    private boolean finishProcessing(
+            String eventId,
+            String processingOwner,
+            EventProcessingStatus status
+    ) {
+        ObservationItem item = processingUpdateItem(eventId);
+        item.setEventStatus(status);
+        Expression condition = Expression.builder()
+                .expression("#status = :processing AND #processingOwner = :processingOwner")
+                .putExpressionName("#status", "eventStatus")
+                .putExpressionName("#processingOwner", "processingOwner")
+                .putExpressionValue(":processing", AttributeValue.fromS("PROCESSING"))
+                .putExpressionValue(":processingOwner", AttributeValue.fromS(processingOwner))
+                .build();
+        return updateConditionally(item, condition);
+    }
+
+    private ObservationItem processingUpdateItem(String eventId) {
+        ObservationItem item = new ObservationItem();
+        item.setPk(ObservationItem.buildPk(eventId));
+        item.setSk("META");
+        return item;
+    }
+
+    private boolean updateConditionally(ObservationItem item, Expression condition) {
+        UpdateItemEnhancedRequest<ObservationItem> request =
+                UpdateItemEnhancedRequest.builder(ObservationItem.class)
+                        .item(item)
+                        .ignoreNullsMode(IgnoreNullsMode.SCALAR_ONLY)
+                        .conditionExpression(condition)
+                        .build();
+        try {
+            table.updateItem(request);
+            return true;
+        } catch (ConditionalCheckFailedException exception) {
+            return false;
         }
     }
 }

--- a/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
@@ -13,6 +13,11 @@ public enum CongestionErrorCode implements BaseErrorCode {
             HttpStatus.SERVICE_UNAVAILABLE,
             "CONGESTION001",
             "혼잡 관측 후속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요."
+    ),
+    EVENT_IDENTITY_MISMATCH(
+            HttpStatus.CONFLICT,
+            "CONGESTION002",
+            "동일한 eventId에 다른 세션, CCTV 또는 경로 정보가 전달되었습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
@@ -1,0 +1,21 @@
+package com.saferoute.global.api.error;
+
+import com.saferoute.global.api.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CongestionErrorCode implements BaseErrorCode {
+
+    EVENT_PROCESSING_FAILED(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            "CONGESTION001",
+            "혼잡 관측 후속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
@@ -15,6 +15,7 @@ import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.error.CongestionErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.global.config.SecurityConfig;
@@ -48,6 +49,7 @@ class CongestionControllerTest {
 
     private static final UUID OBSERVATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
     private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final UUID EDGE_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
 
     @Autowired
     private MockMvc mockMvc;
@@ -221,9 +223,39 @@ class CongestionControllerTest {
                 .andExpect(jsonPath("$.code").value("TRAINING006"));
     }
 
+    @Test
+    @DisplayName("후속 처리 실패 시 공통 형식의 CONGESTION001과 503을 반환한다")
+    void reportCongestion_returnsServiceUnavailableWhenProcessingFails() throws Exception {
+        given(congestionEventService.reportCongestion(any()))
+                .willThrow(new ApiException(CongestionErrorCode.EVENT_PROCESSING_FAILED));
+
+        mockMvc.perform(post("/api/v1/device/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("CONGESTION001"))
+                .andExpect(jsonPath("$.message")
+                        .value("혼잡 관측 후속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요."));
+    }
+
+    @Test
+    @DisplayName("동일 eventId의 식별 정보가 다르면 CONGESTION002와 409를 반환한다")
+    void reportCongestion_returnsConflictWhenEventIdentityMismatches() throws Exception {
+        given(congestionEventService.reportCongestion(any()))
+                .willThrow(new ApiException(CongestionErrorCode.EVENT_IDENTITY_MISMATCH));
+
+        mockMvc.perform(post("/api/v1/device/congestion-events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("CONGESTION002"));
+    }
+
     private ObservationItem observation() {
         return ObservationItem.create(
-                OBSERVATION_ID, SESSION_ID, "CCTV_001", 5.0, 8, 25,
+                OBSERVATION_ID, SESSION_ID, EDGE_ID, "CCTV_001", 5.0, 8, 25,
                 2.5, CongestionLevel.CROWDED, 1_000L, 2_000L,
                 2_000L, null, 1L
         );

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -3,8 +3,11 @@ package com.saferoute.domain.congestion.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,6 +26,7 @@ import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.error.CongestionErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
@@ -124,6 +128,7 @@ class CongestionEventServiceTest {
         )).willReturn(Optional.of(session));
         given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
                 IdempotentSaveResult.created(invocation.getArgument(0, ObservationItem.class)));
+        givenProcessingClaimed();
 
         congestionEventService.reportCongestion(request(CongestionLevel.CAUTION));
 
@@ -149,6 +154,7 @@ class CongestionEventServiceTest {
         )).willReturn(Optional.of(session));
         given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
                 IdempotentSaveResult.created(invocation.getArgument(0, ObservationItem.class)));
+        givenProcessingClaimed();
 
         congestionEventService.reportCongestion(request(CongestionLevel.CROWDED));
 
@@ -167,6 +173,7 @@ class CongestionEventServiceTest {
         )).willReturn(Optional.of(session));
         given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
                 IdempotentSaveResult.created(invocation.getArgument(0, ObservationItem.class)));
+        givenProcessingClaimed();
 
         congestionEventService.reportCongestion(request(CongestionLevel.VERY_CROWDED));
 
@@ -190,5 +197,59 @@ class CongestionEventServiceTest {
         assertThat(result.created()).isFalse();
         verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
         verify(routeRecalculationService, never()).trigger(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("중복 eventId가 RECEIVED이면 후속 처리를 재개한다")
+    void reportCongestion_resumesReceivedDuplicate() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId
+        )).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
+                IdempotentSaveResult.existing(invocation.getArgument(0, ObservationItem.class)));
+        givenProcessingClaimed();
+
+        var result = congestionEventService.reportCongestion(request(CongestionLevel.CROWDED));
+
+        assertThat(result.created()).isFalse();
+        verify(trainingEventPublisher).publishCongestionUpdated(any(), any(), any());
+        verify(routeRecalculationService).trigger(session, edge, CongestionLevel.CROWDED);
+    }
+
+    @Test
+    @DisplayName("후속 처리 실패를 FAILED로 기록하고 공통 혼잡 에러를 반환한다")
+    void reportCongestion_marksFailedWhenSideEffectFails() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId
+        )).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
+                IdempotentSaveResult.created(invocation.getArgument(0, ObservationItem.class)));
+        given(observationRepository.claimProcessing(anyString(), anyString(), anyLong(), anyLong()))
+                .willReturn(true);
+        given(observationRepository.failProcessing(anyString(), anyString())).willReturn(true);
+        doThrow(new IllegalStateException("websocket unavailable"))
+                .when(trainingEventPublisher).publishCongestionUpdated(any(), any(), any());
+
+        assertThatThrownBy(() -> congestionEventService.reportCongestion(request(CongestionLevel.CROWDED)))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        CongestionErrorCode.EVENT_PROCESSING_FAILED
+                );
+
+        verify(observationRepository).failProcessing(anyString(), anyString());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+    }
+
+    private void givenProcessingClaimed() {
+        given(observationRepository.claimProcessing(anyString(), anyString(), anyLong(), anyLong()))
+                .willReturn(true);
+        given(observationRepository.completeProcessing(anyString(), anyString())).willReturn(true);
     }
 }

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @ExtendWith(MockitoExtension.class)
 class CongestionEventServiceTest {
@@ -200,6 +202,34 @@ class CongestionEventServiceTest {
     }
 
     @Test
+    @DisplayName("동일한 eventId가 다른 edge를 가리키면 CONGESTION002를 반환한다")
+    void reportCongestion_rejectsMismatchedEventIdentity() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId
+        )).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation -> {
+            ObservationItem existing = invocation.getArgument(0, ObservationItem.class);
+            existing.setEdgeId(UUID.randomUUID().toString());
+            return IdempotentSaveResult.existing(existing);
+        });
+
+        assertThatThrownBy(() -> congestionEventService.reportCongestion(request(CongestionLevel.CROWDED)))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        CongestionErrorCode.EVENT_IDENTITY_MISMATCH
+                );
+
+        verify(observationRepository, never())
+                .claimProcessing(anyString(), anyString(), anyLong(), anyLong());
+        verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+    }
+
+    @Test
     @DisplayName("중복 eventId가 RECEIVED이면 후속 처리를 재개한다")
     void reportCongestion_resumesReceivedDuplicate() {
         TrainingSession session = mock(TrainingSession.class);
@@ -245,6 +275,68 @@ class CongestionEventServiceTest {
 
         verify(observationRepository).failProcessing(anyString(), anyString());
         verify(routeRecalculationService, never()).trigger(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("후속 처리 성공 상태는 PostgreSQL 커밋 이후에 기록한다")
+    void reportCongestion_marksProcessedAfterCommit() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId
+        )).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
+                IdempotentSaveResult.created(invocation.getArgument(0, ObservationItem.class)));
+        givenProcessingClaimed();
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            congestionEventService.reportCongestion(request(CongestionLevel.CROWDED));
+
+            verify(observationRepository, never()).completeProcessing(anyString(), anyString());
+            TransactionSynchronization synchronization = TransactionSynchronizationManager
+                    .getSynchronizations()
+                    .get(0);
+            synchronization.afterCommit();
+            synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+
+            verify(observationRepository).completeProcessing(anyString(), anyString());
+            verify(observationRepository, never()).failProcessing(anyString(), anyString());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    @DisplayName("PostgreSQL 트랜잭션이 롤백되면 처리 상태를 FAILED로 기록한다")
+    void reportCongestion_marksFailedAfterRollback() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId
+        )).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
+                IdempotentSaveResult.created(invocation.getArgument(0, ObservationItem.class)));
+        given(observationRepository.claimProcessing(anyString(), anyString(), anyLong(), anyLong()))
+                .willReturn(true);
+        given(observationRepository.failProcessing(anyString(), anyString())).willReturn(true);
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            congestionEventService.reportCongestion(request(CongestionLevel.CAUTION));
+
+            TransactionSynchronization synchronization = TransactionSynchronizationManager
+                    .getSynchronizations()
+                    .get(0);
+            synchronization.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            verify(observationRepository).failProcessing(anyString(), anyString());
+            verify(observationRepository, never()).completeProcessing(anyString(), anyString());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     private void givenProcessingClaimed() {

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -274,7 +274,7 @@ class CongestionEventServiceTest {
                 );
 
         verify(observationRepository).failProcessing(anyString(), anyString());
-        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(routeRecalculationService).trigger(session, edge, CongestionLevel.CROWDED);
     }
 
     @Test
@@ -295,6 +295,7 @@ class CongestionEventServiceTest {
             congestionEventService.reportCongestion(request(CongestionLevel.CROWDED));
 
             verify(observationRepository, never()).completeProcessing(anyString(), anyString());
+            verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
             TransactionSynchronization synchronization = TransactionSynchronizationManager
                     .getSynchronizations()
                     .get(0);
@@ -303,6 +304,7 @@ class CongestionEventServiceTest {
 
             verify(observationRepository).completeProcessing(anyString(), anyString());
             verify(observationRepository, never()).failProcessing(anyString(), anyString());
+            verify(trainingEventPublisher).publishCongestionUpdated(any(), any(), any());
         } finally {
             TransactionSynchronizationManager.clearSynchronization();
         }
@@ -327,10 +329,51 @@ class CongestionEventServiceTest {
         try {
             congestionEventService.reportCongestion(request(CongestionLevel.CAUTION));
 
+            verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
             TransactionSynchronization synchronization = TransactionSynchronizationManager
                     .getSynchronizations()
                     .get(0);
             synchronization.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            verify(observationRepository).failProcessing(anyString(), anyString());
+            verify(observationRepository, never()).completeProcessing(anyString(), anyString());
+            verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    @DisplayName("커밋 후 WebSocket 발행 실패를 FAILED로 기록한다")
+    void reportCongestion_marksFailedWhenAfterCommitPublishFails() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(mapEdgeJpaRepository.findById(edgeId)).willReturn(Optional.of(edge));
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId
+        )).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
+                IdempotentSaveResult.created(invocation.getArgument(0, ObservationItem.class)));
+        given(observationRepository.claimProcessing(anyString(), anyString(), anyLong(), anyLong()))
+                .willReturn(true);
+        given(observationRepository.failProcessing(anyString(), anyString())).willReturn(true);
+        doThrow(new IllegalStateException("websocket unavailable"))
+                .when(trainingEventPublisher).publishCongestionUpdated(any(), any(), any());
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            congestionEventService.reportCongestion(request(CongestionLevel.CAUTION));
+            TransactionSynchronization synchronization = TransactionSynchronizationManager
+                    .getSynchronizations()
+                    .get(0);
+
+            assertThatThrownBy(synchronization::afterCommit)
+                    .isInstanceOf(ApiException.class)
+                    .hasFieldOrPropertyWithValue(
+                            "errorCode",
+                            CongestionErrorCode.EVENT_PROCESSING_FAILED
+                    );
+            synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED);
 
             verify(observationRepository).failProcessing(anyString(), anyString());
             verify(observationRepository, never()).completeProcessing(anyString(), anyString());

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
@@ -37,6 +37,7 @@ class TelemetryItemTest {
         assertThat(item.getSk()).isEqualTo("META");
         assertThat(item.getGsi1Pk()).isEqualTo("SESSION#" + SESSION_ID + "#CCTV#CCTV_001");
         assertThat(item.getGsi1Sk()).isEqualTo("TIME#1786500005000");
+        assertThat(item.getEventStatus()).isEqualTo(EventProcessingStatus.RECEIVED);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
@@ -13,6 +13,7 @@ class TelemetryItemTest {
     private static final UUID OBSERVATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
     private static final UUID EVENT_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
     private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final UUID EDGE_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
 
     @Test
     void 혼잡도와_이벤트_타입은_정의된_계약값만_사용한다() {
@@ -35,6 +36,7 @@ class TelemetryItemTest {
 
         assertThat(item.getPk()).isEqualTo("OBSERVATION#" + OBSERVATION_ID);
         assertThat(item.getSk()).isEqualTo("META");
+        assertThat(item.getEdgeId()).isEqualTo(EDGE_ID.toString());
         assertThat(item.getGsi1Pk()).isEqualTo("SESSION#" + SESSION_ID + "#CCTV#CCTV_001");
         assertThat(item.getGsi1Sk()).isEqualTo("TIME#1786500005000");
         assertThat(item.getEventStatus()).isEqualTo(EventProcessingStatus.RECEIVED);
@@ -57,6 +59,7 @@ class TelemetryItemTest {
         assertThat(attributes.get("peakHeadcount").n()).isEqualTo("8");
         assertThat(attributes.get("sampleCount").n()).isEqualTo("25");
         assertThat(attributes.get("density").n()).isEqualTo("2.5");
+        assertThat(attributes.get("edgeId").s()).isEqualTo(EDGE_ID.toString());
         assertThat(attributes)
                 .containsEntry("GSI1_PK", AttributeValue.fromS("SESSION#" + SESSION_ID + "#CCTV#CCTV_001"))
                 .containsEntry("GSI1_SK", AttributeValue.fromS("TIME#1786500005000"));
@@ -91,7 +94,7 @@ class TelemetryItemTest {
 
     private ObservationItem observation() {
         return ObservationItem.create(
-                OBSERVATION_ID, SESSION_ID, "CCTV_001", 5.0, 8, 25,
+                OBSERVATION_ID, SESSION_ID, EDGE_ID, "CCTV_001", 5.0, 8, 25,
                 2.5, CongestionLevel.CAUTION, 1_786_500_000_000L,
                 1_786_500_005_000L, 1_786_500_005_000L, null, 1L
         );

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
@@ -127,7 +127,11 @@ class ObservationRepositoryTest {
         assertThat(request.item().getProcessingStartedAt()).isEqualTo(10_000L);
         assertThat(request.item().getProcessingExpiresAt()).isEqualTo(40_000L);
         assertThat(request.conditionExpression().expression())
-                .contains("#status = :received", "#status = :failed", "#processingExpiresAt <= :now");
+                .startsWith("attribute_exists(#pk) AND (")
+                .contains("#status = :received", "#status = :failed", "#processingExpiresAt <= :now")
+                .endsWith(")");
+        assertThat(request.conditionExpression().expressionNames())
+                .containsEntry("#pk", "pk");
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedExce
 class ObservationRepositoryTest {
 
     private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final UUID EDGE_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
 
     @Mock
     private DynamoDbEnhancedClient enhancedClient;
@@ -175,7 +176,7 @@ class ObservationRepositoryTest {
 
     private ObservationItem item(String eventId, long capturedAt) {
         return ObservationItem.create(
-                UUID.nameUUIDFromBytes(eventId.getBytes(StandardCharsets.UTF_8)), SESSION_ID,
+                UUID.nameUUIDFromBytes(eventId.getBytes(StandardCharsets.UTF_8)), SESSION_ID, EDGE_ID,
                 "CCTV_001", 5.0, 8, 25, 2.5,
                 CongestionLevel.CAUTION, capturedAt - 5_000, capturedAt,
                 capturedAt, null, 1L

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 
 @ExtendWith(MockitoExtension.class)
@@ -111,9 +112,65 @@ class ObservationRepositoryTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void RECEIVED_FAILED_또는_만료된_PROCESSING만_조건부로_선점한다() {
+        ArgumentCaptor<UpdateItemEnhancedRequest<ObservationItem>> captor = updateRequestCaptor();
+
+        boolean claimed = repository.claimProcessing("observation-1", "worker-1", 10_000L, 40_000L);
+
+        assertThat(claimed).isTrue();
+        verify(table).updateItem(captor.capture());
+        UpdateItemEnhancedRequest<ObservationItem> request = captor.getValue();
+        assertThat(request.item().getEventStatus().name()).isEqualTo("PROCESSING");
+        assertThat(request.item().getProcessingOwner()).isEqualTo("worker-1");
+        assertThat(request.item().getProcessingStartedAt()).isEqualTo(10_000L);
+        assertThat(request.item().getProcessingExpiresAt()).isEqualTo(40_000L);
+        assertThat(request.conditionExpression().expression())
+                .contains("#status = :received", "#status = :failed", "#processingExpiresAt <= :now");
+    }
+
+    @Test
+    void 다른_요청이_처리_중이면_선점에_실패한다() {
+        doThrow(ConditionalCheckFailedException.builder().message("processing").build())
+                .when(table).updateItem(any(UpdateItemEnhancedRequest.class));
+
+        boolean claimed = repository.claimProcessing("observation-1", "worker-2", 10_000L, 40_000L);
+
+        assertThat(claimed).isFalse();
+    }
+
+    @Test
+    void 선점한_요청만_PROCESSED로_완료할_수_있다() {
+        ArgumentCaptor<UpdateItemEnhancedRequest<ObservationItem>> captor = updateRequestCaptor();
+
+        boolean completed = repository.completeProcessing("observation-1", "worker-1");
+
+        assertThat(completed).isTrue();
+        verify(table).updateItem(captor.capture());
+        assertThat(captor.getValue().item().getEventStatus().name()).isEqualTo("PROCESSED");
+        assertThat(captor.getValue().conditionExpression().expression())
+                .isEqualTo("#status = :processing AND #processingOwner = :processingOwner");
+    }
+
+    @Test
+    void 처리_실패를_FAILED로_기록한다() {
+        ArgumentCaptor<UpdateItemEnhancedRequest<ObservationItem>> captor = updateRequestCaptor();
+
+        boolean failed = repository.failProcessing("observation-1", "worker-1");
+
+        assertThat(failed).isTrue();
+        verify(table).updateItem(captor.capture());
+        assertThat(captor.getValue().item().getEventStatus().name()).isEqualTo("FAILED");
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     private ArgumentCaptor<PutItemEnhancedRequest<ObservationItem>> requestCaptor() {
         return (ArgumentCaptor) ArgumentCaptor.forClass(PutItemEnhancedRequest.class);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ArgumentCaptor<UpdateItemEnhancedRequest<ObservationItem>> updateRequestCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(UpdateItemEnhancedRequest.class);
     }
 
     private ObservationItem item(String eventId, long capturedAt) {

--- a/src/test/java/com/saferoute/global/security/DeviceSecurityIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/DeviceSecurityIntegrationTest.java
@@ -63,6 +63,7 @@ class DeviceSecurityIntegrationTest {
             ObservationItem item = ObservationItem.create(
                     request.eventId(),
                     request.trainingSessionId(),
+                    request.edgeId(),
                     request.cctvCode(),
                     request.avgHeadcount(),
                     request.peakHeadcount(),


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #79 
- Branch: fix/#79

## 주요 내용
기존 혼잡 관측 요청은 ObservationItem을 DynamoDB에 저장한 후, 동일한 eventId가 이미 존재하면 기존 결과를 즉시 반환했습니다.

이 구조에서는 다음 상황에서 후속 처리가 누락될 수 있었습니다.

관측값 DynamoDB 저장 성공
→ WebSocket 발행 또는 경로 재계산 전에 BE 장애
→ Pi가 동일한 eventId 재전송
→ 이미 저장된 eventId라는 이유로 기존 결과 반환
→ 중단된 후속 처리 복구 불가

이를 해결하기 위해 eventId 존재 여부뿐만 아니라 처리 상태를 기준으로 후속 처리를 재개하도록 변경했습니다.


## 구현 내용

현재 혼잡 수신 API가 실제로 저장하는 단위는 CongestionEventItem이 아니라 ObservationItem입니다.

별도의 혼잡 이벤트 Item을 임의로 생성하지 않고, 실제 멱등 저장 대상인 ObservationItem에 후속 처리 상태와 lease 정보를 추가했습니다.


### 처리 상태

관측값은 다음 상태로 처리됩니다.

RECEIVED
→ PROCESSING
→ PROCESSED

후속 처리 중 실패하거나 PostgreSQL 트랜잭션이 롤백되면 다음 상태로 변경됩니다.

PROCESSING
→ FAILED

FAILED 상태의 요청이 재전송되면 다시 처리할 수 있습니다.

FAILED
→ PROCESSING
→ PROCESSED


### 상태별 재전송 처리

PROCESSED

- 후속 처리를 다시 실행하지 않음
- 기존 관측 결과와 함께 200 OK 반환

RECEIVED

- PROCESSING 상태를 조건부로 선점
- 선점에 성공한 요청만 WebSocket 발행과 경로 재계산 실행
- 처리 성공 후 PROCESSED로 변경

PROCESSING

- 다른 요청이 처리 중인 상태
- WebSocket 발행과 경로 재계산을 중복 실행하지 않음
- 기존 관측 결과와 함께 200 OK 반환

FAILED

- PROCESSING 상태를 조건부로 다시 선점
- 후속 처리 재실행
- 성공하면 PROCESSED
- 다시 실패하면 FAILED


### DynamoDB 변경 사항

ObservationItem에 다음 속성을 추가했습니다.

- edgeId
- eventStatus
- processingStartedAt
- processingExpiresAt
- processingOwner

신규 관측값은 RECEIVED 상태로 저장됩니다.

후속 처리를 실행하려는 요청은 DynamoDB 조건부 갱신을 통해 PROCESSING 상태를 선점합니다.

선점 가능한 조건은 다음과 같습니다.

- eventStatus가 없는 기존 관측값
- RECEIVED 상태
- FAILED 상태
- processingExpiresAt이 만료된 PROCESSING 상태

동시에 같은 eventId가 여러 번 요청되어도 하나의 요청만 PROCESSING 상태를 선점할 수 있습니다.


### PROCESSING lease

BE가 강제 종료되면 FAILED 상태 변경 코드가 실행되지 않아 PROCESSING 상태에 남을 수 있습니다.

이를 복구하기 위해 PROCESSING 상태에 1분 lease를 적용했습니다.

- 처리 시작 시 processingStartedAt 저장
- 처리 만료 시각을 processingExpiresAt에 저장
- processingOwner로 처리 요청 식별
- 1분이 지나지 않은 PROCESSING 요청은 재선점 불가
- 1분이 지난 PROCESSING 요청은 다른 요청이 재선점 가능
- 상태 완료와 실패 변경은 동일한 processingOwner만 가능


### PostgreSQL 트랜잭션 처리

Spring의 Transactional은 PostgreSQL과 DynamoDB를 하나의 트랜잭션으로 묶지 못합니다.

DynamoDB가 먼저 PROCESSED가 되고 PostgreSQL 작업이 롤백되는 상황을 방지하기 위해 다음 순서로 처리합니다.

후속 처리 실행
→ PostgreSQL 트랜잭션 커밋
→ DynamoDB 상태를 PROCESSED로 변경

PostgreSQL 트랜잭션이 롤백되면 DynamoDB 상태를 FAILED로 변경합니다.


### 중복 eventId 식별 정보 검증

후속 처리를 재개할 때 재전송된 요청 body의 edgeId를 그대로 신뢰하면 동일한 eventId가 다른 경로에 적용될 수 있습니다.

이를 방지하기 위해 edgeId를 ObservationItem에 함께 저장하고 다음 식별 정보를 기존 관측값과 비교합니다.

- trainingSessionId
- cctvCode
- edgeId

동일한 eventId에 다른 식별 정보가 전달되면 후속 처리를 실행하지 않고 409 Conflict를 반환합니다.
avgHeadcount, density 등 수치만 다른 중복 요청은 기존 멱등 계약에 따라 최초 저장 결과를 반환합니다.


### 에러 코드

CONGESTION001

- HTTP 상태: 503 Service Unavailable
- 발생 조건: WebSocket 발행 또는 경로 재계산 등 후속 처리에서 예상하지 못한 오류 발생
- 메시지: 혼잡 관측 후속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.
- 이벤트 상태를 FAILED로 변경한 후 반환
- Pi가 동일한 eventId를 재전송하면 재처리 가능

CONGESTION002

- HTTP 상태: 409 Conflict
- 발생 조건: 동일한 eventId에 다른 trainingSessionId, cctvCode 또는 edgeId가 전달됨
- 메시지: 동일한 eventId에 다른 세션, CCTV 또는 경로 정보가 전달되었습니다.
- 후속 처리 실행 안 함


### API 응답 계약

POST /api/v1/device/congestion-events

- 최초 관측 요청: 201 Created
- RECEIVED 재처리 성공: 200 OK와 기존 관측 결과
- FAILED 재처리 성공: 200 OK와 기존 관측 결과
- PROCESSING 중복 요청: 200 OK와 기존 관측 결과
- PROCESSED 중복 요청: 200 OK와 기존 관측 결과
- 예상하지 못한 후속 처리 실패: 503, CONGESTION001
- 동일 eventId 식별 정보 불일치: 409, CONGESTION002

### 주의사항

- 배포 전에 생성된 기존 ObservationItem에는 edgeId가 없습니다.
- 기존 관측값이 남아 있는 상태에서 동일한 eventId가 재전송되면 CONGESTION002가 발생할 수 있습니다.
- 관측값에는 30일 TTL이 적용되어 있고 아직 운영 데이터가 없다면 영향은 없습니다.
- WebSocket은 외부 메시지 발행이므로 완전한 exactly-once 처리를 보장하지 않습니다.
- WebSocket 발행 직후 BE가 강제 종료되면 lease 만료 후 재처리 과정에서 동일한 eventId의 메시지가 다시 발행될 수 있습니다.
- WebSocket 클라이언트에서도 eventId 기준 중복 메시지를 허용하거나 제거할 수 있어야 합니다.
- 경로 재계산 저장은 기존 PENDING 중복 확인과 데이터베이스 유니크 제약으로 보호됩니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 혼잡 이벤트의 식별 정보를 검증해 잘못된 후속 요청을 구분합니다.
  * 이벤트 처리 중복을 방지하고, 최초 처리 이벤트만 알림과 경로 재계산을 수행합니다.
  * 처리 중·완료·실패 상태를 추적하며, 장시간 중단된 처리는 다시 시도할 수 있습니다.

* **버그 수정**
  * 이벤트 후속 처리 실패 시 명확한 오류 응답을 제공합니다.
  * 식별 정보가 일치하지 않는 요청에 대해 충돌 오류를 반환합니다.
  * 처리 성공 및 실패 상태가 트랜잭션 결과에 맞게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->