### PR TITLE
[chore] #83: dynamodb 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation platform('software.amazon.awssdk:bom:2.31.77')
     implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:dynamodb'
     implementation 'software.amazon.awssdk:dynamodb-enhanced'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #83 
- Branch: feat/#83

## 주요 내용
dynamodb는 Enhanced Client의 전이 의존성으로 현재 동작하지만, 코드에서 DynamoDbClient를 직접 사용하므로 추가함.
