### PR TITLE
Feat/#89 Pi 혼잡 설정 조회 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionConfigController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionConfigController.java
@@ -1,0 +1,37 @@
+package com.saferoute.domain.congestion.controller;
+
+import com.saferoute.domain.congestion.dto.response.CongestionConfigQueryResponse;
+import com.saferoute.domain.congestion.service.CongestionConfigQueryService;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.service.DeviceAuthorizationService;
+import com.saferoute.global.security.DevicePrincipal;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "혼잡도", description = "Pi 혼잡 설정 조회 API")
+@RestController
+@RequestMapping("/api/v1/device/congestion-config")
+@RequiredArgsConstructor
+@Validated
+public class CongestionConfigController {
+
+    private final DeviceAuthorizationService deviceAuthorizationService;
+    private final CongestionConfigQueryService congestionConfigQueryService;
+
+    @GetMapping
+    public ResponseEntity<CongestionConfigQueryResponse> getConfig(
+            @AuthenticationPrincipal DevicePrincipal principal,
+            @RequestParam @NotBlank String cctvCode
+    ) {
+        Cctv cctv = deviceAuthorizationService.validateCctv(principal, cctvCode);
+        return ResponseEntity.ok(congestionConfigQueryService.getConfigFor(cctv));
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/dto/response/CongestionConfigQueryResponse.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/response/CongestionConfigQueryResponse.java
@@ -1,0 +1,39 @@
+package com.saferoute.domain.congestion.dto.response;
+
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+
+public record CongestionConfigQueryResponse(
+        boolean trainingActive,
+        String trainingSessionId,
+        String cctvCode,
+        Double monitoredAreaM2,
+        Long configVersion,
+        Integer snapshotIntervalSec,
+        Integer targetInferenceFps,
+        CongestionThresholdsResponse congestionThresholds,
+        EventDetectionResponse eventDetection
+) {
+
+    // 훈련 중이 아니면 Pi는 재시도 주기만 알면 되므로, 판정 설정은 내려주지 않고 configVersion만 포함한다.
+    public static CongestionConfigQueryResponse inactive(String cctvCode, CongestionConfig config) {
+        return new CongestionConfigQueryResponse(
+                false, null, cctvCode, null, config.getVersion(), null, null, null, null
+        );
+    }
+
+    public static CongestionConfigQueryResponse active(
+            String trainingSessionId, String cctvCode, Double monitoredAreaM2, CongestionConfig config
+    ) {
+        return new CongestionConfigQueryResponse(
+                true,
+                trainingSessionId,
+                cctvCode,
+                monitoredAreaM2,
+                config.getVersion(),
+                config.getSnapshotIntervalSec(),
+                config.getTargetInferenceFps(),
+                CongestionThresholdsResponse.from(config),
+                EventDetectionResponse.from(config)
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/dto/response/CongestionThresholdsResponse.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/response/CongestionThresholdsResponse.java
@@ -1,0 +1,19 @@
+package com.saferoute.domain.congestion.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+
+public record CongestionThresholdsResponse(
+        @JsonProperty("CAUTION_FROM") Double cautionFrom,
+        @JsonProperty("CROWDED_FROM") Double crowdedFrom,
+        @JsonProperty("VERY_CROWDED_FROM") Double veryCrowdedFrom
+) {
+
+    public static CongestionThresholdsResponse from(CongestionConfig config) {
+        return new CongestionThresholdsResponse(
+                config.getCautionFrom(),
+                config.getCrowdedFrom(),
+                config.getVeryCrowdedFrom()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/dto/response/EventDetectionResponse.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/response/EventDetectionResponse.java
@@ -1,0 +1,18 @@
+package com.saferoute.domain.congestion.dto.response;
+
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+
+public record EventDetectionResponse(
+        Integer requiredConsecutiveFrames,
+        Integer recoveryConsecutiveFrames,
+        Integer cooldownSec
+) {
+
+    public static EventDetectionResponse from(CongestionConfig config) {
+        return new EventDetectionResponse(
+                config.getRequiredConsecutiveFrames(),
+                config.getRecoveryConsecutiveFrames(),
+                config.getCooldownSec()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionConfigQueryService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionConfigQueryService.java
@@ -1,0 +1,50 @@
+package com.saferoute.domain.congestion.service;
+
+import com.saferoute.domain.congestion.dto.response.CongestionConfigQueryResponse;
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.util.MonitoredAreaCalculator;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// Pi가 주기적으로 호출하는 혼잡 설정 조회(이슈 6)를 처리한다.
+// CCTV 인증/활성화 검증은 컨트롤러에서 DeviceAuthorizationService로 먼저 끝낸 뒤 이 서비스를 호출한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CongestionConfigQueryService {
+
+    private final CctvGridCellRepository cctvGridCellRepository;
+    private final TrainingSessionRepository trainingSessionRepository;
+    private final CongestionConfigService congestionConfigService;
+
+    public CongestionConfigQueryResponse getConfigFor(Cctv cctv) {
+        CongestionConfig config = congestionConfigService.getConfig();
+        Floor floor = cctv.getCustomNode().getFloor();
+        var buildingId = floor.getBuilding().getId();
+
+        TrainingSession runningSession = trainingSessionRepository
+                .findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(TrainingStatus.RUNNING, buildingId)
+                .orElse(null);
+
+        if (runningSession == null) {
+            return CongestionConfigQueryResponse.inactive(cctv.getCode(), config);
+        }
+
+        int gridCellCount = cctvGridCellRepository.countByCctv_Id(cctv.getId());
+        Double monitoredAreaM2 = MonitoredAreaCalculator.calculate(gridCellCount, floor.getGridCellSizeMeter());
+
+        return CongestionConfigQueryResponse.active(
+                runningSession.getId().toString(),
+                cctv.getCode(),
+                monitoredAreaM2,
+                config
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionConfigQueryService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionConfigQueryService.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// Pi가 주기적으로 호출하는 혼잡 설정 조회(이슈 6)를 처리한다.
+// Pi가 주기적으로 호출하는 혼잡 설정 조회를 처리한다.
 // CCTV 인증/활성화 검증은 컨트롤러에서 DeviceAuthorizationService로 먼저 끝낸 뒤 이 서비스를 호출한다.
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
@@ -12,6 +12,9 @@ public interface CctvGridCellRepository extends JpaRepository<CctvGridCell, UUID
 
     List<CctvGridCell> findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(UUID cctvId);
 
+    // 감시 면적 계산엔 셀 목록 전체가 아니라 개수만 필요하다 (Pi 설정 조회 API).
+    int countByCctv_Id(UUID cctvId);
+
     @Query("""
             select mapping
             from CctvGridCell mapping

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -20,6 +20,12 @@ public interface TrainingSessionRepository extends JpaRepository<TrainingSession
   Optional<TrainingSession> findByIdAndStatusAndScenario_Building_Id(
       UUID id, TrainingStatus status, UUID buildingId);
 
+  // Pi의 설정 조회 요청엔 세션 id가 없어 건물만으로 현재 RUNNING 세션을 찾는다.
+  // 건물당 동시 RUNNING 세션은 1개라고 가정하되(TrainingSession에 세션-층 직접 연결이 없어 건물 단위로 조회),
+  // 이 가정이 DB 제약으로 강제되진 않으므로 예외적으로 여러 개가 있어도 결과가 흔들리지 않도록 시작 시각 기준으로 정렬한다.
+  Optional<TrainingSession> findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(
+      TrainingStatus status, UUID buildingId);
+
   boolean existsByScenario_Id(UUID scenarioId);
 
   // 목록 조회에서 시나리오별로 deletable을 N+1 없이 계산하기 위해, 세션이 하나라도 있는 시나리오 id만 모아서 가져온다.

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionConfigControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionConfigControllerTest.java
@@ -1,0 +1,100 @@
+package com.saferoute.domain.congestion.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.saferoute.domain.congestion.dto.response.CongestionConfigQueryResponse;
+import com.saferoute.domain.congestion.dto.response.CongestionThresholdsResponse;
+import com.saferoute.domain.congestion.dto.response.EventDetectionResponse;
+import com.saferoute.domain.congestion.service.CongestionConfigQueryService;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.service.DeviceAuthorizationService;
+import com.saferoute.global.config.SecurityConfig;
+import com.saferoute.global.security.DeviceAuthenticationFilter;
+import com.saferoute.global.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = CongestionConfigController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {
+                        JwtAuthenticationFilter.class,
+                        DeviceAuthenticationFilter.class,
+                        SecurityConfig.class
+                }
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class CongestionConfigControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DeviceAuthorizationService deviceAuthorizationService;
+
+    @MockitoBean
+    private CongestionConfigQueryService congestionConfigQueryService;
+
+    @Test
+    @DisplayName("cctvCode 없이 요청하면 400을 반환한다")
+    void getConfig_missingCctvCode_returnsBadRequest() throws Exception {
+        mockMvc.perform(get("/api/v1/device/congestion-config"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("훈련 중이면 설정 값을 포함한 응답을 반환한다")
+    void getConfig_trainingActive_returnsFullConfig() throws Exception {
+        given(deviceAuthorizationService.validateCctv(any(), org.mockito.ArgumentMatchers.eq("CCTV_001")))
+                .willReturn(Mockito.mock(Cctv.class));
+        given(congestionConfigQueryService.getConfigFor(any())).willReturn(
+                CongestionConfigQueryResponse.active(
+                        "session-uuid",
+                        "CCTV_001",
+                        2.0,
+                        com.saferoute.domain.congestion.entity.CongestionConfig.createDefault()
+                )
+        );
+
+        mockMvc.perform(get("/api/v1/device/congestion-config").param("cctvCode", "CCTV_001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.trainingActive").value(true))
+                .andExpect(jsonPath("$.trainingSessionId").value("session-uuid"))
+                .andExpect(jsonPath("$.monitoredAreaM2").value(2.0))
+                .andExpect(jsonPath("$.congestionThresholds.CAUTION_FROM").value(2.0))
+                .andExpect(jsonPath("$.eventDetection.cooldownSec").value(30));
+    }
+
+    @Test
+    @DisplayName("훈련 중이 아니면 최소 정보만 반환한다")
+    void getConfig_trainingInactive_returnsMinimalConfig() throws Exception {
+        given(deviceAuthorizationService.validateCctv(any(), org.mockito.ArgumentMatchers.eq("CCTV_001")))
+                .willReturn(Mockito.mock(Cctv.class));
+        given(congestionConfigQueryService.getConfigFor(any())).willReturn(
+                CongestionConfigQueryResponse.inactive(
+                        "CCTV_001",
+                        com.saferoute.domain.congestion.entity.CongestionConfig.createDefault()
+                )
+        );
+
+        mockMvc.perform(get("/api/v1/device/congestion-config").param("cctvCode", "CCTV_001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.trainingActive").value(false))
+                .andExpect(jsonPath("$.trainingSessionId").doesNotExist())
+                .andExpect(jsonPath("$.configVersion").value(1));
+    }
+}

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionConfigQueryServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionConfigQueryServiceTest.java
@@ -1,0 +1,105 @@
+package com.saferoute.domain.congestion.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.congestion.dto.response.CongestionConfigQueryResponse;
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionConfigQueryServiceTest {
+
+    @Mock
+    private CctvGridCellRepository cctvGridCellRepository;
+
+    @Mock
+    private TrainingSessionRepository trainingSessionRepository;
+
+    @Mock
+    private CongestionConfigService congestionConfigService;
+
+    private CongestionConfigQueryService service;
+
+    private UUID cctvId;
+    private UUID buildingId;
+    private Cctv cctv;
+
+    @BeforeEach
+    void setUp() {
+        service = new CongestionConfigQueryService(
+                cctvGridCellRepository, trainingSessionRepository, congestionConfigService);
+
+        cctvId = UUID.randomUUID();
+        buildingId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        given(building.getId()).willReturn(buildingId);
+        Floor floor = mock(Floor.class);
+        given(floor.getBuilding()).willReturn(building);
+        // RUNNING 세션이 없는 케이스에서는 감시 면적을 계산하지 않아 이 스텁을 쓰지 않는다.
+        org.mockito.Mockito.lenient().when(floor.getGridCellSizeMeter()).thenReturn(0.5);
+        MapNode node = mock(MapNode.class);
+        given(node.getFloor()).willReturn(floor);
+        cctv = mock(Cctv.class);
+        // RUNNING 세션이 없는 케이스에서는 GridCell 개수를 조회하지 않아 이 스텁을 쓰지 않는다.
+        org.mockito.Mockito.lenient().when(cctv.getId()).thenReturn(cctvId);
+        given(cctv.getCode()).willReturn("CCTV_001");
+        given(cctv.getCustomNode()).willReturn(node);
+
+        given(congestionConfigService.getConfig()).willReturn(CongestionConfig.createDefault());
+    }
+
+    @Test
+    @DisplayName("건물에 RUNNING 세션이 없으면 trainingActive=false와 configVersion만 응답한다")
+    void getConfigFor_noRunningSession_returnsInactive() {
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(
+                TrainingStatus.RUNNING, buildingId)).willReturn(Optional.empty());
+
+        CongestionConfigQueryResponse response = service.getConfigFor(cctv);
+
+        assertThat(response.trainingActive()).isFalse();
+        assertThat(response.trainingSessionId()).isNull();
+        assertThat(response.cctvCode()).isEqualTo("CCTV_001");
+        assertThat(response.monitoredAreaM2()).isNull();
+        assertThat(response.configVersion()).isEqualTo(1L);
+        assertThat(response.congestionThresholds()).isNull();
+    }
+
+    @Test
+    @DisplayName("건물에 RUNNING 세션이 있으면 훈련 정보와 감시 면적, 판정 설정을 모두 응답한다")
+    void getConfigFor_runningSession_returnsActiveConfig() {
+        UUID sessionId = UUID.randomUUID();
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(
+                TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        given(cctvGridCellRepository.countByCctv_Id(cctvId)).willReturn(8);
+
+        CongestionConfigQueryResponse response = service.getConfigFor(cctv);
+
+        assertThat(response.trainingActive()).isTrue();
+        assertThat(response.trainingSessionId()).isEqualTo(sessionId.toString());
+        assertThat(response.cctvCode()).isEqualTo("CCTV_001");
+        assertThat(response.monitoredAreaM2()).isEqualTo(2.0);
+        assertThat(response.configVersion()).isEqualTo(1L);
+        assertThat(response.snapshotIntervalSec()).isEqualTo(5);
+        assertThat(response.congestionThresholds().cautionFrom()).isEqualTo(2.0);
+        assertThat(response.eventDetection().cooldownSec()).isEqualTo(30);
+    }
+}


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #89
- Branch: feat/#89

## 주요 내용

- `GET /api/v1/device/congestion-config?cctvCode={cctvCode}` 엔드포인트 추가 (디바이스 Bearer Token 인증)
- 훈련 진행 여부 판단: CCTV가 속한 건물에 RUNNING 세션이 있는지로 결정
  - 세션 id 없이 건물만으로 RUNNING 세션을 찾는 `findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc` 추가
- 감시 면적 계산용 `countByCctv_Id` 추가 (전체 GridCell 매핑 대신 개수만 조회)
- 훈련 중/종료 두 응답 형태를 `CongestionConfigQueryResponse.active()` / `.inactive()` 정적 팩토리로 구분
  - 종료 상태에서는 `cctvCode`, `configVersion`만 응답하고 판정 설정은 생략
- #87에서 만든 `MonitoredAreaCalculator`(감시 면적 계산), `CongestionConfigService`(설정 조회)를 그대로 재사용해 조합만 새로 구현

> 임계값 필드(`CAUTION_FROM`/`CROWDED_FROM`/`VERY_CROWDED_FROM`)는 나머지 응답 필드와 달리 문서에 명시된 대문자 스네이크케이스 그대로 유지했습니다. Pi 쪽 계약을 깨지 않기 위해 `@JsonProperty`로 고정했습니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?