### PR TITLE
Feat/#91 5초 관측값 수신 API

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionObservationController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionObservationController.java
@@ -1,0 +1,43 @@
+package com.saferoute.domain.congestion.controller;
+
+import com.saferoute.domain.congestion.dto.request.ReportObservationRequest;
+import com.saferoute.domain.congestion.dto.response.ObservationResponse;
+import com.saferoute.domain.congestion.service.CongestionObservationService;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.service.DeviceAuthorizationService;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
+import com.saferoute.global.security.DevicePrincipal;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "혼잡도", description = "Pi 5초 관측값 수신 API")
+@RestController
+@RequestMapping("/api/v1/device/congestion-observations")
+@RequiredArgsConstructor
+public class CongestionObservationController {
+
+    private final DeviceAuthorizationService deviceAuthorizationService;
+    private final CongestionObservationService congestionObservationService;
+
+    @PostMapping
+    public ResponseEntity<ObservationResponse> reportObservation(
+            @AuthenticationPrincipal DevicePrincipal principal,
+            @Valid @RequestBody ReportObservationRequest request
+    ) {
+        Cctv cctv = deviceAuthorizationService.validateCctv(principal, request.cctvCode());
+        IdempotentSaveResult<ObservationItem> saveResult =
+                congestionObservationService.reportObservation(cctv, request);
+        ObservationResponse response = ObservationResponse.from(saveResult.item());
+        HttpStatus status = saveResult.created() ? HttpStatus.CREATED : HttpStatus.OK;
+        return ResponseEntity.status(status).body(response);
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/dto/request/ReportObservationRequest.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/request/ReportObservationRequest.java
@@ -1,0 +1,47 @@
+package com.saferoute.domain.congestion.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.UUID;
+
+// Pi가 5초마다 보내는 관측값. edgeId/density/congestionLevel은 Pi가 보내지 않는다 - BE가 직접 계산한다.
+public record ReportObservationRequest(
+        @NotNull UUID eventId,
+        @NotNull UUID trainingSessionId,
+        @NotBlank String cctvCode,
+        @NotNull @PositiveOrZero Double avgHeadcount,
+        @NotNull @PositiveOrZero Integer peakHeadcount,
+        @NotNull @Positive Integer sampleCount,
+        @NotNull @PositiveOrZero Long windowStart,
+        @NotNull @PositiveOrZero Long windowEnd,
+        @NotNull @PositiveOrZero Long capturedAt,
+        @NotNull @Positive Long configVersion,
+        String monitoringImageKey
+) {
+    @AssertTrue(message = "avgHeadcount must not exceed peakHeadcount")
+    public boolean isHeadcountValid() {
+        if (avgHeadcount == null || peakHeadcount == null) {
+            return true;
+        }
+        return avgHeadcount <= peakHeadcount.doubleValue();
+    }
+
+    @AssertTrue(message = "windowEnd must not be before windowStart")
+    public boolean isWindowValid() {
+        if (windowStart == null || windowEnd == null) {
+            return true;
+        }
+        return windowEnd >= windowStart;
+    }
+
+    @AssertTrue(message = "capturedAt must not be before windowStart")
+    public boolean isCapturedAtValid() {
+        if (capturedAt == null || windowStart == null) {
+            return true;
+        }
+        return capturedAt >= windowStart;
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/entity/CongestionConfig.java
+++ b/src/main/java/com/saferoute/domain/congestion/entity/CongestionConfig.java
@@ -97,6 +97,21 @@ public class CongestionConfig {
         this.version++;
     }
 
+    // Pi가 보고한 값을 신뢰하지 않고 BE가 직접 밀도로 혼잡 단계를 판정한다.
+    // Pi 쪽 CongestionThresholds.classify()와 동일한 경계값 판정(>=)을 사용해야 한다.
+    public CongestionLevel classify(double density) {
+        if (density >= veryCrowdedFrom) {
+            return CongestionLevel.VERY_CROWDED;
+        }
+        if (density >= crowdedFrom) {
+            return CongestionLevel.CROWDED;
+        }
+        if (density >= cautionFrom) {
+            return CongestionLevel.CAUTION;
+        }
+        return CongestionLevel.NORMAL;
+    }
+
     // 값이 실제로 바뀐 필드가 하나라도 있을 때만 version을 올린다 (no-op 갱신 요청으로 버전이 튀는 것 방지).
     public void updateSettings(Integer snapshotIntervalSec, Integer targetInferenceFps,
             Double cautionFrom, Double crowdedFrom, Double veryCrowdedFrom,

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -1,0 +1,238 @@
+package com.saferoute.domain.congestion.service;
+
+import com.saferoute.domain.congestion.dto.request.ReportObservationRequest;
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.entity.CctvGridCell;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.util.MonitoredAreaCalculator;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
+import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.global.api.error.CongestionErrorCode;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+// Pi가 5초마다 보내는 관측값(이슈 8)을 받아 BE가 직접 밀도·혼잡 단계를 계산하고 저장한다.
+// 멱등 저장/처리 lease/after-commit 발행 구조는 CongestionEventService(기존 관측+즉시이벤트 통합 엔드포인트)와 동일한 패턴을 쓴다.
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CongestionObservationService {
+
+    static final Duration PROCESSING_LEASE = Duration.ofMinutes(1);
+
+    private final ObservationRepository observationRepository;
+    private final CurrentCctvStateRepository currentCctvStateRepository;
+    private final TrainingSessionRepository trainingSessionRepository;
+    private final CctvGridCellRepository cctvGridCellRepository;
+    private final MapEdgeGridCellRepository mapEdgeGridCellRepository;
+    private final CongestionConfigService congestionConfigService;
+    private final RouteRecalculationService routeRecalculationService;
+    private final TrainingEventPublisher trainingEventPublisher;
+
+    @Transactional
+    public IdempotentSaveResult<ObservationItem> reportObservation(Cctv cctv, ReportObservationRequest request) {
+        Floor floor = cctv.getCustomNode().getFloor();
+        UUID buildingId = floor.getBuilding().getId();
+        TrainingSession session = trainingSessionRepository
+                .findByIdAndStatusAndScenario_Building_Id(
+                        request.trainingSessionId(), TrainingStatus.RUNNING, buildingId)
+                .orElseThrow(() -> new ApiException(TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND));
+
+        CongestionConfig config = congestionConfigService.getConfig();
+        Double monitoredAreaM2 = MonitoredAreaCalculator.calculate(
+                cctvGridCellRepository.countByCctv_Id(cctv.getId()), floor.getGridCellSizeMeter());
+        // GridCell이 하나도 없으면 0.0㎡로 계산되는데, 그대로 나누면 density가 무한대가 되므로 여기서도 막는다.
+        if (monitoredAreaM2 == null || monitoredAreaM2 <= 0) {
+            throw new ApiException(CongestionErrorCode.MONITORED_AREA_NOT_AVAILABLE);
+        }
+
+        double density = request.avgHeadcount() / monitoredAreaM2;
+        CongestionLevel level = config.classify(density);
+
+        ObservationItem item = ObservationItem.create(
+                request.eventId(),
+                session.getId(),
+                null,
+                cctv.getCode(),
+                request.avgHeadcount(),
+                request.peakHeadcount(),
+                request.sampleCount(),
+                density,
+                level,
+                request.windowStart(),
+                request.windowEnd(),
+                request.capturedAt(),
+                request.monitoringImageKey(),
+                request.configVersion()
+        );
+
+        IdempotentSaveResult<ObservationItem> saveResult = observationRepository.saveIfAbsent(item);
+        validateEventIdentity(saveResult.item(), request, session.getId());
+
+        String processingOwner = UUID.randomUUID().toString();
+        long processingStartedAt = Instant.now().toEpochMilli();
+        boolean claimed = observationRepository.claimProcessing(
+                saveResult.item().getEventId(),
+                processingOwner,
+                processingStartedAt,
+                processingStartedAt + PROCESSING_LEASE.toMillis()
+        );
+        if (!claimed) {
+            return saveResult;
+        }
+
+        try {
+            List<MapEdge> affectedEdges = resolveAffectedEdges(cctv.getId());
+            updateCurrentState(session.getId(), cctv.getCode(), request, saveResult.item());
+
+            CongestionLevel savedLevel = saveResult.item().getCongestionLevel();
+            if (savedLevel.requiresRouteRecalculation()) {
+                for (MapEdge edge : affectedEdges) {
+                    routeRecalculationService.trigger(session, edge, savedLevel);
+                }
+            }
+            publishAndCompleteAfterCommit(session.getId(), affectedEdges, saveResult.item(), processingOwner);
+        } catch (ApiException exception) {
+            failProcessing(saveResult.item().getEventId(), processingOwner, exception);
+            throw exception;
+        } catch (RuntimeException exception) {
+            failProcessing(saveResult.item().getEventId(), processingOwner, exception);
+            throw new ApiException(CongestionErrorCode.EVENT_PROCESSING_FAILED, exception);
+        }
+        return saveResult;
+    }
+
+    // CCTV -> CctvGridCell -> FloorGridCell -> MapEdgeGridCell -> MapEdge 연쇄 조회.
+    // CCTV 한 대가 여러 Edge를 감시할 수 있어 목록으로 반환한다 (Cctv.java 클래스 주석 참고).
+    private List<MapEdge> resolveAffectedEdges(UUID cctvId) {
+        List<UUID> gridCellIds = cctvGridCellRepository
+                .findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(cctvId)
+                .stream()
+                .map(mapping -> mapping.getGridCell().getId())
+                .toList();
+        if (gridCellIds.isEmpty()) {
+            return List.of();
+        }
+        return mapEdgeGridCellRepository.findAllByGridCell_IdIn(gridCellIds).stream()
+                .map(MapEdgeGridCell::getMapEdge)
+                .distinct()
+                .toList();
+    }
+
+    private void updateCurrentState(
+            UUID sessionId, String cctvCode, ReportObservationRequest request, ObservationItem item
+    ) {
+        CurrentCctvStateItem stateItem = CurrentCctvStateItem.create(
+                sessionId,
+                cctvCode,
+                (int) Math.round(request.avgHeadcount()),
+                item.getDensity(),
+                item.getCongestionLevel(),
+                request.capturedAt(),
+                request.configVersion()
+        );
+        // 오래된 관측값이 최신 상태를 덮어쓰지 않도록 조건부 갱신 (lastDetectedAt 기준). 실패해도 관측값 저장 자체는 유지한다.
+        if (!currentCctvStateRepository.updateIfLatest(stateItem)) {
+            log.debug("더 최신 상태가 있어 CCTV 현재 상태 갱신을 건너뜀: cctvCode={}", cctvCode);
+        }
+    }
+
+    private void validateEventIdentity(ObservationItem item, ReportObservationRequest request, UUID sessionId) {
+        boolean sameIdentity = Objects.equals(item.getTrainingSessionId(), sessionId.toString())
+                && Objects.equals(item.getCctvCode(), request.cctvCode());
+        if (!sameIdentity) {
+            throw new ApiException(CongestionErrorCode.EVENT_IDENTITY_MISMATCH);
+        }
+    }
+
+    private void publishAndCompleteAfterCommit(
+            UUID sessionId, List<MapEdge> affectedEdges, ObservationItem item, String processingOwner
+    ) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            publishCongestionUpdated(sessionId, affectedEdges, item);
+            completeProcessing(item.getEventId(), processingOwner);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                try {
+                    publishCongestionUpdated(sessionId, affectedEdges, item);
+                    completeProcessing(item.getEventId(), processingOwner);
+                } catch (RuntimeException exception) {
+                    failProcessing(item.getEventId(), processingOwner, exception);
+                    throw new ApiException(CongestionErrorCode.EVENT_PROCESSING_FAILED, exception);
+                }
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+                if (status != TransactionSynchronization.STATUS_COMMITTED) {
+                    failProcessing(item.getEventId(), processingOwner, null);
+                }
+            }
+        });
+    }
+
+    // Edge가 없으면(감시 영역에 아직 GridCell/Edge 매핑이 안 된 CCTV) edgeId 없이 한 번만 발행해
+    // 대시보드가 최소한 CCTV 단위 관측값은 볼 수 있게 한다.
+    private void publishCongestionUpdated(UUID sessionId, List<MapEdge> affectedEdges, ObservationItem item) {
+        if (affectedEdges.isEmpty()) {
+            trainingEventPublisher.publishCongestionUpdated(sessionId, null, item);
+            return;
+        }
+        for (MapEdge edge : affectedEdges) {
+            trainingEventPublisher.publishCongestionUpdated(sessionId, edge.getId(), item);
+        }
+    }
+
+    private void completeProcessing(String eventId, String processingOwner) {
+        try {
+            if (!observationRepository.completeProcessing(eventId, processingOwner)) {
+                log.warn("혼잡 관측 처리 완료 상태 갱신 실패: eventId={}", eventId);
+            }
+        } catch (RuntimeException exception) {
+            log.error("혼잡 관측 처리 완료 상태 저장 중 오류: eventId={}", eventId, exception);
+        }
+    }
+
+    private void failProcessing(String eventId, String processingOwner, RuntimeException cause) {
+        try {
+            if (!observationRepository.failProcessing(eventId, processingOwner)) {
+                log.warn("혼잡 관측 처리 실패 상태 갱신 실패: eventId={}", eventId);
+            }
+        } catch (RuntimeException statusException) {
+            if (cause != null) {
+                cause.addSuppressed(statusException);
+            }
+            log.error("혼잡 관측 처리 실패 상태 저장 중 오류: eventId={}", eventId, statusException);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
@@ -64,7 +64,9 @@ public class ObservationItem {
         ObservationItem item = new ObservationItem();
         item.eventId = eventId.toString();
         item.trainingSessionId = trainingSessionId.toString();
-        item.edgeId = edgeId.toString();
+        // 관측값 하나가 여러 MapEdge에 걸칠 수 있어(CCTV 1개가 여러 Edge를 감시) 특정 Edge로 고정할 수 없다.
+        // 영향받는 Edge 목록은 저장 시점이 아니라 조회 시점에 CCTV -> GridCell -> MapEdge로 다시 계산한다.
+        item.edgeId = edgeId != null ? edgeId.toString() : null;
         item.cctvCode = cctvCode;
         item.avgHeadcount = avgHeadcount;
         item.peakHeadcount = peakHeadcount;

--- a/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
@@ -48,6 +48,11 @@ public enum CongestionErrorCode implements BaseErrorCode {
             HttpStatus.CONFLICT,
             "CONGESTION008",
             "업로드가 완료된 이벤트 이미지 객체를 찾을 수 없습니다."
+    ),
+    MONITORED_AREA_NOT_AVAILABLE(
+            HttpStatus.CONFLICT,
+            "CONGESTION009",
+            "CCTV의 감시 면적을 계산할 수 없습니다. 감시 영역이 설정되지 않았습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionObservationControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionObservationControllerTest.java
@@ -1,0 +1,156 @@
+package com.saferoute.domain.congestion.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.saferoute.domain.congestion.dto.request.ReportObservationRequest;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.congestion.service.CongestionObservationService;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.service.DeviceAuthorizationService;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
+import com.saferoute.global.config.SecurityConfig;
+import com.saferoute.global.security.DeviceAuthenticationFilter;
+import com.saferoute.global.security.JwtAuthenticationFilter;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = CongestionObservationController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {
+                        JwtAuthenticationFilter.class,
+                        DeviceAuthenticationFilter.class,
+                        SecurityConfig.class
+                }
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class CongestionObservationControllerTest {
+
+    private static final UUID OBSERVATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private DeviceAuthorizationService deviceAuthorizationService;
+
+    @MockitoBean
+    private CongestionObservationService congestionObservationService;
+
+    private ReportObservationRequest validRequest() {
+        return new ReportObservationRequest(
+                UUID.randomUUID(), UUID.randomUUID(), "CCTV_001",
+                5.0, 8, 25, 1_000L, 2_000L, 2_000L, 1L, null
+        );
+    }
+
+    private ObservationItem observation() {
+        return ObservationItem.create(
+                OBSERVATION_ID, UUID.randomUUID(), null, "CCTV_001",
+                5.0, 8, 25, 1.25, CongestionLevel.NORMAL,
+                1_000L, 2_000L, 2_000L, null, 1L
+        );
+    }
+
+    @Test
+    @DisplayName("처음 수신한 eventId이면 관측값과 201을 반환한다")
+    void reportObservation_returnsCreated() throws Exception {
+        given(deviceAuthorizationService.validateCctv(any(), org.mockito.ArgumentMatchers.eq("CCTV_001")))
+                .willReturn(Mockito.mock(Cctv.class));
+        given(congestionObservationService.reportObservation(any(), any()))
+                .willReturn(IdempotentSaveResult.created(observation()));
+
+        mockMvc.perform(post("/api/v1/device/congestion-observations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.eventId").value(OBSERVATION_ID.toString()))
+                .andExpect(jsonPath("$.congestionLevel").value("NORMAL"));
+    }
+
+    @Test
+    @DisplayName("중복 eventId이면 기존 관측값과 200을 반환한다")
+    void reportObservation_returnsExistingObservation() throws Exception {
+        given(deviceAuthorizationService.validateCctv(any(), org.mockito.ArgumentMatchers.eq("CCTV_001")))
+                .willReturn(Mockito.mock(Cctv.class));
+        given(congestionObservationService.reportObservation(any(), any()))
+                .willReturn(IdempotentSaveResult.existing(observation()));
+
+        mockMvc.perform(post("/api/v1/device/congestion-observations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("edgeId, density, congestionLevel 필드가 없어도(Pi가 안 보내므로) 400이 나지 않는다")
+    void reportObservation_doesNotRequireEdgeIdOrDensityFields() throws Exception {
+        ObjectNode body = objectMapper.valueToTree(validRequest());
+        assertNoField(body, "edgeId");
+        assertNoField(body, "density");
+        assertNoField(body, "congestionLevel");
+
+        given(deviceAuthorizationService.validateCctv(any(), org.mockito.ArgumentMatchers.eq("CCTV_001")))
+                .willReturn(Mockito.mock(Cctv.class));
+        given(congestionObservationService.reportObservation(any(), any()))
+                .willReturn(IdempotentSaveResult.created(observation()));
+
+        mockMvc.perform(post("/api/v1/device/congestion-observations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("avgHeadcount가 없으면 400을 반환한다")
+    void reportObservation_returnsBadRequestWhenAvgHeadcountMissing() throws Exception {
+        ObjectNode body = objectMapper.valueToTree(validRequest());
+        body.remove("avgHeadcount");
+
+        mockMvc.perform(post("/api/v1/device/congestion-observations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("windowEnd가 windowStart보다 이르면 400을 반환한다")
+    void reportObservation_returnsBadRequestWhenWindowInvalid() throws Exception {
+        ObjectNode body = objectMapper.valueToTree(validRequest());
+        body.put("windowStart", 5_000L);
+        body.put("windowEnd", 1_000L);
+
+        mockMvc.perform(post("/api/v1/device/congestion-observations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+    private void assertNoField(ObjectNode body, String field) {
+        if (body.has(field)) {
+            throw new AssertionError("validRequest()에 " + field + " 필드가 있으면 안 됩니다 (Pi가 보내지 않음)");
+        }
+    }
+}

--- a/src/test/java/com/saferoute/domain/congestion/entity/CongestionConfigTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/entity/CongestionConfigTest.java
@@ -57,4 +57,18 @@ class CongestionConfigTest {
         assertThat(config.getVersion()).isEqualTo(1L);
         assertThat(config.getCautionFrom()).isEqualTo(2.0);
     }
+
+    @Test
+    @DisplayName("기본 임계값(2.0/3.0/5.0) 경계에서 혼잡 단계를 판정한다")
+    void classify_usesDefaultThresholdBoundaries() {
+        CongestionConfig config = CongestionConfig.createDefault();
+
+        assertThat(config.classify(1.99)).isEqualTo(CongestionLevel.NORMAL);
+        assertThat(config.classify(2.0)).isEqualTo(CongestionLevel.CAUTION);
+        assertThat(config.classify(2.99)).isEqualTo(CongestionLevel.CAUTION);
+        assertThat(config.classify(3.0)).isEqualTo(CongestionLevel.CROWDED);
+        assertThat(config.classify(4.99)).isEqualTo(CongestionLevel.CROWDED);
+        assertThat(config.classify(5.0)).isEqualTo(CongestionLevel.VERY_CROWDED);
+        assertThat(config.classify(100.0)).isEqualTo(CongestionLevel.VERY_CROWDED);
+    }
 }

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -1,0 +1,284 @@
+package com.saferoute.domain.congestion.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.congestion.dto.request.ReportObservationRequest;
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.entity.CctvGridCell;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
+import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.global.api.error.CongestionErrorCode;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionObservationServiceTest {
+
+    @InjectMocks
+    private CongestionObservationService service;
+
+    @Mock
+    private ObservationRepository observationRepository;
+
+    @Mock
+    private CurrentCctvStateRepository currentCctvStateRepository;
+
+    @Mock
+    private TrainingSessionRepository trainingSessionRepository;
+
+    @Mock
+    private CctvGridCellRepository cctvGridCellRepository;
+
+    @Mock
+    private MapEdgeGridCellRepository mapEdgeGridCellRepository;
+
+    @Mock
+    private CongestionConfigService congestionConfigService;
+
+    @Mock
+    private RouteRecalculationService routeRecalculationService;
+
+    @Mock
+    private TrainingEventPublisher trainingEventPublisher;
+
+    private final UUID cctvId = UUID.randomUUID();
+    private final UUID buildingId = UUID.randomUUID();
+    private final UUID sessionId = UUID.randomUUID();
+    private Cctv cctv;
+
+    @BeforeEach
+    void setUp() {
+        Building building = mock(Building.class);
+        org.mockito.Mockito.lenient().when(building.getId()).thenReturn(buildingId);
+        Floor floor = mock(Floor.class);
+        org.mockito.Mockito.lenient().when(floor.getBuilding()).thenReturn(building);
+        org.mockito.Mockito.lenient().when(floor.getGridCellSizeMeter()).thenReturn(1.0);
+        MapNode node = mock(MapNode.class);
+        org.mockito.Mockito.lenient().when(node.getFloor()).thenReturn(floor);
+        cctv = mock(Cctv.class);
+        org.mockito.Mockito.lenient().when(cctv.getId()).thenReturn(cctvId);
+        org.mockito.Mockito.lenient().when(cctv.getCode()).thenReturn("CCTV_001");
+        org.mockito.Mockito.lenient().when(cctv.getCustomNode()).thenReturn(node);
+
+        org.mockito.Mockito.lenient().when(congestionConfigService.getConfig())
+                .thenReturn(CongestionConfig.createDefault());
+        // 기본은 GridCell 4개(면적 4.0m2)로, avgHeadcount=5 -> density=1.25 (NORMAL)
+        org.mockito.Mockito.lenient().when(cctvGridCellRepository.countByCctv_Id(cctvId)).thenReturn(4);
+    }
+
+    private ReportObservationRequest request(double avgHeadcount) {
+        return new ReportObservationRequest(
+                UUID.randomUUID(), sessionId, "CCTV_001", avgHeadcount, 8, 25,
+                1_000L, 2_000L, 2_000L, 1L, null
+        );
+    }
+
+    private void givenProcessingClaimed() {
+        given(observationRepository.claimProcessing(anyString(), anyString(), anyLong(), anyLong()))
+                .willReturn(true);
+        given(observationRepository.completeProcessing(anyString(), anyString())).willReturn(true);
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
+                IdempotentSaveResult.created(invocation.getArgument(0, ObservationItem.class)));
+    }
+
+    private MapEdge edge(UUID id) {
+        MapEdge edge = mock(MapEdge.class);
+        org.mockito.Mockito.lenient().when(edge.getId()).thenReturn(id);
+        return edge;
+    }
+
+    private void givenAffectedEdges(MapEdge... edges) {
+        UUID gridCellId = UUID.randomUUID();
+        FloorGridCell gridCell = mock(FloorGridCell.class);
+        given(gridCell.getId()).willReturn(gridCellId);
+        CctvGridCell mapping = mock(CctvGridCell.class);
+        given(mapping.getGridCell()).willReturn(gridCell);
+        given(cctvGridCellRepository.findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(cctvId))
+                .willReturn(List.of(mapping));
+
+        List<MapEdgeGridCell> edgeMappings = java.util.Arrays.stream(edges)
+                .map(e -> {
+                    MapEdgeGridCell edgeGridCell = mock(MapEdgeGridCell.class);
+                    given(edgeGridCell.getMapEdge()).willReturn(e);
+                    return edgeGridCell;
+                })
+                .toList();
+        given(mapEdgeGridCellRepository.findAllByGridCell_IdIn(List.of(gridCellId))).willReturn(edgeMappings);
+    }
+
+    @Test
+    @DisplayName("대상 건물에 RUNNING 세션이 없으면 전용 에러를 반환하고 아무것도 저장하지 않는다")
+    void reportObservation_throwsWhenNoRunningSession() {
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.reportObservation(cctv, request(5.0)))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND);
+
+        verify(observationRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("감시 면적을 계산할 수 없으면 전용 에러를 반환한다")
+    void reportObservation_throwsWhenMonitoredAreaUnavailable() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        given(cctvGridCellRepository.countByCctv_Id(cctvId)).willReturn(0);
+
+        assertThatThrownBy(() -> service.reportObservation(cctv, request(5.0)))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORED_AREA_NOT_AVAILABLE);
+
+        verify(observationRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("BE가 직접 density와 congestionLevel을 계산해서 저장한다 (Pi 값을 받지 않음)")
+    void reportObservation_computesDensityAndLevelItself() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+
+        // avgHeadcount=9, 면적=4.0 -> density=2.25 -> CAUTION (기본 임계값: CAUTION>=2.0, CROWDED>=3.0)
+        service.reportObservation(cctv, request(9.0));
+
+        verify(observationRepository).saveIfAbsent(argThat(item ->
+                item.getDensity().equals(2.25) && item.getCongestionLevel() == CongestionLevel.CAUTION));
+    }
+
+    @Test
+    @DisplayName("NORMAL/CAUTION 수준이면 재탐색을 트리거하지 않는다")
+    void reportObservation_doesNotTriggerRecalculationForLowLevel() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges(edge(UUID.randomUUID()));
+
+        // avgHeadcount=5 -> density=1.25 -> NORMAL
+        service.reportObservation(cctv, request(5.0));
+
+        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(currentCctvStateRepository).updateIfLatest(any());
+    }
+
+    @Test
+    @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하고 각각 발행한다")
+    void reportObservation_triggersRecalculationForEachAffectedEdge() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        MapEdge edgeA = edge(UUID.randomUUID());
+        MapEdge edgeB = edge(UUID.randomUUID());
+        givenAffectedEdges(edgeA, edgeB);
+
+        // avgHeadcount=13 -> density=3.25 -> CROWDED
+        service.reportObservation(cctv, request(13.0));
+
+        verify(routeRecalculationService).trigger(eq(session), eq(edgeA), eq(CongestionLevel.CROWDED));
+        verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED));
+        verify(trainingEventPublisher, times(2)).publishCongestionUpdated(eq(sessionId), any(), any());
+    }
+
+    @Test
+    @DisplayName("매핑된 Edge가 없으면 edgeId 없이 한 번만 발행하고 재탐색은 트리거하지 않는다")
+    void reportObservation_noMappedEdges_publishesOnceWithoutEdgeId() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        given(cctvGridCellRepository.findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(cctvId))
+                .willReturn(List.of());
+
+        // avgHeadcount=13 -> density=3.25 -> CROWDED, 그래도 Edge가 없으니 트리거는 없음
+        service.reportObservation(cctv, request(13.0));
+
+        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(trainingEventPublisher).publishCongestionUpdated(eq(sessionId), isNull(), any());
+    }
+
+    @Test
+    @DisplayName("중복 eventId이면 발행과 재탐색을 다시 수행하지 않는다")
+    void reportObservation_doesNotRepeatSideEffectsForDuplicateEvent() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation ->
+                IdempotentSaveResult.existing(invocation.getArgument(0, ObservationItem.class)));
+
+        var result = service.reportObservation(cctv, request(5.0));
+
+        assertThat(result.created()).isFalse();
+        verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("동일한 eventId가 다른 세션·CCTV를 가리키면 CONGESTION002를 반환한다")
+    void reportObservation_rejectsMismatchedEventIdentity() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willAnswer(invocation -> {
+            ObservationItem existing = invocation.getArgument(0, ObservationItem.class);
+            existing.setCctvCode("CCTV_999");
+            return IdempotentSaveResult.existing(existing);
+        });
+
+        assertThatThrownBy(() -> service.reportObservation(cctv, request(5.0)))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.EVENT_IDENTITY_MISMATCH);
+
+        verify(observationRepository, never()).claimProcessing(anyString(), anyString(), anyLong(), anyLong());
+    }
+}


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #91
- Branch: feat/#91

## 주요 내용

- `POST /api/v1/device/congestion-observations` 신규 엔드포인트 추가 — Pi(SafeRoute-AI)가 실제로 호출하는 경로·필드 그대로 맞춤 (`edgeId`/`density`/`congestionLevel` 없음)
- BE가 직접 밀도·혼잡 단계 계산
  - `density = avgHeadcount / monitoredAreaM2`
  - `CongestionConfig.classify(density)` 신규 추가 — Pi 값을 신뢰하지 않고 저장된 임계값으로 직접 판정 (Pi 쪽 `CongestionThresholds.classify()`와 경계값 `>=` 규칙 동일하게 맞춤)
- CCTV 1대가 여러 Edge를 감시할 수 있는 구조 대응
  - CCTV → GridCell → MapEdgeGridCell → MapEdge 체인으로 영향받는 Edge 전부 조회
  - CROWDED 이상이면 Edge마다 재탐색 트리거 및 WebSocket 발행
  - 매핑된 Edge가 없으면 edgeId 없이 한 번만 발행
  - `ObservationItem.edgeId`를 nullable로 변경 (기존 `/congestion-events`는 그대로 유지, 안 건드림)
- `CurrentCctvStateItem` 연결 — 만들어져만 있고 미사용이던 걸 `updateIfLatest()`로 실제 갱신하도록 연결 (오래된 timestamp는 자동 무시)
- `MONITORED_AREA_NOT_AVAILABLE` 에러코드 추가 (감시 면적 0 이하일 때)
- 멱등 저장/처리 lease(claim/complete/fail)/커밋 후 WebSocket 발행은 `CongestionEventService`의 기존 검증된 패턴을 그대로 재사용

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?