### PR TITLE
Feat/#87 혼잡 설정 및 configVersion 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/entity/CongestionConfig.java
+++ b/src/main/java/com/saferoute/domain/congestion/entity/CongestionConfig.java
@@ -1,0 +1,130 @@
+package com.saferoute.domain.congestion.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+// Pi가 사용하는 혼잡 임계값·탐지 설정. CCTV마다 다르게 둘 이유가 없어 시스템 전체가 공유하는
+// 단일 행(싱글턴)으로 관리한다 (id는 고정값). 감시 면적은 CCTV별로 이미 계산되므로 여기 포함하지 않는다.
+@Entity
+@Getter
+@Table(name = "congestion_configs")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CongestionConfig {
+
+    // 싱글턴 행을 findById로 바로 찾기 위한 고정 id. 새로 발급하지 않는다.
+    public static final UUID SINGLETON_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Id
+    private UUID id;
+
+    // Pi/BE가 같은 설정을 보고 있는지 판단하는 버전. 아래 필드 중 하나라도 바뀌거나
+    // CCTV 감시 영역(GridCell)이 바뀌면 증가한다 (감시 영역 변경 트리거는 CctvService/CctvRegistrationService에서 호출).
+    @Column(name = "version", nullable = false)
+    private long version;
+
+    @Column(name = "snapshot_interval_sec", nullable = false)
+    private Integer snapshotIntervalSec;
+
+    @Column(name = "target_inference_fps", nullable = false)
+    private Integer targetInferenceFps;
+
+    @Column(name = "caution_from", nullable = false)
+    private Double cautionFrom;
+
+    @Column(name = "crowded_from", nullable = false)
+    private Double crowdedFrom;
+
+    @Column(name = "very_crowded_from", nullable = false)
+    private Double veryCrowdedFrom;
+
+    @Column(name = "required_consecutive_frames", nullable = false)
+    private Integer requiredConsecutiveFrames;
+
+    @Column(name = "recovery_consecutive_frames", nullable = false)
+    private Integer recoveryConsecutiveFrames;
+
+    @Column(name = "cooldown_sec", nullable = false)
+    private Integer cooldownSec;
+
+    @Column(name = "state_stale_after_sec", nullable = false)
+    private Integer stateStaleAfterSec;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    private CongestionConfig(Integer snapshotIntervalSec, Integer targetInferenceFps,
+            Double cautionFrom, Double crowdedFrom, Double veryCrowdedFrom,
+            Integer requiredConsecutiveFrames, Integer recoveryConsecutiveFrames,
+            Integer cooldownSec, Integer stateStaleAfterSec) {
+        this.id = SINGLETON_ID;
+        this.version = 1L;
+        this.snapshotIntervalSec = snapshotIntervalSec;
+        this.targetInferenceFps = targetInferenceFps;
+        this.cautionFrom = cautionFrom;
+        this.crowdedFrom = crowdedFrom;
+        this.veryCrowdedFrom = veryCrowdedFrom;
+        this.requiredConsecutiveFrames = requiredConsecutiveFrames;
+        this.recoveryConsecutiveFrames = recoveryConsecutiveFrames;
+        this.cooldownSec = cooldownSec;
+        this.stateStaleAfterSec = stateStaleAfterSec;
+    }
+
+    // 문서(2.2, 2.3절)에 명시된 기본값으로 최초 1회 생성되는 설정.
+    public static CongestionConfig createDefault() {
+        return new CongestionConfig(5, 5, 2.0, 3.0, 5.0, 3, 5, 30, 15);
+    }
+
+    // CCTV 감시 영역(GridCell) 변경처럼 이 엔티티의 필드는 그대로지만
+    // Pi가 다시 조회해야 하는 변경이 생겼을 때 외부에서 호출한다.
+    public void incrementVersion() {
+        this.version++;
+    }
+
+    // 값이 실제로 바뀐 필드가 하나라도 있을 때만 version을 올린다 (no-op 갱신 요청으로 버전이 튀는 것 방지).
+    public void updateSettings(Integer snapshotIntervalSec, Integer targetInferenceFps,
+            Double cautionFrom, Double crowdedFrom, Double veryCrowdedFrom,
+            Integer requiredConsecutiveFrames, Integer recoveryConsecutiveFrames,
+            Integer cooldownSec, Integer stateStaleAfterSec) {
+        boolean changed = false;
+        changed |= applyIfChanged(snapshotIntervalSec, this.snapshotIntervalSec, v -> this.snapshotIntervalSec = v);
+        changed |= applyIfChanged(targetInferenceFps, this.targetInferenceFps, v -> this.targetInferenceFps = v);
+        changed |= applyIfChanged(cautionFrom, this.cautionFrom, v -> this.cautionFrom = v);
+        changed |= applyIfChanged(crowdedFrom, this.crowdedFrom, v -> this.crowdedFrom = v);
+        changed |= applyIfChanged(veryCrowdedFrom, this.veryCrowdedFrom, v -> this.veryCrowdedFrom = v);
+        changed |= applyIfChanged(requiredConsecutiveFrames, this.requiredConsecutiveFrames,
+                v -> this.requiredConsecutiveFrames = v);
+        changed |= applyIfChanged(recoveryConsecutiveFrames, this.recoveryConsecutiveFrames,
+                v -> this.recoveryConsecutiveFrames = v);
+        changed |= applyIfChanged(cooldownSec, this.cooldownSec, v -> this.cooldownSec = v);
+        changed |= applyIfChanged(stateStaleAfterSec, this.stateStaleAfterSec, v -> this.stateStaleAfterSec = v);
+
+        if (changed) {
+            this.version++;
+        }
+    }
+
+    private <T> boolean applyIfChanged(T newValue, T currentValue, java.util.function.Consumer<T> setter) {
+        if (newValue == null || newValue.equals(currentValue)) {
+            return false;
+        }
+        setter.accept(newValue);
+        return true;
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/repository/CongestionConfigRepository.java
+++ b/src/main/java/com/saferoute/domain/congestion/repository/CongestionConfigRepository.java
@@ -1,0 +1,11 @@
+package com.saferoute.domain.congestion.repository;
+
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CongestionConfigRepository extends JpaRepository<CongestionConfig, UUID> {
+
+}

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionConfigService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionConfigService.java
@@ -1,0 +1,55 @@
+package com.saferoute.domain.congestion.service;
+
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+import com.saferoute.domain.congestion.repository.CongestionConfigRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CongestionConfigService {
+
+    private final CongestionConfigRepository congestionConfigRepository;
+
+    // 싱글턴 설정을 조회하고, 앱이 아직 한 번도 초기화되지 않았다면 기본값으로 최초 생성한다.
+    // 클래스 기본은 readOnly라 쓰기(최초 생성)가 필요한 이 메서드만 별도로 쓰기 트랜잭션을 연다.
+    @Transactional
+    public CongestionConfig getConfig() {
+        return congestionConfigRepository.findById(CongestionConfig.SINGLETON_ID)
+                .orElseGet(this::createDefaultConfig);
+    }
+
+    // 값 필드 변경. null로 넘긴 필드는 유지되고, 실제로 값이 바뀐 경우에만 configVersion이 증가한다.
+    @Transactional
+    public CongestionConfig updateSettings(Integer snapshotIntervalSec, Integer targetInferenceFps,
+            Double cautionFrom, Double crowdedFrom, Double veryCrowdedFrom,
+            Integer requiredConsecutiveFrames, Integer recoveryConsecutiveFrames,
+            Integer cooldownSec, Integer stateStaleAfterSec) {
+        CongestionConfig config = getConfig();
+        config.updateSettings(snapshotIntervalSec, targetInferenceFps, cautionFrom, crowdedFrom, veryCrowdedFrom,
+                requiredConsecutiveFrames, recoveryConsecutiveFrames, cooldownSec, stateStaleAfterSec);
+        return config;
+    }
+
+    // CCTV 감시 영역(GridCell) 매핑이 바뀌었을 때 CctvService/CctvRegistrationService가 호출한다.
+    // 이 엔티티 자체의 필드는 그대로지만, Pi가 다시 설정을 조회해야 하므로 버전만 올린다.
+    @Transactional
+    public void incrementVersionForGridChange() {
+        getConfig().incrementVersion();
+    }
+
+    // 동시에 여러 요청이 최초 설정을 만들려고 하면 고정 id의 PK 제약에서 하나만 성공하므로,
+    // 진 요청은 방금 다른 트랜잭션이 만든 행을 다시 읽어온다 (CctvCodeAllocator와 동일한 컨벤션).
+    // getConfig()의 쓰기 트랜잭션 안에서 self-invocation으로 호출되므로 별도 @Transactional을 붙이지 않는다.
+    private CongestionConfig createDefaultConfig() {
+        try {
+            return congestionConfigRepository.save(CongestionConfig.createDefault());
+        } catch (DataIntegrityViolationException exception) {
+            return congestionConfigRepository.findById(CongestionConfig.SINGLETON_ID)
+                    .orElseThrow(() -> exception);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/dto/response/CctvResponse.java
+++ b/src/main/java/com/saferoute/domain/device/dto/response/CctvResponse.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.device.dto.response;
 
 import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.util.MonitoredAreaCalculator;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import java.util.List;
 import java.util.UUID;
@@ -21,10 +22,7 @@ public record CctvResponse(
 ) {
     public static CctvResponse of(Cctv cctv, List<FloorGridCell> gridCells) {
         Double cellSizeMeter = cctv.getCustomNode().getFloor().getGridCellSizeMeter();
-        boolean validCellSizeMeter = cellSizeMeter != null && cellSizeMeter > 0;
-        Double monitoredAreaM2 = !validCellSizeMeter
-                ? null
-                : gridCells.size() * cellSizeMeter * cellSizeMeter;
+        Double monitoredAreaM2 = MonitoredAreaCalculator.calculate(gridCells.size(), cellSizeMeter);
         return new CctvResponse(
                 cctv.getId(),
                 cctv.getCode(),

--- a/src/main/java/com/saferoute/domain/device/service/CctvRegistrationService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvRegistrationService.java
@@ -7,6 +7,7 @@ import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.congestion.service.CongestionConfigService;
 import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
@@ -37,6 +38,7 @@ public class CctvRegistrationService {
     private final MapNodeJpaRepository mapNodeJpaRepository;
     private final FloorRepository floorRepository;
     private final DeviceTokenService deviceTokenService;
+    private final CongestionConfigService congestionConfigService;
 
     // MapNode/Cctv/매핑 저장은 하나의 트랜잭션으로 처리한다.
     // CCTV 코드는 호출 전에 독립 트랜잭션의 DB sequence로 이미 발급된다.
@@ -67,6 +69,7 @@ public class CctvRegistrationService {
                         .map(cell -> CctvGridCell.create(savedCctv, cell))
                         .toList()
         );
+        congestionConfigService.incrementVersionForGridChange();
 
         return new CctvRegistrationResponse(
                 CctvResponse.of(savedCctv, gridCells),

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -9,6 +9,7 @@ import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.congestion.service.CongestionConfigService;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
 import com.saferoute.domain.floor.entity.Floor;
@@ -37,6 +38,7 @@ public class CctvService {
     private final CctvCodeAllocator cctvCodeAllocator;
     private final CctvRegistrationService cctvRegistrationService;
     private final DeviceTokenService deviceTokenService;
+    private final CongestionConfigService congestionConfigService;
 
     public CctvRegistrationResponse createCctv(CreateCctvRequest request) {
         return cctvRegistrationService.register(request, cctvCodeAllocator.allocate());
@@ -100,6 +102,7 @@ public class CctvService {
 
         cctvGridCellRepository.deleteAllByCctvId(cctvId);
         saveMappings(cctv, gridCells);
+        congestionConfigService.incrementVersionForGridChange();
         return CctvResponse.of(cctv, gridCells);
     }
 

--- a/src/main/java/com/saferoute/domain/device/util/MonitoredAreaCalculator.java
+++ b/src/main/java/com/saferoute/domain/device/util/MonitoredAreaCalculator.java
@@ -1,0 +1,17 @@
+package com.saferoute.domain.device.util;
+
+// CCTV의 감시 면적(monitoredAreaM2) 계산. CctvResponse(관리자 응답)와
+// 향후 Pi 설정 조회 API(이슈 6)가 동일한 계산을 공유하기 위해 분리했다.
+public final class MonitoredAreaCalculator {
+
+    private MonitoredAreaCalculator() {
+    }
+
+    // gridCellSizeMeter가 아직 설정되지 않은 층이면 면적을 계산할 수 없어 null을 반환한다.
+    public static Double calculate(int gridCellCount, Double gridCellSizeMeter) {
+        if (gridCellSizeMeter == null || gridCellSizeMeter <= 0) {
+            return null;
+        }
+        return gridCellCount * gridCellSizeMeter * gridCellSizeMeter;
+    }
+}

--- a/src/test/java/com/saferoute/domain/congestion/entity/CongestionConfigTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/entity/CongestionConfigTest.java
@@ -1,0 +1,60 @@
+package com.saferoute.domain.congestion.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CongestionConfigTest {
+
+    @Test
+    @DisplayName("기본 설정은 문서에 정의된 값과 configVersion=1로 생성된다")
+    void createDefault_hasDocumentedDefaultsAndVersionOne() {
+        CongestionConfig config = CongestionConfig.createDefault();
+
+        assertThat(config.getId()).isEqualTo(CongestionConfig.SINGLETON_ID);
+        assertThat(config.getVersion()).isEqualTo(1L);
+        assertThat(config.getSnapshotIntervalSec()).isEqualTo(5);
+        assertThat(config.getTargetInferenceFps()).isEqualTo(5);
+        assertThat(config.getCautionFrom()).isEqualTo(2.0);
+        assertThat(config.getCrowdedFrom()).isEqualTo(3.0);
+        assertThat(config.getVeryCrowdedFrom()).isEqualTo(5.0);
+        assertThat(config.getRequiredConsecutiveFrames()).isEqualTo(3);
+        assertThat(config.getRecoveryConsecutiveFrames()).isEqualTo(5);
+        assertThat(config.getCooldownSec()).isEqualTo(30);
+        assertThat(config.getStateStaleAfterSec()).isEqualTo(15);
+    }
+
+    @Test
+    @DisplayName("incrementVersion은 다른 필드를 건드리지 않고 버전만 올린다")
+    void incrementVersion_onlyBumpsVersion() {
+        CongestionConfig config = CongestionConfig.createDefault();
+
+        config.incrementVersion();
+
+        assertThat(config.getVersion()).isEqualTo(2L);
+        assertThat(config.getCautionFrom()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("값이 실제로 바뀐 필드가 있으면 configVersion이 증가한다")
+    void updateSettings_withChangedValue_incrementsVersion() {
+        CongestionConfig config = CongestionConfig.createDefault();
+
+        config.updateSettings(null, null, 2.5, null, null, null, null, null, null);
+
+        assertThat(config.getVersion()).isEqualTo(2L);
+        assertThat(config.getCautionFrom()).isEqualTo(2.5);
+    }
+
+    @Test
+    @DisplayName("기존 값과 동일하거나 null인 필드만 넘기면 configVersion이 증가하지 않는다")
+    void updateSettings_withoutRealChange_doesNotIncrementVersion() {
+        CongestionConfig config = CongestionConfig.createDefault();
+
+        config.updateSettings(null, null, 2.0, null, null, null, null, null, null);
+
+        assertThat(config.getVersion()).isEqualTo(1L);
+        assertThat(config.getCautionFrom()).isEqualTo(2.0);
+    }
+}

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionConfigServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionConfigServiceTest.java
@@ -1,0 +1,92 @@
+package com.saferoute.domain.congestion.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+import com.saferoute.domain.congestion.repository.CongestionConfigRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionConfigServiceTest {
+
+    @InjectMocks
+    private CongestionConfigService congestionConfigService;
+
+    @Mock
+    private CongestionConfigRepository congestionConfigRepository;
+
+    @Test
+    @DisplayName("설정이 이미 있으면 그대로 반환하고 새로 만들지 않는다")
+    void getConfig_existing_returnsWithoutCreating() {
+        CongestionConfig existing = CongestionConfig.createDefault();
+        given(congestionConfigRepository.findById(CongestionConfig.SINGLETON_ID))
+                .willReturn(Optional.of(existing));
+
+        CongestionConfig result = congestionConfigService.getConfig();
+
+        assertThat(result).isSameAs(existing);
+    }
+
+    @Test
+    @DisplayName("설정이 없으면 기본값으로 최초 생성한다")
+    void getConfig_missing_createsDefault() {
+        given(congestionConfigRepository.findById(CongestionConfig.SINGLETON_ID))
+                .willReturn(Optional.empty());
+        given(congestionConfigRepository.save(org.mockito.ArgumentMatchers.any(CongestionConfig.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        CongestionConfig result = congestionConfigService.getConfig();
+
+        assertThat(result.getVersion()).isEqualTo(1L);
+        assertThat(result.getCautionFrom()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("동시에 최초 생성이 경합하면 유니크 제약 충돌 후 이미 만들어진 행을 다시 읽는다")
+    void getConfig_concurrentCreationConflict_reReadsExistingRow() {
+        CongestionConfig alreadyCreatedByOtherTransaction = CongestionConfig.createDefault();
+        given(congestionConfigRepository.findById(CongestionConfig.SINGLETON_ID))
+                .willReturn(Optional.empty())
+                .willReturn(Optional.of(alreadyCreatedByOtherTransaction));
+        given(congestionConfigRepository.save(org.mockito.ArgumentMatchers.any(CongestionConfig.class)))
+                .willThrow(new DataIntegrityViolationException("duplicate key"));
+
+        CongestionConfig result = congestionConfigService.getConfig();
+
+        assertThat(result).isSameAs(alreadyCreatedByOtherTransaction);
+    }
+
+    @Test
+    @DisplayName("감시 영역 변경 시 설정 값은 그대로 두고 버전만 올린다")
+    void incrementVersionForGridChange_bumpsVersionOnly() {
+        CongestionConfig config = mock(CongestionConfig.class);
+        given(congestionConfigRepository.findById(CongestionConfig.SINGLETON_ID))
+                .willReturn(Optional.of(config));
+
+        congestionConfigService.incrementVersionForGridChange();
+
+        verify(config).incrementVersion();
+    }
+
+    @Test
+    @DisplayName("설정 변경 요청을 엔티티의 updateSettings로 위임한다")
+    void updateSettings_delegatesToEntity() {
+        CongestionConfig config = mock(CongestionConfig.class);
+        given(congestionConfigRepository.findById(CongestionConfig.SINGLETON_ID))
+                .willReturn(Optional.of(config));
+
+        congestionConfigService.updateSettings(10, null, 2.5, null, null, null, null, null, null);
+
+        verify(config).updateSettings(10, null, 2.5, null, null, null, null, null, null);
+    }
+}

--- a/src/test/java/com/saferoute/domain/device/service/CctvRegistrationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvRegistrationServiceTest.java
@@ -12,6 +12,7 @@ import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.congestion.service.CongestionConfigService;
 import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
@@ -40,6 +41,7 @@ class CctvRegistrationServiceTest {
     @Mock MapNodeJpaRepository mapNodeJpaRepository;
     @Mock FloorRepository floorRepository;
     @Mock DeviceTokenService deviceTokenService;
+    @Mock CongestionConfigService congestionConfigService;
 
     private CctvRegistrationService service;
     private Floor floor;
@@ -53,7 +55,8 @@ class CctvRegistrationServiceTest {
                 floorGridCellRepository,
                 mapNodeJpaRepository,
                 floorRepository,
-                deviceTokenService
+                deviceTokenService,
+                congestionConfigService
         );
         floor = org.mockito.Mockito.mock(Floor.class);
         floorId = UUID.randomUUID();
@@ -87,6 +90,7 @@ class CctvRegistrationServiceTest {
         ArgumentCaptor<List<CctvGridCell>> mappings = ArgumentCaptor.forClass(List.class);
         verify(cctvGridCellRepository).saveAll(mappings.capture());
         assertThat(mappings.getValue()).hasSize(2);
+        verify(congestionConfigService).incrementVersionForGridChange();
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -16,6 +16,7 @@ import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.congestion.service.CongestionConfigService;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
@@ -42,6 +43,7 @@ class CctvServiceTest {
     @Mock CctvCodeAllocator cctvCodeAllocator;
     @Mock CctvRegistrationService cctvRegistrationService;
     @Mock DeviceTokenService deviceTokenService;
+    @Mock CongestionConfigService congestionConfigService;
 
     private CctvService cctvService;
 
@@ -53,7 +55,8 @@ class CctvServiceTest {
                 floorGridCellRepository,
                 cctvCodeAllocator,
                 cctvRegistrationService,
-                deviceTokenService
+                deviceTokenService,
+                congestionConfigService
         );
     }
 
@@ -159,6 +162,7 @@ class CctvServiceTest {
 
         verify(cctvGridCellRepository).deleteAllByCctvId(cctvId);
         verify(cctvGridCellRepository).saveAll(any());
+        verify(congestionConfigService).incrementVersionForGridChange();
     }
 
     private CreateCctvRequest request() {

--- a/src/test/java/com/saferoute/domain/device/util/MonitoredAreaCalculatorTest.java
+++ b/src/test/java/com/saferoute/domain/device/util/MonitoredAreaCalculatorTest.java
@@ -1,0 +1,30 @@
+package com.saferoute.domain.device.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MonitoredAreaCalculatorTest {
+
+    @Test
+    @DisplayName("GridCell 개수와 셀 크기로 감시 면적을 계산한다")
+    void calculate_returnsCellCountTimesSquaredCellSize() {
+        Double area = MonitoredAreaCalculator.calculate(8, 0.5);
+
+        assertThat(area).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("셀 크기가 설정되지 않았으면 null을 반환한다")
+    void calculate_nullCellSize_returnsNull() {
+        assertThat(MonitoredAreaCalculator.calculate(8, null)).isNull();
+    }
+
+    @Test
+    @DisplayName("셀 크기가 0 이하이면 null을 반환한다")
+    void calculate_nonPositiveCellSize_returnsNull() {
+        assertThat(MonitoredAreaCalculator.calculate(8, 0.0)).isNull();
+        assertThat(MonitoredAreaCalculator.calculate(8, -1.0)).isNull();
+    }
+}


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #87
- Branch: feat/#87

## 주요 내용

- `CongestionConfig` 싱글턴 엔티티 및 저장소 추가 (Pi가 사용할 혼잡 임계값/탐지 설정을 시스템 전체가 공유하는 단일 행으로 관리)
- `CongestionConfigService` 구현
  - `getConfig()`: 최초 조회 시 문서 기본값(스냅샷 5초, FPS 5, CAUTION 2.0/CROWDED 3.0/VERY_CROWDED 5.0, 연속프레임 3/5, cooldown 30초, stale 15초)으로 자동 생성. 동시 생성 경합은 재조회로 처리
  - `updateSettings()`: 값이 실제로 바뀐 필드가 있을 때만 configVersion 증가
  - `incrementVersionForGridChange()`: 설정 값은 그대로 두고 버전만 증가
- CCTV 감시 영역(GridCell) 변경 시 configVersion 증가 연결
  - 신규 등록(`CctvRegistrationService.register`)
  - 감시 영역 재설정(`CctvService.configureGridCells`)
- 감시 면적(monitoredAreaM2) 계산 로직을 `MonitoredAreaCalculator`로 분리 (기존 `CctvResponse` 인라인 계산 리팩터, 이후 Pi 설정 조회 API에서 재사용 예정)

> 혼잡 임계값/FPS/탐지조건은 CCTV별이 아니라 시스템 전체가 공유하는 전역 설정으로 구현했습니다. 문서에 CCTV별로 다르게 설정한다는 근거가 없고, 감시 면적만 CCTV별로 이미 계산되고 있어서(`CctvResponse`) 이렇게 결정했습니다.
>
> `updateSettings()`를 호출할 관리자용 API는 이번 범위에 포함하지 않았습니다. 서비스 레이어까지만 구현했고, 실제로 이 값을 누가/어떤 엔드포인트로 바꿀지는 별도 논의가 필요합니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?