### PR TITLE
Feat: #74 시나리오 API 수정

### DIFF
--- a/src/main/java/com/saferoute/domain/training/dto/ScenarioResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/ScenarioResponse.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.training.dto;
 
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
+import com.saferoute.domain.training.entity.ScenarioStatus;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import java.time.Instant;
 import java.util.UUID;
@@ -19,10 +20,17 @@ public class ScenarioResponse {
     private Instant scheduledAt;
     private Boolean isTemplate;
     private FireSpreadSpeed fireSpreadSpeed;
+    private ScenarioStatus status;
+    // 훈련 세션이 하나도 없는 시나리오만 삭제 가능. 단건 조회에선 항상 null (목록 조회 전용 필드).
+    private Boolean deletable;
     private Instant createdAt;
     private Instant updatedAt;
 
     public static ScenarioResponse from(TrainingScenario scenario) {
+        return from(scenario, null);
+    }
+
+    public static ScenarioResponse from(TrainingScenario scenario, Boolean deletable) {
         return ScenarioResponse.builder()
                 .id(scenario.getId())
                 .name(scenario.getName())
@@ -32,6 +40,8 @@ public class ScenarioResponse {
                 .scheduledAt(scenario.getScheduledAt())
                 .isTemplate(scenario.getIsTemplate())
                 .fireSpreadSpeed(scenario.getFireSpreadSpeed())
+                .status(scenario.getStatus())
+                .deletable(deletable)
                 .createdAt(scenario.getCreatedAt())
                 .updatedAt(scenario.getUpdatedAt())
                 .build();

--- a/src/main/java/com/saferoute/domain/training/entity/ScenarioStatus.java
+++ b/src/main/java/com/saferoute/domain/training/entity/ScenarioStatus.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.training.entity;
+
+// 시나리오 진행 상태. 연결된 TrainingSession의 생명주기 이벤트에 맞춰 전이된다
+// (TrainingSessionService.start()/end()/forceEnd()/failTimedOutSessions()에서 갱신).
+public enum ScenarioStatus {
+    DRAFT,
+    READY,
+    IN_PROGRESS,
+    COMPLETED,
+    ERROR
+}

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -55,6 +55,12 @@ public class TrainingScenario {
     @Column(name = "is_template", nullable = false)
     private Boolean isTemplate = false;
 
+    // 연결된 세션의 생명주기에 따라 갱신되는 진행 상태 (상태 전이 가드는 TrainingSessionService가 담당).
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ScenarioStatus status;
+
     // 화재 확산 속도. 발화점(FireZone)마다가 아니라 시나리오 전체에 하나로 적용된다.
     // 확산 시뮬레이션의 tick 간격을 결정한다. (FAST < MEDIUM < SLOW 순으로 주기가 짧음)
     @NotNull
@@ -99,6 +105,9 @@ public class TrainingScenario {
         scenario.fireSpreadSpeed = fireSpreadSpeed != null ? fireSpreadSpeed : FireSpreadSpeed.MEDIUM;
         scenario.building = building;
         scenario.admin = admin;
+        // 생성 시점엔 필수 필드가 모두 채워져 있어 바로 실행 가능한 상태로 시작한다.
+        // 초안 저장(DRAFT) 플로우는 별도 엔드포인트가 생기면 그때 지정한다.
+        scenario.status = ScenarioStatus.READY;
         return scenario;
     }
 
@@ -112,6 +121,20 @@ public class TrainingScenario {
         if (scheduledAt != null) this.scheduledAt = scheduledAt;
         if (isTemplate != null) this.isTemplate = isTemplate;
         if (fireSpreadSpeed != null) this.fireSpreadSpeed = fireSpreadSpeed;
+    }
+
+    // 상태 전이 가드는 이 엔티티가 아니라 TrainingSessionService가 담당한다
+    // (RouteRecalculation, IoTLight와 동일한 컨벤션 - 엔티티는 단순 세터).
+    public void markInProgress() {
+        this.status = ScenarioStatus.IN_PROGRESS;
+    }
+
+    public void markCompleted() {
+        this.status = ScenarioStatus.COMPLETED;
+    }
+
+    public void markError() {
+        this.status = ScenarioStatus.ERROR;
     }
 
     // 응답용 getter

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -3,10 +3,14 @@ package com.saferoute.domain.training.repository;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TrainingSessionRepository extends JpaRepository<TrainingSession, UUID> {
 
@@ -15,4 +19,10 @@ public interface TrainingSessionRepository extends JpaRepository<TrainingSession
   // Pi가 보낸 UUID 세션이 실행 중이고, 혼잡 엣지와 같은 건물에 속하는지 한 번에 검증한다.
   Optional<TrainingSession> findByIdAndStatusAndScenario_Building_Id(
       UUID id, TrainingStatus status, UUID buildingId);
+
+  boolean existsByScenario_Id(UUID scenarioId);
+
+  // 목록 조회에서 시나리오별로 deletable을 N+1 없이 계산하기 위해, 세션이 하나라도 있는 시나리오 id만 모아서 가져온다.
+  @Query("select distinct s.scenario.id from TrainingSession s where s.scenario.id in :scenarioIds")
+  Set<UUID> findScenarioIdsWithAnySession(@Param("scenarioIds") Collection<UUID> scenarioIds);
 }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -7,11 +7,14 @@ import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.entity.User;
 import com.saferoute.domain.user.repository.UserRepository;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,14 +25,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrainingScenarioService {
 
     private final TrainingScenarioRepository scenarioRepository;
+    private final TrainingSessionRepository trainingSessionRepository;
     private final BuildingRepository buildingRepository;
     private final UserRepository userRepository;
 
-    // 목록 조회
+    // 목록 조회 (deletable = 연결된 훈련 세션이 하나도 없는 시나리오인지 여부)
     public List<ScenarioResponse> getScenarios() {
-        return scenarioRepository.findAll().stream()
-                .map(ScenarioResponse::from)
-                .collect(Collectors.toList());
+        List<TrainingScenario> scenarios = scenarioRepository.findAll();
+        if (scenarios.isEmpty()) {
+            return List.of();
+        }
+
+        List<UUID> scenarioIds = scenarios.stream().map(TrainingScenario::getId).toList();
+        Set<UUID> scenarioIdsWithSession = trainingSessionRepository.findScenarioIdsWithAnySession(scenarioIds);
+
+        return scenarios.stream()
+                .map(scenario -> ScenarioResponse.from(scenario, !scenarioIdsWithSession.contains(scenario.getId())))
+                .toList();
     }
 
     // 단건 조회
@@ -71,10 +83,13 @@ public class TrainingScenarioService {
         return ScenarioResponse.from(scenario);
     }
 
-    // 삭제
+    // 삭제 (훈련 세션이 하나라도 연결된 시나리오는 삭제 불가 - 과거 훈련 기록 보존을 위해)
     @Transactional
     public void deleteScenario(UUID id) {
         TrainingScenario scenario = findById(id);
+        if (trainingSessionRepository.existsByScenario_Id(id)) {
+            throw new ApiException(TrainingErrorCode.SCENARIO_DELETE_NOT_ALLOWED);
+        }
         scenarioRepository.delete(scenario);
     }
 

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -100,6 +100,7 @@ public class TrainingSessionService {
     }
 
     session.start(Instant.now());
+    session.getScenario().markInProgress();
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
     return TrainingSessionResponse.from(session);
@@ -114,11 +115,13 @@ public class TrainingSessionService {
     }
 
     session.complete(Instant.now());
+    session.getScenario().markCompleted();
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
     return TrainingSessionResponse.from(session);
   }
 
+  // 관리자가 훈련을 중간에 강제로 끊는 경우로, 정상 종료(COMPLETED)와 구분해 시나리오도 ERROR로 표시한다.
   @Transactional
   public TrainingSessionResponse forceEnd(UUID sessionId) {
     TrainingSession session = findSession(sessionId);
@@ -128,6 +131,7 @@ public class TrainingSessionService {
     }
 
     session.stop(Instant.now());
+    session.getScenario().markError();
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
     return TrainingSessionResponse.from(session);
@@ -142,6 +146,7 @@ public class TrainingSessionService {
 
     for (TrainingSession session : timedOutSessions) {
       session.fail(Instant.now());
+      session.getScenario().markError();
       trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
       log.info("훈련 세션 타임아웃 처리: sessionId={}", session.getId());
     }

--- a/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
@@ -14,7 +14,8 @@ public enum TrainingErrorCode implements BaseErrorCode {
     TRAINING_SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "TRAINING003", "훈련 시나리오를 찾을 수 없습니다."),
     INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, "TRAINING004", "현재 상태에서는 요청한 전이를 수행할 수 없습니다."),
     UNSUPPORTED_STATUS(HttpStatus.CONFLICT, "TRAINING005", "지원하지 않는 훈련 상태입니다."),
-    RUNNING_TRAINING_SESSION_NOT_FOUND(HttpStatus.CONFLICT,"TRAINING006", "진행 중인 훈련 세션을 찾을 수 없습니다.");
+    RUNNING_TRAINING_SESSION_NOT_FOUND(HttpStatus.CONFLICT,"TRAINING006", "진행 중인 훈련 세션을 찾을 수 없습니다."),
+    SCENARIO_DELETE_NOT_ALLOWED(HttpStatus.CONFLICT, "TRAINING007", "훈련 세션이 존재하는 시나리오는 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -1,0 +1,137 @@
+package com.saferoute.domain.training.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.training.dto.ScenarioResponse;
+import com.saferoute.domain.training.entity.FireSpreadSpeed;
+import com.saferoute.domain.training.entity.TrainingScenario;
+import com.saferoute.domain.training.repository.TrainingScenarioRepository;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.domain.user.entity.User;
+import com.saferoute.domain.user.repository.UserRepository;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TrainingScenarioServiceTest {
+
+    @InjectMocks
+    private TrainingScenarioService trainingScenarioService;
+
+    @Mock
+    private TrainingScenarioRepository scenarioRepository;
+
+    @Mock
+    private TrainingSessionRepository trainingSessionRepository;
+
+    @Mock
+    private BuildingRepository buildingRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private TrainingScenario scenarioWithId(UUID id) {
+        TrainingScenario scenario = TrainingScenario.create(
+                "테스트 시나리오",
+                10,
+                Instant.now(),
+                false,
+                FireSpreadSpeed.MEDIUM,
+                mock(Building.class),
+                mock(User.class));
+        ReflectionTestUtils.setField(scenario, "id", id);
+        return scenario;
+    }
+
+    // === getScenarios (deletable) ===
+
+    @Test
+    @DisplayName("연결된 훈련 세션이 없는 시나리오는 deletable=true로 응답한다")
+    void getScenarios_scenarioWithoutSession_isDeletable() {
+        UUID scenarioId = UUID.randomUUID();
+        TrainingScenario scenario = scenarioWithId(scenarioId);
+        given(scenarioRepository.findAll()).willReturn(List.of(scenario));
+        given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
+                .willReturn(Set.of());
+
+        List<ScenarioResponse> responses = trainingScenarioService.getScenarios();
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getDeletable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("연결된 훈련 세션이 하나라도 있는 시나리오는 deletable=false로 응답한다")
+    void getScenarios_scenarioWithSession_isNotDeletable() {
+        UUID scenarioId = UUID.randomUUID();
+        TrainingScenario scenario = scenarioWithId(scenarioId);
+        given(scenarioRepository.findAll()).willReturn(List.of(scenario));
+        given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
+                .willReturn(Set.of(scenarioId));
+
+        List<ScenarioResponse> responses = trainingScenarioService.getScenarios();
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getDeletable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("시나리오가 하나도 없으면 세션 조회 없이 빈 목록을 반환한다")
+    void getScenarios_noScenarios_returnsEmptyListWithoutQueryingSessions() {
+        given(scenarioRepository.findAll()).willReturn(List.of());
+
+        List<ScenarioResponse> responses = trainingScenarioService.getScenarios();
+
+        assertThat(responses).isEmpty();
+        verify(trainingSessionRepository, never()).findScenarioIdsWithAnySession(org.mockito.ArgumentMatchers.any());
+    }
+
+    // === deleteScenario ===
+
+    @Test
+    @DisplayName("연결된 훈련 세션이 없으면 시나리오를 삭제할 수 있다")
+    void deleteScenario_withoutSession_deletesScenario() {
+        UUID scenarioId = UUID.randomUUID();
+        TrainingScenario scenario = scenarioWithId(scenarioId);
+        given(scenarioRepository.findById(scenarioId)).willReturn(Optional.of(scenario));
+        given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(false);
+
+        trainingScenarioService.deleteScenario(scenarioId);
+
+        verify(scenarioRepository).delete(scenario);
+    }
+
+    @Test
+    @DisplayName("연결된 훈련 세션이 하나라도 있으면 시나리오 삭제가 거부된다")
+    void deleteScenario_withSession_throwsException() {
+        UUID scenarioId = UUID.randomUUID();
+        TrainingScenario scenario = scenarioWithId(scenarioId);
+        given(scenarioRepository.findById(scenarioId)).willReturn(Optional.of(scenario));
+        given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(true);
+
+        assertThatThrownBy(() -> trainingScenarioService.deleteScenario(scenarioId))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.SCENARIO_DELETE_NOT_ALLOWED);
+        verify(scenarioRepository, never()).delete(scenario);
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -88,7 +88,7 @@ class TrainingSessionServiceTest {
     // === start ===
 
     @Test
-    @DisplayName("SCHEDULED 상태의 세션을 시작하면 RUNNING으로 전이하고 이벤트를 발행한다")
+    @DisplayName("SCHEDULED 상태의 세션을 시작하면 RUNNING으로 전이하고 이벤트를 발행하며 시나리오도 IN_PROGRESS로 바뀐다")
     void start_fromScheduled_transitionsToRunningAndPublishesEvent() {
         TrainingSession session = sessionWithStatus(TrainingStatus.SCHEDULED);
         given(trainingSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
@@ -97,6 +97,7 @@ class TrainingSessionServiceTest {
 
         assertThat(session.getStatus()).isEqualTo(TrainingStatus.RUNNING);
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
+        verify(session.getScenario(), times(1)).markInProgress();
     }
 
     @Test
@@ -126,7 +127,7 @@ class TrainingSessionServiceTest {
     // === end ===
 
     @Test
-    @DisplayName("RUNNING 상태의 세션을 정상 종료하면 COMPLETED로 전이하고 이벤트를 발행한다")
+    @DisplayName("RUNNING 상태의 세션을 정상 종료하면 COMPLETED로 전이하고 이벤트를 발행하며 시나리오도 COMPLETED로 바뀐다")
     void end_fromRunning_transitionsToCompletedAndPublishesEvent() {
         TrainingSession session = sessionWithStatus(TrainingStatus.RUNNING);
         given(trainingSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
@@ -136,6 +137,7 @@ class TrainingSessionServiceTest {
         assertThat(session.getStatus()).isEqualTo(TrainingStatus.COMPLETED);
         assertThat(session.getEndedAt()).isNotNull();
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
+        verify(session.getScenario(), times(1)).markCompleted();
     }
 
     @Test
@@ -166,7 +168,7 @@ class TrainingSessionServiceTest {
     // === forceEnd ===
 
     @Test
-    @DisplayName("RUNNING 상태의 세션을 강제 종료하면 STOPPED로 전이하고 이벤트를 발행한다")
+    @DisplayName("RUNNING 상태의 세션을 강제 종료하면 STOPPED로 전이하고 이벤트를 발행하며 시나리오는 ERROR로 바뀐다")
     void forceEnd_fromRunning_transitionsToStoppedAndPublishesEvent() {
         TrainingSession session = sessionWithStatus(TrainingStatus.RUNNING);
         given(trainingSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
@@ -175,6 +177,7 @@ class TrainingSessionServiceTest {
 
         assertThat(session.getStatus()).isEqualTo(TrainingStatus.STOPPED);
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
+        verify(session.getScenario(), times(1)).markError();
     }
 
     @Test
@@ -205,7 +208,7 @@ class TrainingSessionServiceTest {
     // === failTimedOutSessions ===
 
     @Test
-    @DisplayName("10분 타임아웃을 넘긴 RUNNING 세션을 FAILED로 처리하고 이벤트를 발행한다")
+    @DisplayName("10분 타임아웃을 넘긴 RUNNING 세션을 FAILED로 처리하고 이벤트를 발행하며 시나리오는 ERROR로 바뀐다")
     void failTimedOutSessions_marksExpiredSessionsAsFailed() {
         TrainingSession timedOut = TrainingSession.create(
                 TrainingStatus.RUNNING,
@@ -221,6 +224,7 @@ class TrainingSessionServiceTest {
 
         assertThat(timedOut.getStatus()).isEqualTo(TrainingStatus.FAILED);
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(timedOut);
+        verify(timedOut.getScenario(), times(1)).markError();
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #74
- Branch: feat/#74

## 주요 내용

- `TrainingScenario`에 `status`(DRAFT/READY/IN_PROGRESS/COMPLETED/ERROR) 필드 추가
- 훈련 세션 생명주기와 시나리오 상태 자동 동기화
  - 세션 시작(`start`) → `IN_PROGRESS`
  - 정상 종료(`end`) → `COMPLETED`
  - 강제 종료(`forceEnd`) / 타임아웃(`failTimedOutSessions`) → `ERROR`
- 시나리오 목록 조회 응답에 `deletable` 필드 추가 (연결된 훈련 세션이 하나도 없으면 true)
- 세션이 하나라도 존재하는 시나리오는 삭제 시 `SCENARIO_DELETE_NOT_ALLOWED`(409)로 거부
- 목록 조회 시 N+1 방지를 위해 세션 존재 여부를 단일 쿼리(`findScenarioIdsWithAnySession`)로 일괄 조회

> `DRAFT` 상태는 enum 값만 정의했습니다. 현재 생성 API(`createScenario`)는 필수 필드를 모두 요구해서 항상 `READY`로 생성되며, `DRAFT`를 실제로 세팅하는 임시저장 플로우는 이번 스코프에 없어 별도 이슈로 진행이 필요합니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?