### PR TITLE
[FEAT] #83: 이벤트 이미지 연결 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionController.java
@@ -1,8 +1,10 @@
 package com.saferoute.domain.congestion.controller;
 
 import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
+import com.saferoute.domain.congestion.dto.request.ConnectEventImageRequest;
 import com.saferoute.domain.congestion.dto.response.ObservationResponse;
 import com.saferoute.domain.congestion.service.CongestionEventService;
+import com.saferoute.domain.congestion.service.CongestionEventImageService;
 import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
@@ -14,9 +16,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.UUID;
 
 @Tag(name = "혼잡도", description = "CCTV 혼잡 이벤트 수신 API")
 @RestController
@@ -25,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CongestionController {
 
     private final CongestionEventService congestionEventService;
+    private final CongestionEventImageService congestionEventImageService;
     private final DeviceAuthorizationService deviceAuthorizationService;
 
     @PostMapping
@@ -37,5 +43,15 @@ public class CongestionController {
         ObservationResponse response = ObservationResponse.from(saveResult.item());
         HttpStatus status = saveResult.created() ? HttpStatus.CREATED : HttpStatus.OK;
         return ResponseEntity.status(status).body(response);
+    }
+
+    @PatchMapping("/{eventId}/image")
+    public ResponseEntity<Void> connectEventImage(
+            @AuthenticationPrincipal DevicePrincipal principal,
+            @PathVariable UUID eventId,
+            @Valid @RequestBody ConnectEventImageRequest request
+    ) {
+        congestionEventImageService.connectImage(principal, eventId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/saferoute/domain/congestion/dto/request/ConnectEventImageRequest.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/request/ConnectEventImageRequest.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.congestion.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record ConnectEventImageRequest(
+        @NotBlank String eventImageKey,
+        @NotNull @PositiveOrZero Long uploadedAt
+) {
+}

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventImageService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventImageService.java
@@ -38,8 +38,14 @@ public class CongestionEventImageService {
     ) {
         ObservationItem item = findEvent(eventId);
         deviceAuthorizationService.validateCctv(principal, item.getCctvCode());
-        validateState(item, request);
+        validateEventProcessed(item);
         validateObjectKey(item, eventId, request.eventImageKey());
+
+        if (isSameCompletedImage(item, request)) {
+            publishImageUpdated(item);
+            return;
+        }
+        validateImageState(item);
 
         if (!s3Service.objectExists(request.eventImageKey())) {
             throw new ApiException(CongestionErrorCode.EVENT_IMAGE_OBJECT_NOT_FOUND);
@@ -67,14 +73,15 @@ public class CongestionEventImageService {
                 .orElseThrow(() -> new ApiException(CongestionErrorCode.EVENT_NOT_FOUND));
     }
 
-    private void validateState(ObservationItem item, ConnectEventImageRequest request) {
+    private void validateEventProcessed(ObservationItem item) {
         if (item.getEventStatus() != EventProcessingStatus.PROCESSED) {
             throw new ApiException(CongestionErrorCode.EVENT_NOT_PROCESSED);
         }
-        if (isSameCompletedImage(item, request)) {
-            return;
-        }
-        if (item.getImageUploadStatus() != ImageUploadStatus.PENDING
+    }
+
+    private void validateImageState(ObservationItem item) {
+        if (item.getImageUploadStatus() != null
+                && item.getImageUploadStatus() != ImageUploadStatus.PENDING
                 && item.getImageUploadStatus() != ImageUploadStatus.FAILED) {
             throw new ApiException(CongestionErrorCode.EVENT_IMAGE_STATE_CONFLICT);
         }
@@ -116,9 +123,14 @@ public class CongestionEventImageService {
             ObservationItem item,
             ConnectEventImageRequest request
     ) {
-        return item.getImageUploadStatus() == ImageUploadStatus.COMPLETED
+        return isCompletedStatus(item.getImageUploadStatus())
                 && Objects.equals(item.getEventImageKey(), request.eventImageKey())
                 && Objects.equals(item.getImageUploadedAt(), request.uploadedAt());
+    }
+
+    @SuppressWarnings("deprecation")
+    private boolean isCompletedStatus(ImageUploadStatus status) {
+        return status == ImageUploadStatus.COMPLETED || status == ImageUploadStatus.UPLOADED;
     }
 
     private void publishImageUpdated(ObservationItem item) {

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventImageService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventImageService.java
@@ -1,0 +1,130 @@
+package com.saferoute.domain.congestion.service;
+
+import com.saferoute.domain.congestion.dto.request.ConnectEventImageRequest;
+import com.saferoute.domain.device.service.DeviceAuthorizationService;
+import com.saferoute.domain.telemetry.dynamo.entity.EventProcessingStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.global.api.error.CongestionErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DevicePrincipal;
+import com.saferoute.infrastructure.s3.service.S3Service;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CongestionEventImageService {
+
+    private static final String TRAINING_PREFIX = "training";
+    private static final String EVENTS_DIRECTORY = "events";
+    private static final String JPEG_SUFFIX = ".jpg";
+
+    private final ObservationRepository observationRepository;
+    private final DeviceAuthorizationService deviceAuthorizationService;
+    private final S3Service s3Service;
+    private final TrainingEventPublisher trainingEventPublisher;
+
+    public void connectImage(
+            DevicePrincipal principal,
+            UUID eventId,
+            ConnectEventImageRequest request
+    ) {
+        ObservationItem item = findEvent(eventId);
+        deviceAuthorizationService.validateCctv(principal, item.getCctvCode());
+        validateState(item, request);
+        validateObjectKey(item, eventId, request.eventImageKey());
+
+        if (!s3Service.objectExists(request.eventImageKey())) {
+            throw new ApiException(CongestionErrorCode.EVENT_IMAGE_OBJECT_NOT_FOUND);
+        }
+
+        if (!observationRepository.completeImageUpload(
+                eventId.toString(), request.eventImageKey(), request.uploadedAt()
+        )) {
+            ObservationItem latest = findEvent(eventId);
+            if (!isSameCompletedImage(latest, request)) {
+                throw new ApiException(CongestionErrorCode.EVENT_IMAGE_STATE_CONFLICT);
+            }
+            publishImageUpdated(latest);
+            return;
+        }
+
+        item.setEventImageKey(request.eventImageKey());
+        item.setImageUploadedAt(request.uploadedAt());
+        item.setImageUploadStatus(ImageUploadStatus.COMPLETED);
+        publishImageUpdated(item);
+    }
+
+    private ObservationItem findEvent(UUID eventId) {
+        return observationRepository.findByEventId(eventId.toString())
+                .orElseThrow(() -> new ApiException(CongestionErrorCode.EVENT_NOT_FOUND));
+    }
+
+    private void validateState(ObservationItem item, ConnectEventImageRequest request) {
+        if (item.getEventStatus() != EventProcessingStatus.PROCESSED) {
+            throw new ApiException(CongestionErrorCode.EVENT_NOT_PROCESSED);
+        }
+        if (isSameCompletedImage(item, request)) {
+            return;
+        }
+        if (item.getImageUploadStatus() != ImageUploadStatus.PENDING
+                && item.getImageUploadStatus() != ImageUploadStatus.FAILED) {
+            throw new ApiException(CongestionErrorCode.EVENT_IMAGE_STATE_CONFLICT);
+        }
+    }
+
+    private void validateObjectKey(ObservationItem item, UUID eventId, String objectKey) {
+        String[] segments = objectKey.split("/", -1);
+        if (segments.length != 5
+                || !TRAINING_PREFIX.equals(segments[0])
+                || !EVENTS_DIRECTORY.equals(segments[2])
+                || !segments[4].endsWith(JPEG_SUFFIX)) {
+            throw new ApiException(CongestionErrorCode.EVENT_IMAGE_KEY_INVALID);
+        }
+
+        UUID sessionId = parseCanonicalUuid(segments[1]);
+        String imageEventId = segments[4].substring(0, segments[4].length() - JPEG_SUFFIX.length());
+        UUID keyEventId = parseCanonicalUuid(imageEventId);
+        boolean sameIdentity = Objects.equals(item.getTrainingSessionId(), sessionId.toString())
+                && Objects.equals(item.getCctvCode(), segments[3])
+                && eventId.equals(keyEventId);
+        if (!sameIdentity) {
+            throw new ApiException(CongestionErrorCode.EVENT_IMAGE_IDENTITY_MISMATCH);
+        }
+    }
+
+    private UUID parseCanonicalUuid(String value) {
+        try {
+            UUID uuid = UUID.fromString(value);
+            if (!uuid.toString().equals(value)) {
+                throw new IllegalArgumentException("non-canonical UUID");
+            }
+            return uuid;
+        } catch (IllegalArgumentException exception) {
+            throw new ApiException(CongestionErrorCode.EVENT_IMAGE_KEY_INVALID, exception);
+        }
+    }
+
+    private boolean isSameCompletedImage(
+            ObservationItem item,
+            ConnectEventImageRequest request
+    ) {
+        return item.getImageUploadStatus() == ImageUploadStatus.COMPLETED
+                && Objects.equals(item.getEventImageKey(), request.eventImageKey())
+                && Objects.equals(item.getImageUploadedAt(), request.uploadedAt());
+    }
+
+    private void publishImageUpdated(ObservationItem item) {
+        trainingEventPublisher.publishCongestionImageUpdated(
+                UUID.fromString(item.getTrainingSessionId()),
+                item
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ImageUploadStatus.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ImageUploadStatus.java
@@ -3,5 +3,9 @@ package com.saferoute.domain.telemetry.dynamo.entity;
 public enum ImageUploadStatus {
     PENDING,
     COMPLETED,
-    FAILED
+    FAILED,
+
+    /** 기존 DynamoDB 항목 역직렬화를 위한 호환 값. 신규 저장에는 사용하지 않는다. */
+    @Deprecated
+    UPLOADED
 }

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ImageUploadStatus.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ImageUploadStatus.java
@@ -2,6 +2,6 @@ package com.saferoute.domain.telemetry.dynamo.entity;
 
 public enum ImageUploadStatus {
     PENDING,
-    UPLOADED,
+    COMPLETED,
     FAILED
 }

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
@@ -32,6 +32,9 @@ public class ObservationItem {
     private Long windowEnd;
     private Long capturedAt;
     private String monitoringImageKey;
+    private String eventImageKey;
+    private Long imageUploadedAt;
+    private ImageUploadStatus imageUploadStatus;
     private Long configVersion;
     private Long expiresAt;
     private EventProcessingStatus eventStatus;
@@ -72,6 +75,7 @@ public class ObservationItem {
         item.windowEnd = windowEnd;
         item.capturedAt = capturedAt;
         item.monitoringImageKey = monitoringImageKey;
+        item.imageUploadStatus = ImageUploadStatus.PENDING;
         item.configVersion = configVersion;
         item.expiresAt = Math.floorDiv(capturedAt, 1_000L) + TTL_SECONDS;
         item.eventStatus = EventProcessingStatus.RECEIVED;
@@ -234,6 +238,30 @@ public class ObservationItem {
 
     public void setMonitoringImageKey(String monitoringImageKey) {
         this.monitoringImageKey = monitoringImageKey;
+    }
+
+    public String getEventImageKey() {
+        return eventImageKey;
+    }
+
+    public void setEventImageKey(String eventImageKey) {
+        this.eventImageKey = eventImageKey;
+    }
+
+    public Long getImageUploadedAt() {
+        return imageUploadedAt;
+    }
+
+    public void setImageUploadedAt(Long imageUploadedAt) {
+        this.imageUploadedAt = imageUploadedAt;
+    }
+
+    public ImageUploadStatus getImageUploadStatus() {
+        return imageUploadStatus;
+    }
+
+    public void setImageUploadStatus(ImageUploadStatus imageUploadStatus) {
+        this.imageUploadStatus = imageUploadStatus;
     }
 
     public Long getConfigVersion() {

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
@@ -162,12 +162,15 @@ public class CongestionEventRepository {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void validateImageStatusTransition(
             ImageUploadStatus expectedStatus,
             ImageUploadStatus newStatus
     ) {
         boolean complete = expectedStatus == ImageUploadStatus.PENDING
-                && (newStatus == ImageUploadStatus.COMPLETED || newStatus == ImageUploadStatus.FAILED);
+                && (newStatus == ImageUploadStatus.COMPLETED
+                || newStatus == ImageUploadStatus.UPLOADED
+                || newStatus == ImageUploadStatus.FAILED);
         boolean retry = expectedStatus == ImageUploadStatus.FAILED
                 && newStatus == ImageUploadStatus.PENDING;
         if (!complete && !retry) {

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
@@ -167,7 +167,7 @@ public class CongestionEventRepository {
             ImageUploadStatus newStatus
     ) {
         boolean complete = expectedStatus == ImageUploadStatus.PENDING
-                && (newStatus == ImageUploadStatus.UPLOADED || newStatus == ImageUploadStatus.FAILED);
+                && (newStatus == ImageUploadStatus.COMPLETED || newStatus == ImageUploadStatus.FAILED);
         boolean retry = expectedStatus == ImageUploadStatus.FAILED
                 && newStatus == ImageUploadStatus.PENDING;
         if (!complete && !retry) {

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
@@ -123,7 +123,8 @@ public class ObservationRepository {
 
         Expression condition = Expression.builder()
                 .expression("attribute_exists(#pk) AND #eventStatus = :processed"
-                        + " AND (#imageStatus = :pending OR #imageStatus = :failed)")
+                        + " AND (attribute_not_exists(#imageStatus)"
+                        + " OR #imageStatus = :pending OR #imageStatus = :failed)")
                 .putExpressionName("#pk", "pk")
                 .putExpressionName("#eventStatus", "eventStatus")
                 .putExpressionName("#imageStatus", "imageUploadStatus")

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.telemetry.dynamo.repository;
 
 import com.saferoute.domain.telemetry.dynamo.entity.EventProcessingStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import java.util.List;
 import java.util.Optional;
@@ -112,6 +113,25 @@ public class ObservationRepository {
                 processingOwner,
                 EventProcessingStatus.FAILED
         );
+    }
+
+    public boolean completeImageUpload(String eventId, String eventImageKey, long uploadedAt) {
+        ObservationItem item = processingUpdateItem(eventId);
+        item.setEventImageKey(eventImageKey);
+        item.setImageUploadedAt(uploadedAt);
+        item.setImageUploadStatus(ImageUploadStatus.COMPLETED);
+
+        Expression condition = Expression.builder()
+                .expression("attribute_exists(#pk) AND #eventStatus = :processed"
+                        + " AND (#imageStatus = :pending OR #imageStatus = :failed)")
+                .putExpressionName("#pk", "pk")
+                .putExpressionName("#eventStatus", "eventStatus")
+                .putExpressionName("#imageStatus", "imageUploadStatus")
+                .putExpressionValue(":processed", AttributeValue.fromS("PROCESSED"))
+                .putExpressionValue(":pending", AttributeValue.fromS("PENDING"))
+                .putExpressionValue(":failed", AttributeValue.fromS("FAILED"))
+                .build();
+        return updateConditionally(item, condition);
     }
 
     public List<ObservationItem> findAllBySessionIdAndCctvCode(

--- a/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
@@ -18,6 +18,36 @@ public enum CongestionErrorCode implements BaseErrorCode {
             HttpStatus.CONFLICT,
             "CONGESTION002",
             "동일한 eventId에 다른 세션, CCTV 또는 경로 정보가 전달되었습니다."
+    ),
+    EVENT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "CONGESTION003",
+            "혼잡 이벤트를 찾을 수 없습니다."
+    ),
+    EVENT_NOT_PROCESSED(
+            HttpStatus.CONFLICT,
+            "CONGESTION004",
+            "처리가 완료된 혼잡 이벤트에만 이미지를 연결할 수 있습니다."
+    ),
+    EVENT_IMAGE_STATE_CONFLICT(
+            HttpStatus.CONFLICT,
+            "CONGESTION005",
+            "현재 이미지 상태에서는 이미지를 연결할 수 없습니다."
+    ),
+    EVENT_IMAGE_KEY_INVALID(
+            HttpStatus.BAD_REQUEST,
+            "CONGESTION006",
+            "이벤트 이미지 경로 형식이 올바르지 않습니다."
+    ),
+    EVENT_IMAGE_IDENTITY_MISMATCH(
+            HttpStatus.CONFLICT,
+            "CONGESTION007",
+            "이미지 경로의 세션, CCTV 또는 eventId가 이벤트와 일치하지 않습니다."
+    ),
+    EVENT_IMAGE_OBJECT_NOT_FOUND(
+            HttpStatus.CONFLICT,
+            "CONGESTION008",
+            "업로드가 완료된 이벤트 이미지 객체를 찾을 수 없습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/global/api/error/S3ErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/S3ErrorCode.java
@@ -15,6 +15,11 @@ public enum S3ErrorCode implements BaseErrorCode {
             HttpStatus.INTERNAL_SERVER_ERROR,
             "S3_ERROR_003",
             "S3 업로드 URL 발급에 실패했습니다."
+    ),
+    OBJECT_CHECK_FAILED(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            "S3_ERROR_004",
+            "S3 객체 확인에 실패했습니다. 잠시 후 다시 시도해 주세요."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/infrastructure/s3/service/S3Service.java
+++ b/src/main/java/com/saferoute/infrastructure/s3/service/S3Service.java
@@ -13,6 +13,9 @@ import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @Service
 public class S3Service {
@@ -57,6 +60,26 @@ public class S3Service {
                 file.getSize(),
                 contentType
         );
+    }
+
+    public boolean objectExists(String key) {
+        HeadObjectRequest request = HeadObjectRequest.builder()
+                .bucket(s3Properties.bucket())
+                .key(key)
+                .build();
+        try {
+            s3Client.headObject(request);
+            return true;
+        } catch (NoSuchKeyException exception) {
+            return false;
+        } catch (S3Exception exception) {
+            if (exception.statusCode() == 404) {
+                return false;
+            }
+            throw new ApiException(S3ErrorCode.OBJECT_CHECK_FAILED, exception);
+        } catch (SdkException exception) {
+            throw new ApiException(S3ErrorCode.OBJECT_CHECK_FAILED, exception);
+        }
     }
 
     private String createObjectKey(String originalFilename) {

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionImageUpdatedData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionImageUpdatedData.java
@@ -1,0 +1,21 @@
+package com.saferoute.infrastructure.websocket.dto;
+
+import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import java.util.UUID;
+
+public record CongestionImageUpdatedData(
+        UUID eventId,
+        String eventImageKey,
+        Long uploadedAt,
+        ImageUploadStatus imageUploadStatus
+) {
+    public static CongestionImageUpdatedData from(ObservationItem item) {
+        return new CongestionImageUpdatedData(
+                UUID.fromString(item.getEventId()),
+                item.getEventImageKey(),
+                item.getImageUploadedAt(),
+                item.getImageUploadStatus()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
@@ -9,6 +9,9 @@ public enum TrainingEventType {
     // CongestionEventService.reportCongestion() 호출 시 발행된다. (이슈 #48)
     CONGESTION_UPDATED,
 
+    // 혼잡 이벤트 이미지가 S3 업로드 완료 후 연결되었을 때 발행된다. (이슈 #83)
+    CONGESTION_IMAGE_UPDATED,
+
     // RouteRecalculationService.trigger()가 재탐색 결과를 PENDING으로 저장했을 때 발행된다. (이슈 #48)
     ROUTE_RECALCULATION_REQUESTED,
 

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.infrastructure.websocket.dto.CongestionEventData;
+import com.saferoute.infrastructure.websocket.dto.CongestionImageUpdatedData;
 import com.saferoute.infrastructure.websocket.dto.IoTLightEventMessage;
 import com.saferoute.infrastructure.websocket.dto.IoTLightStatusEventData;
 import com.saferoute.infrastructure.websocket.dto.RouteRecalculationEventData;
@@ -146,6 +147,21 @@ public class TrainingEventPublisher {
                 sessionId,
                 edgeId,
                 item.getCongestionLevel()
+        );
+    }
+
+    public void publishCongestionImageUpdated(UUID sessionId, ObservationItem item) {
+        TrainingEventMessage<CongestionImageUpdatedData> message = TrainingEventMessage.of(
+                TrainingEventType.CONGESTION_IMAGE_UPDATED,
+                sessionId,
+                CongestionImageUpdatedData.from(item)
+        );
+
+        messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
+        log.debug(
+                "혼잡 이벤트 이미지 갱신 발행: sessionId={}, eventId={}",
+                sessionId,
+                item.getEventId()
         );
     }
 

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.congestion.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -285,6 +286,41 @@ class CongestionControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("이벤트를 찾을 수 없으면 CONGESTION003과 404를 반환한다")
+    void connectEventImage_returnsNotFoundWhenEventMissing() throws Exception {
+        doThrow(new ApiException(CongestionErrorCode.EVENT_NOT_FOUND))
+                .when(congestionEventImageService).connectImage(any(), any(), any());
+
+        mockMvc.perform(patch("/api/v1/device/congestion-events/{eventId}/image", OBSERVATION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validImageRequest())))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("CONGESTION003"));
+    }
+
+    @Test
+    @DisplayName("이미지 상태가 충돌하면 CONGESTION005와 409를 반환한다")
+    void connectEventImage_returnsConflictWhenImageStateConflicts() throws Exception {
+        doThrow(new ApiException(CongestionErrorCode.EVENT_IMAGE_STATE_CONFLICT))
+                .when(congestionEventImageService).connectImage(any(), any(), any());
+
+        mockMvc.perform(patch("/api/v1/device/congestion-events/{eventId}/image", OBSERVATION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validImageRequest())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("CONGESTION005"));
+    }
+
+    private ObjectNode validImageRequest() {
+        return objectMapper.createObjectNode()
+                .put("eventImageKey", "training/" + SESSION_ID + "/events/CCTV_001/"
+                        + OBSERVATION_ID + ".jpg")
+                .put("uploadedAt", 1_786_500_002_800L);
     }
 
     private ObservationItem observation() {

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionControllerTest.java
@@ -2,7 +2,9 @@ package com.saferoute.domain.congestion.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -11,6 +13,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.saferoute.domain.congestion.dto.request.ReportCongestionRequest;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.congestion.service.CongestionEventService;
+import com.saferoute.domain.congestion.service.CongestionEventImageService;
 import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
@@ -59,6 +62,9 @@ class CongestionControllerTest {
 
     @MockitoBean
     private CongestionEventService congestionEventService;
+
+    @MockitoBean
+    private CongestionEventImageService congestionEventImageService;
 
     @MockitoBean
     private DeviceAuthorizationService deviceAuthorizationService;
@@ -251,6 +257,34 @@ class CongestionControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.isSuccess").value(false))
                 .andExpect(jsonPath("$.code").value("CONGESTION002"));
+    }
+
+    @Test
+    @DisplayName("이벤트 이미지 연결 성공 시 204를 반환한다")
+    void connectEventImage_returnsNoContent() throws Exception {
+        ObjectNode body = objectMapper.createObjectNode()
+                .put("eventImageKey", "training/" + SESSION_ID + "/events/CCTV_001/"
+                        + OBSERVATION_ID + ".jpg")
+                .put("uploadedAt", 1_786_500_002_800L);
+
+        mockMvc.perform(patch("/api/v1/device/congestion-events/{eventId}/image", OBSERVATION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isNoContent());
+
+        verify(congestionEventImageService).connectImage(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("eventImageKey가 없으면 400을 반환한다")
+    void connectEventImage_returnsBadRequestWithoutImageKey() throws Exception {
+        ObjectNode body = objectMapper.createObjectNode()
+                .put("uploadedAt", 1_786_500_002_800L);
+
+        mockMvc.perform(patch("/api/v1/device/congestion-events/{eventId}/image", OBSERVATION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
     }
 
     private ObservationItem observation() {

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventImageServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventImageServiceTest.java
@@ -13,6 +13,7 @@ import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.global.api.error.CongestionErrorCode;
+import com.saferoute.global.api.error.DeviceErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.global.security.DevicePrincipal;
 import com.saferoute.infrastructure.s3.service.S3Service;
@@ -22,6 +23,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -148,14 +151,68 @@ class CongestionEventImageServiceTest {
         item.setImageUploadedAt(request.uploadedAt());
         item.setImageUploadStatus(ImageUploadStatus.COMPLETED);
         given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
-        given(s3Service.objectExists(IMAGE_KEY)).willReturn(true);
-        given(observationRepository.completeImageUpload(
-                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
-        )).willReturn(false);
 
         service.connectImage(principal, EVENT_ID, request);
 
+        verify(s3Service, never()).objectExists(IMAGE_KEY);
+        verify(observationRepository, never()).completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        );
         verify(trainingEventPublisher).publishCongestionImageUpdated(SESSION_ID, item);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void 기존_UPLOADED_완료_항목도_멱등하게_처리한다() {
+        item.setEventImageKey(IMAGE_KEY);
+        item.setImageUploadedAt(request.uploadedAt());
+        item.setImageUploadStatus(ImageUploadStatus.UPLOADED);
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+
+        service.connectImage(principal, EVENT_ID, request);
+
+        verify(s3Service, never()).objectExists(IMAGE_KEY);
+        verify(observationRepository, never()).completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        );
+        verify(trainingEventPublisher).publishCongestionImageUpdated(SESSION_ID, item);
+    }
+
+    @Test
+    void 기존_항목의_누락된_이미지_상태는_PENDING으로_취급한다() {
+        item.setImageUploadStatus(null);
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        given(s3Service.objectExists(IMAGE_KEY)).willReturn(true);
+        given(observationRepository.completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        )).willReturn(true);
+
+        service.connectImage(principal, EVENT_ID, request);
+
+        verify(observationRepository).completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = DeviceErrorCode.class,
+            names = {"CCTV_CODE_MISMATCH", "CCTV_DISABLED"}
+    )
+    void CCTV_권한_검증이_실패하면_후속_처리를_중단한다(DeviceErrorCode errorCode) {
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        given(deviceAuthorizationService.validateCctv(principal, CCTV_CODE))
+                .willThrow(new ApiException(errorCode));
+
+        assertThatThrownBy(() -> service.connectImage(principal, EVENT_ID, request))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", errorCode);
+
+        verify(s3Service, never()).objectExists(IMAGE_KEY);
+        verify(observationRepository, never()).completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        );
+        verify(trainingEventPublisher, never()).publishCongestionImageUpdated(SESSION_ID, item);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventImageServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventImageServiceTest.java
@@ -1,0 +1,190 @@
+package com.saferoute.domain.congestion.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.congestion.dto.request.ConnectEventImageRequest;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.device.service.DeviceAuthorizationService;
+import com.saferoute.domain.telemetry.dynamo.entity.EventProcessingStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.global.api.error.CongestionErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.security.DevicePrincipal;
+import com.saferoute.infrastructure.s3.service.S3Service;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionEventImageServiceTest {
+
+    private static final UUID EVENT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID EDGE_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final String CCTV_CODE = "CCTV_001";
+    private static final String IMAGE_KEY = "training/" + SESSION_ID + "/events/"
+            + CCTV_CODE + "/" + EVENT_ID + ".jpg";
+
+    @InjectMocks
+    private CongestionEventImageService service;
+    @Mock
+    private ObservationRepository observationRepository;
+    @Mock
+    private DeviceAuthorizationService deviceAuthorizationService;
+    @Mock
+    private S3Service s3Service;
+    @Mock
+    private TrainingEventPublisher trainingEventPublisher;
+
+    private final DevicePrincipal principal = new DevicePrincipal(UUID.randomUUID(), CCTV_CODE);
+    private final ConnectEventImageRequest request = new ConnectEventImageRequest(IMAGE_KEY, 1_786_500_002_800L);
+    private ObservationItem item;
+
+    @BeforeEach
+    void setUp() {
+        item = ObservationItem.create(
+                EVENT_ID, SESSION_ID, EDGE_ID, CCTV_CODE, 5.0, 8, 25, 2.5,
+                CongestionLevel.CROWDED, 1_000L, 2_000L, 2_000L, null, 1L
+        );
+        item.setEventStatus(EventProcessingStatus.PROCESSED);
+    }
+
+    @Test
+    void 처리된_이벤트에_S3_이미지를_연결하고_업데이트를_발행한다() {
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        given(s3Service.objectExists(IMAGE_KEY)).willReturn(true);
+        given(observationRepository.completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        )).willReturn(true);
+
+        service.connectImage(principal, EVENT_ID, request);
+
+        verify(deviceAuthorizationService).validateCctv(principal, CCTV_CODE);
+        verify(observationRepository).completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        );
+        verify(trainingEventPublisher).publishCongestionImageUpdated(SESSION_ID, item);
+    }
+
+    @Test
+    void 이벤트_POST보다_PATCH가_먼저_도착하면_404를_반환한다() {
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.empty());
+
+        assertError(CongestionErrorCode.EVENT_NOT_FOUND, request);
+
+        verify(s3Service, never()).objectExists(IMAGE_KEY);
+    }
+
+    @Test
+    void 이벤트가_PROCESSED가_아니면_이미지를_연결하지_않는다() {
+        item.setEventStatus(EventProcessingStatus.PROCESSING);
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+
+        assertError(CongestionErrorCode.EVENT_NOT_PROCESSED, request);
+
+        verify(s3Service, never()).objectExists(IMAGE_KEY);
+    }
+
+    @Test
+    void 다른_세션_CCTV_eventId의_object_key를_거부한다() {
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        ConnectEventImageRequest wrongSession = new ConnectEventImageRequest(
+                "training/" + UUID.randomUUID() + "/events/" + CCTV_CODE + "/" + EVENT_ID + ".jpg",
+                request.uploadedAt()
+        );
+        ConnectEventImageRequest wrongCctv = new ConnectEventImageRequest(
+                "training/" + SESSION_ID + "/events/CCTV_002/" + EVENT_ID + ".jpg",
+                request.uploadedAt()
+        );
+        ConnectEventImageRequest wrongEvent = new ConnectEventImageRequest(
+                "training/" + SESSION_ID + "/events/" + CCTV_CODE + "/" + UUID.randomUUID() + ".jpg",
+                request.uploadedAt()
+        );
+
+        assertError(CongestionErrorCode.EVENT_IMAGE_IDENTITY_MISMATCH, wrongSession);
+        assertError(CongestionErrorCode.EVENT_IMAGE_IDENTITY_MISMATCH, wrongCctv);
+        assertError(CongestionErrorCode.EVENT_IMAGE_IDENTITY_MISMATCH, wrongEvent);
+
+        verify(s3Service, never()).objectExists(IMAGE_KEY);
+    }
+
+    @Test
+    void 형식이_잘못된_object_key를_거부한다() {
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        ConnectEventImageRequest malformed = new ConnectEventImageRequest(
+                "training/" + SESSION_ID + "/monitoring/" + CCTV_CODE + "/" + EVENT_ID + ".jpg",
+                request.uploadedAt()
+        );
+
+        assertError(CongestionErrorCode.EVENT_IMAGE_KEY_INVALID, malformed);
+    }
+
+    @Test
+    void S3에_객체가_없으면_연결하지_않는다() {
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        given(s3Service.objectExists(IMAGE_KEY)).willReturn(false);
+
+        assertError(CongestionErrorCode.EVENT_IMAGE_OBJECT_NOT_FOUND, request);
+
+        verify(observationRepository, never()).completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        );
+    }
+
+    @Test
+    void 동일한_완료_PATCH는_멱등하게_처리하고_이벤트를_재발행한다() {
+        item.setEventImageKey(IMAGE_KEY);
+        item.setImageUploadedAt(request.uploadedAt());
+        item.setImageUploadStatus(ImageUploadStatus.COMPLETED);
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        given(s3Service.objectExists(IMAGE_KEY)).willReturn(true);
+        given(observationRepository.completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        )).willReturn(false);
+
+        service.connectImage(principal, EVENT_ID, request);
+
+        verify(trainingEventPublisher).publishCongestionImageUpdated(SESSION_ID, item);
+    }
+
+    @Test
+    void 조건부_갱신_경쟁에서_다른_이미지가_완료되면_409를_반환한다() {
+        ObservationItem latest = item;
+        latest.setEventImageKey("training/" + SESSION_ID + "/events/" + CCTV_CODE + "/other.jpg");
+        latest.setImageUploadedAt(1L);
+        latest.setImageUploadStatus(ImageUploadStatus.COMPLETED);
+        ObservationItem initial = ObservationItem.create(
+                EVENT_ID, SESSION_ID, EDGE_ID, CCTV_CODE, 5.0, 8, 25, 2.5,
+                CongestionLevel.CROWDED, 1_000L, 2_000L, 2_000L, null, 1L
+        );
+        initial.setEventStatus(EventProcessingStatus.PROCESSED);
+        given(observationRepository.findByEventId(EVENT_ID.toString()))
+                .willReturn(Optional.of(initial), Optional.of(latest));
+        given(s3Service.objectExists(IMAGE_KEY)).willReturn(true);
+        given(observationRepository.completeImageUpload(
+                EVENT_ID.toString(), IMAGE_KEY, request.uploadedAt()
+        )).willReturn(false);
+
+        assertError(CongestionErrorCode.EVENT_IMAGE_STATE_CONFLICT, request);
+    }
+
+    private void assertError(
+            CongestionErrorCode errorCode,
+            ConnectEventImageRequest connectRequest
+    ) {
+        assertThatThrownBy(() -> service.connectImage(principal, EVENT_ID, connectRequest))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", errorCode);
+    }
+}

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
@@ -40,6 +40,7 @@ class TelemetryItemTest {
         assertThat(item.getGsi1Pk()).isEqualTo("SESSION#" + SESSION_ID + "#CCTV#CCTV_001");
         assertThat(item.getGsi1Sk()).isEqualTo("TIME#1786500005000");
         assertThat(item.getEventStatus()).isEqualTo(EventProcessingStatus.RECEIVED);
+        assertThat(item.getImageUploadStatus()).isEqualTo(ImageUploadStatus.PENDING);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
@@ -168,6 +168,26 @@ class ObservationRepositoryTest {
         assertThat(captor.getValue().item().getEventStatus().name()).isEqualTo("FAILED");
     }
 
+    @Test
+    void PROCESSED이고_이미지가_PENDING_FAILED일_때만_이미지를_완료한다() {
+        ArgumentCaptor<UpdateItemEnhancedRequest<ObservationItem>> captor = updateRequestCaptor();
+
+        boolean completed = repository.completeImageUpload(
+                "observation-1", "training/session/events/CCTV_001/event.jpg", 2_000L
+        );
+
+        assertThat(completed).isTrue();
+        verify(table).updateItem(captor.capture());
+        UpdateItemEnhancedRequest<ObservationItem> request = captor.getValue();
+        assertThat(request.item().getEventImageKey())
+                .isEqualTo("training/session/events/CCTV_001/event.jpg");
+        assertThat(request.item().getImageUploadedAt()).isEqualTo(2_000L);
+        assertThat(request.item().getImageUploadStatus().name()).isEqualTo("COMPLETED");
+        assertThat(request.conditionExpression().expression())
+                .contains("#eventStatus = :processed")
+                .contains("#imageStatus = :pending OR #imageStatus = :failed");
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     private ArgumentCaptor<PutItemEnhancedRequest<ObservationItem>> requestCaptor() {
         return (ArgumentCaptor) ArgumentCaptor.forClass(PutItemEnhancedRequest.class);

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
@@ -185,7 +185,20 @@ class ObservationRepositoryTest {
         assertThat(request.item().getImageUploadStatus().name()).isEqualTo("COMPLETED");
         assertThat(request.conditionExpression().expression())
                 .contains("#eventStatus = :processed")
+                .contains("attribute_not_exists(#imageStatus)")
                 .contains("#imageStatus = :pending OR #imageStatus = :failed");
+    }
+
+    @Test
+    void 이미지_조건부_갱신에_실패하면_false를_반환한다() {
+        doThrow(ConditionalCheckFailedException.builder().message("conflict").build())
+                .when(table).updateItem(any(UpdateItemEnhancedRequest.class));
+
+        boolean completed = repository.completeImageUpload(
+                "observation-1", "training/session/events/CCTV_001/event.jpg", 2_000L
+        );
+
+        assertThat(completed).isFalse();
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/com/saferoute/infrastructure/s3/S3ServiceTest.java
+++ b/src/test/java/com/saferoute/infrastructure/s3/S3ServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
@@ -116,5 +117,25 @@ class S3ServiceTest {
                 .thenThrow(S3Exception.builder().statusCode(404).message("not found").build());
 
         assertThat(s3Service.objectExists("missing.jpg")).isFalse();
+    }
+
+    @Test
+    void mapsS3ServerErrorToObjectCheckFailed() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(S3Exception.builder().statusCode(503).message("unavailable").build());
+
+        assertThatThrownBy(() -> s3Service.objectExists("event.jpg"))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", S3ErrorCode.OBJECT_CHECK_FAILED);
+    }
+
+    @Test
+    void mapsSdkFailureToObjectCheckFailed() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(SdkClientException.builder().message("network error").build());
+
+        assertThatThrownBy(() -> s3Service.objectExists("event.jpg"))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", S3ErrorCode.OBJECT_CHECK_FAILED);
     }
 }

--- a/src/test/java/com/saferoute/infrastructure/s3/S3ServiceTest.java
+++ b/src/test/java/com/saferoute/infrastructure/s3/S3ServiceTest.java
@@ -25,6 +25,9 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @ExtendWith(MockitoExtension.class)
 class S3ServiceTest {
@@ -91,5 +94,27 @@ class S3ServiceTest {
 
         verify(s3Client, never())
                 .putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    void findsExistingObjectWithHeadRequest() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenReturn(HeadObjectResponse.builder().build());
+
+        assertThat(s3Service.objectExists("training/session/events/CCTV_001/event.jpg")).isTrue();
+
+        ArgumentCaptor<HeadObjectRequest> captor = ArgumentCaptor.forClass(HeadObjectRequest.class);
+        verify(s3Client).headObject(captor.capture());
+        assertThat(captor.getValue().bucket()).isEqualTo("test-bucket");
+        assertThat(captor.getValue().key())
+                .isEqualTo("training/session/events/CCTV_001/event.jpg");
+    }
+
+    @Test
+    void returnsFalseWhenObjectDoesNotExist() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(S3Exception.builder().statusCode(404).message("not found").build());
+
+        assertThat(s3Service.objectExists("missing.jpg")).isFalse();
     }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #83 
- Branch: feat/#83

## 주요 내용
### 이벤트 이미지 연결 API 구현

```http
PATCH /api/v1/device/congestion-events/{eventId}/image
Authorization: Bearer {DEVICE_TOKEN}
```

이미지 업로드가 완료된 후 기존 혼잡 이벤트에 S3 Object Key를 연결하는 API를 구현했습니다.

### 이미지 연결 검증

- `eventId` 기반 혼잡 이벤트 조회
- 이벤트가 존재하지 않으면 `404 Not Found` 반환
- 이벤트 상태가 `PROCESSED`인지 검증
- 이미지 상태가 `PENDING` 또는 `FAILED`인지 검증
- Device Token의 CCTV와 이벤트 CCTV 일치 여부 검증
- Object Key의 형식 검증
- Object Key의 `sessionId` 검증
- Object Key의 `cctvCode` 검증
- Object Key의 `eventId` 검증
- S3 `HeadObject`를 통한 객체 존재 여부 확인

허용되는 Object Key 형식은 다음과 같습니다.

```text
training/{sessionId}/events/{cctvCode}/{eventId}.jpg
```

### 이미지 상태 및 DynamoDB 갱신

- `ObservationItem`에 다음 필드 추가
  - `eventImageKey`
  - `imageUploadedAt`
  - `imageUploadStatus`
- 이벤트 생성 시 이미지 상태를 `PENDING`으로 초기화
- 연결 성공 시 이미지 상태를 `COMPLETED`로 변경
- 이벤트 상태가 `PROCESSED`이고 이미지 상태가 `PENDING` 또는 `FAILED`인 경우에만 조건부 갱신
- 경쟁 요청으로 상태가 변경된 경우 `409 Conflict` 반환
- 동일한 이미지 연결 요청은 멱등하게 처리

### 관리자 화면 업데이트 이벤트

이미지 연결 완료 후 관리자 화면에 다음 WebSocket 이벤트를 발행하도록 구현했습니다.

```text
CONGESTION_IMAGE_UPDATED
```

이벤트 데이터:

- `eventId`
- `eventImageKey`
- `uploadedAt`
- `imageUploadStatus`

### S3 객체 확인

- `S3Service`에 `HeadObject` 기반 객체 존재 확인 기능 추가
- 객체가 없으면 이미지 연결을 거부
- S3 확인 과정에서 장애가 발생하면 재시도 가능한 `503 Service Unavailable` 응답 반환

## 예외 응답

| 상황 | HTTP 상태 | 에러 코드 |
| --- | --- | --- |
| 이벤트가 아직 생성되지 않음 | `404 Not Found` | `CONGESTION003` |
| 이벤트가 `PROCESSED` 상태가 아님 | `409 Conflict` | `CONGESTION004` |
| 이미지 상태 충돌 | `409 Conflict` | `CONGESTION005` |
| Object Key 형식 오류 | `400 Bad Request` | `CONGESTION006` |
| 세션·CCTV·eventId 불일치 | `409 Conflict` | `CONGESTION007` |
| S3 객체가 존재하지 않음 | `409 Conflict` | `CONGESTION008` |
| S3 객체 확인 실패 | `503 Service Unavailable` | `S3_ERROR_004` |

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 처리 완료된 혼잡 이벤트에 CCTV 이미지를 연결할 수 있는 기능을 추가했습니다.
  - 이미지 연결 요청의 유효성과 저장소 내 이미지 존재 여부를 검증합니다.
  - 이미지 연결 완료 정보를 실시간 이벤트로 전달합니다.

- **개선 사항**
  - 이미지 업로드 상태를 `PENDING`, `COMPLETED`, `FAILED`로 관리합니다.
  - 동일한 완료 요청을 안전하게 재처리할 수 있습니다.

- **테스트**
  - 이미지 연결, 검증 오류, 중복 요청 및 저장소 오류에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->