### PR TITLE
Feat/#95 관리자 승인 기반 경로 재계산 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -9,9 +9,11 @@ import com.saferoute.domain.device.util.MonitoredAreaCalculator;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
 import com.saferoute.domain.telemetry.dynamo.entity.EventProcessingStatus;
 import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
@@ -107,9 +109,13 @@ public class CongestionEventService {
             updateCurrentState(session.getId(), cctv.getCode(), request, saveResult.item());
 
             CongestionLevel savedLevel = saveResult.item().getCongestionLevel();
-            if (savedLevel.requiresRouteRecalculation()) {
+            RecalculationTriggerType triggerType = mapTriggerType(saveResult.item().getEventType());
+            // ENDED는 레벨이 NORMAL이라 requiresRouteRecalculation()이 false지만, 정상 경로로의
+            // 복구 후보를 제시해야 하므로(RouteRecalculationService.trigger 참고) 별도로 포함한다.
+            if (savedLevel.requiresRouteRecalculation() || triggerType == RecalculationTriggerType.ENDED) {
                 for (MapEdge edge : affectedEdges) {
-                    routeRecalculationService.trigger(session, edge, savedLevel);
+                    routeRecalculationService.trigger(
+                            session, edge, savedLevel, triggerType, cctv.getCode(), density);
                 }
             }
             publishAndCompleteAfterCommit(session.getId(), affectedEdges, saveResult.item());
@@ -138,6 +144,14 @@ public class CongestionEventService {
                 .map(MapEdgeGridCell::getMapEdge)
                 .distinct()
                 .toList();
+    }
+
+    private RecalculationTriggerType mapTriggerType(CongestionEventType eventType) {
+        return switch (eventType) {
+            case CONGESTION_STARTED -> RecalculationTriggerType.STARTED;
+            case CONGESTION_LEVEL_UP -> RecalculationTriggerType.LEVEL_UP;
+            case CONGESTION_ENDED -> RecalculationTriggerType.ENDED;
+        };
     }
 
     private boolean claimProcessing(CongestionEventItem item) {

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -34,9 +34,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-// Pi가 혼잡 진입/상승/종료를 감지한 즉시 보내는 이벤트(이슈 9)를 받아 BE가 직접 밀도·혼잡 단계를
+// Pi가 혼잡 진입/상승/종료를 감지한 즉시 보내는 이벤트를 받아 BE가 직접 밀도·혼잡 단계를
 // 계산하고 저장한다. 멱등 저장/처리 상태 전이/after-commit 발행 구조는 CongestionObservationService
-// (이슈 8, 5초 관측값)와 동일한 패턴을 쓰되, CongestionEventRepository는 처리 소유자(lease) 없이
+// (5초 관측값)와 동일한 패턴을 쓰되, CongestionEventRepository는 처리 소유자(lease) 없이
 // RECEIVED/PROCESSING/PROCESSED/FAILED 상태만으로 동시 처리를 막는다.
 @Slf4j
 @Service

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -10,6 +10,7 @@ import com.saferoute.domain.device.util.MonitoredAreaCalculator;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
@@ -112,9 +113,12 @@ public class CongestionObservationService {
             updateCurrentState(session.getId(), cctv.getCode(), request, saveResult.item());
 
             CongestionLevel savedLevel = saveResult.item().getCongestionLevel();
+            // 관측값은 5초 단위 스냅샷이라 STARTED/ENDED 같은 이벤트 구분이 없다 - 항상 LEVEL_UP으로 취급한다
+            // (즉시 이벤트의 CONGESTION_ENDED 기반 복구 트리거는 CongestionEventService가 전담한다).
             if (savedLevel.requiresRouteRecalculation()) {
                 for (MapEdge edge : affectedEdges) {
-                    routeRecalculationService.trigger(session, edge, savedLevel);
+                    routeRecalculationService.trigger(
+                            session, edge, savedLevel, RecalculationTriggerType.LEVEL_UP, cctv.getCode(), density);
                 }
             }
             publishAndCompleteAfterCommit(session.getId(), affectedEdges, saveResult.item(), processingOwner);

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -25,9 +25,11 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -154,6 +156,46 @@ public class IoTLightService {
         trainingEventPublisher.publishIoTLightStatusUpdatedAfterCommit(light, direction);
 
         return new LightDirectionResponse(light.getId(), direction, Instant.now());
+    }
+
+    // RouteRecalculation 승인 시 호출한다. 승인된 경로가 지나가는 분기점마다 그 경로를 안내하는
+    // 방향으로 유도등을 전환한다. 개별 유도등이 비활성/미설정/기기 unreachable이어도 다른 유도등
+    // 전환을 막지 않도록 여기서 흡수한다 - 유도등 반영은 승인 자체의 성공 여부에 영향을 주지 않는다.
+    public void applyRouteGuidance(List<UUID> routeNodeIds) {
+        for (int i = 0; i < routeNodeIds.size() - 1; i++) {
+            UUID decisionNodeId = routeNodeIds.get(i);
+            UUID nextNodeId = routeNodeIds.get(i + 1);
+            for (IoTLight light : iotLightJpaRepository.findAllByDecisionNode_Id(decisionNodeId)) {
+                IoTLightDirection direction = resolveDirection(light, decisionNodeId, nextNodeId);
+                if (direction == null) {
+                    continue;
+                }
+                try {
+                    changeDirection(light.getId(), new ChangeLightDirectionRequest(direction));
+                } catch (ApiException exception) {
+                    log.warn("경로 승인에 따른 유도등 자동 전환 실패: lightId={}, direction={}",
+                            light.getId(), direction, exception);
+                }
+            }
+        }
+    }
+
+    // leftEdge/rightEdge 중 다음 노드로 이어지는 쪽을 찾는다. 둘 다 아니면(이 유도등은 이 경로와 무관) null.
+    private IoTLightDirection resolveDirection(IoTLight light, UUID decisionNodeId, UUID nextNodeId) {
+        if (!light.isGuidanceConfigured()) {
+            return null;
+        }
+        if (otherEndpoint(light.getLeftEdge(), decisionNodeId).equals(nextNodeId)) {
+            return IoTLightDirection.LEFT;
+        }
+        if (otherEndpoint(light.getRightEdge(), decisionNodeId).equals(nextNodeId)) {
+            return IoTLightDirection.RIGHT;
+        }
+        return null;
+    }
+
+    private UUID otherEndpoint(MapEdge edge, UUID nodeId) {
+        return edge.getFromNode().getId().equals(nodeId) ? edge.getToNode().getId() : edge.getFromNode().getId();
     }
 
     private IoTLight findLightOrThrow(UUID lightId) {

--- a/src/main/java/com/saferoute/domain/device/util/MonitoredAreaCalculator.java
+++ b/src/main/java/com/saferoute/domain/device/util/MonitoredAreaCalculator.java
@@ -1,7 +1,7 @@
 package com.saferoute.domain.device.util;
 
 // CCTV의 감시 면적(monitoredAreaM2) 계산. CctvResponse(관리자 응답)와
-// 향후 Pi 설정 조회 API(이슈 6)가 동일한 계산을 공유하기 위해 분리했다.
+// Pi 설정 조회 API가 동일한 계산을 공유하기 위해 분리했다.
 public final class MonitoredAreaCalculator {
 
     private MonitoredAreaCalculator() {

--- a/src/main/java/com/saferoute/domain/evacuation/controller/RouteRecalculationController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/RouteRecalculationController.java
@@ -1,19 +1,28 @@
 package com.saferoute.domain.evacuation.controller;
 
+import com.saferoute.domain.evacuation.recalculation.dto.request.RejectRouteRecalculationRequest;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationDetailResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationSummaryResponse;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.EvacuationSuccessCode;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "재탐색 승인", description = "혼잡 재탐색 결과 승인/거절 API")
+@Tag(name = "재탐색 승인", description = "혼잡 재탐색 결과 조회/승인/거절 API")
 @RestController
 @RequestMapping("/api/v1/route-recalculations")
 @RequiredArgsConstructor
@@ -21,15 +30,43 @@ public class RouteRecalculationController {
 
     private final RouteRecalculationService routeRecalculationService;
 
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RouteRecalculationSummaryResponse>>> getRecalculations(
+            @RequestParam UUID trainingSessionId,
+            @RequestParam(required = false) RecalculationStatus status
+    ) {
+        List<RouteRecalculationSummaryResponse> response =
+                routeRecalculationService.getRecalculations(trainingSessionId, status);
+        return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_LIST_FOUND, response));
+    }
+
+    @GetMapping("/{recalculationId}")
+    public ResponseEntity<ApiResponse<RouteRecalculationDetailResponse>> getRecalculationDetail(
+            @PathVariable UUID recalculationId
+    ) {
+        RouteRecalculationDetailResponse response = routeRecalculationService.getRecalculationDetail(recalculationId);
+        return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_DETAIL_FOUND, response));
+    }
+
     @PatchMapping("/{recalculationId}/approve")
-    public ResponseEntity<ApiResponse<RouteRecalculationResponse>> approve(@PathVariable UUID recalculationId) {
-        RouteRecalculationResponse response = routeRecalculationService.approve(recalculationId);
+    public ResponseEntity<ApiResponse<RouteRecalculationResponse>> approve(
+            @PathVariable UUID recalculationId,
+            Authentication authentication
+    ) {
+        RouteRecalculationResponse response =
+                routeRecalculationService.approve(recalculationId, authentication.getName());
         return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_APPROVED, response));
     }
 
     @PatchMapping("/{recalculationId}/reject")
-    public ResponseEntity<ApiResponse<RouteRecalculationResponse>> reject(@PathVariable UUID recalculationId) {
-        RouteRecalculationResponse response = routeRecalculationService.reject(recalculationId);
+    public ResponseEntity<ApiResponse<RouteRecalculationResponse>> reject(
+            @PathVariable UUID recalculationId,
+            Authentication authentication,
+            @RequestBody(required = false) RejectRouteRecalculationRequest request
+    ) {
+        String reason = request != null ? request.reason() : null;
+        RouteRecalculationResponse response =
+                routeRecalculationService.reject(recalculationId, authentication.getName(), reason);
         return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_REJECTED, response));
     }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/request/RejectRouteRecalculationRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/request/RejectRouteRecalculationRequest.java
@@ -1,0 +1,5 @@
+package com.saferoute.domain.evacuation.recalculation.dto.request;
+
+// 거절 사유는 선택 - 요청 Body 없이 보내도 거절은 처리된다.
+public record RejectRouteRecalculationRequest(String reason) {
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationDetailResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationDetailResponse.java
@@ -1,0 +1,54 @@
+package com.saferoute.domain.evacuation.recalculation.dto.response;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+// 관리자가 기존 경로(previousRoute)와 새 후보(candidateRoute)를 비교할 수 있도록 제공하는 상세 조회 응답.
+public record RouteRecalculationDetailResponse(
+        UUID recalculationId,
+        UUID trainingSessionId,
+        String cctvCode,
+        UUID triggerEdgeId,
+        RecalculationTriggerType triggerType,
+        CongestionLevel congestionLevel,
+        double density,
+        RouteSegment previousRoute,
+        RouteSegment candidateRoute,
+        RecalculationStatus status,
+        Instant requestedAt,
+        Instant resolvedAt,
+        String resolvedBy,
+        String rejectReason,
+        String cancelReason
+) {
+
+    public record RouteSegment(List<UUID> nodeIds, double totalWeight) {
+    }
+
+    public static RouteRecalculationDetailResponse from(RouteRecalculation recalculation) {
+        return new RouteRecalculationDetailResponse(
+                recalculation.getId(),
+                recalculation.getTrainingSession().getId(),
+                recalculation.getCctvCode(),
+                recalculation.getTriggerEdge().getId(),
+                recalculation.getTriggerType(),
+                recalculation.getCongestionLevel(),
+                recalculation.getDensity(),
+                // @ElementCollection(LAZY) - 트랜잭션이 살아있는 지금 List.copyOf로 즉시 초기화한다
+                // (open-in-view: false 환경에서 직렬화 시점의 LazyInitializationException 방지, RouteRecalculationResponse 참고).
+                new RouteSegment(List.copyOf(recalculation.getPreviousNodeIds()), recalculation.getPreviousTotalWeight()),
+                new RouteSegment(List.copyOf(recalculation.getRecalculatedNodeIds()), recalculation.getTotalWeight()),
+                recalculation.getStatus(),
+                recalculation.getRequestedAt(),
+                recalculation.getResolvedAt(),
+                recalculation.getResolvedBy() != null ? recalculation.getResolvedBy().getUsername() : null,
+                recalculation.getRejectReason(),
+                recalculation.getCancelReason()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationResponse.java
@@ -16,7 +16,9 @@ public record RouteRecalculationResponse(
         double totalWeight,
         RecalculationStatus status,
         Instant requestedAt,
-        Instant resolvedAt
+        Instant resolvedAt,
+        String resolvedBy,
+        String rejectReason
 ) {
 
     public static RouteRecalculationResponse from(RouteRecalculation recalculation) {
@@ -32,7 +34,9 @@ public record RouteRecalculationResponse(
                 recalculation.getTotalWeight(),
                 recalculation.getStatus(),
                 recalculation.getRequestedAt(),
-                recalculation.getResolvedAt()
+                recalculation.getResolvedAt(),
+                recalculation.getResolvedBy() != null ? recalculation.getResolvedBy().getUsername() : null,
+                recalculation.getRejectReason()
         );
     }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationSummaryResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationSummaryResponse.java
@@ -1,0 +1,36 @@
+package com.saferoute.domain.evacuation.recalculation.dto.response;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import java.time.Instant;
+import java.util.UUID;
+
+// 승인 대기 목록 화면용 - 경로 상세는 포함하지 않는다 (상세 조회 API 참고).
+public record RouteRecalculationSummaryResponse(
+        UUID recalculationId,
+        UUID trainingSessionId,
+        String cctvCode,
+        UUID triggerEdgeId,
+        RecalculationTriggerType triggerType,
+        CongestionLevel congestionLevel,
+        double density,
+        RecalculationStatus status,
+        Instant requestedAt
+) {
+
+    public static RouteRecalculationSummaryResponse from(RouteRecalculation recalculation) {
+        return new RouteRecalculationSummaryResponse(
+                recalculation.getId(),
+                recalculation.getTrainingSession().getId(),
+                recalculation.getCctvCode(),
+                recalculation.getTriggerEdge().getId(),
+                recalculation.getTriggerType(),
+                recalculation.getCongestionLevel(),
+                recalculation.getDensity(),
+                recalculation.getStatus(),
+                recalculation.getRequestedAt()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RecalculationStatus.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RecalculationStatus.java
@@ -6,5 +6,9 @@ package com.saferoute.domain.evacuation.recalculation.entity;
 public enum RecalculationStatus {
     PENDING,
     APPROVED,
-    REJECTED
+    REJECTED,
+
+    // 승인 전에 혼잡 상태가 바뀌었거나(레벨 변동), 훈련이 종료되었거나, 혼잡이 먼저 끝나서
+    // 더 이상 유효하지 않게 된 후보. RouteRecalculationService가 시스템적으로만 부여한다.
+    CANCELLED
 }

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RecalculationTriggerType.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RecalculationTriggerType.java
@@ -1,0 +1,8 @@
+package com.saferoute.domain.evacuation.recalculation.entity;
+
+// 재탐색을 발생시킨 혼잡 이벤트의 종류. ENDED는 우회 경로가 아니라 정상 경로로의 복구 후보를 의미한다.
+public enum RecalculationTriggerType {
+    STARTED,
+    LEVEL_UP,
+    ENDED
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RouteRecalculation.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RouteRecalculation.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.evacuation.recalculation.entity;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.user.entity.User;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -17,9 +18,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -29,12 +28,14 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 // 혼잡 감지로 트리거된 우회 경로 재탐색 결과. 관리자가 승인해야 실제 대피 경로에 반영된다.
+//
+// 같은 세션+엣지라도 혼잡 레벨이 오르내릴 때마다 PENDING -> CANCELLED -> 새 PENDING, 승인 후
+// 다시 레벨이 오르면 그 엣지에 대해 두 번째 APPROVED가 생기는 식으로 이력이 여러 행 쌓일 수 있어
+// (session, edge, status) 유니크 제약은 걸지 않는다 - "같은 세션+엣지에 PENDING 하나만" 규칙은
+// RouteRecalculationService가 트리거 시점에 조회해서 지킨다.
 @Entity
 @Getter
-@Table(name = "route_recalculations", uniqueConstraints = @UniqueConstraint(
-        name = "uk_route_recalculation_session_edge_status",
-        columnNames = {"training_session_id", "trigger_edge_id", "status"}
-))
+@Table(name = "route_recalculations")
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RouteRecalculation {
@@ -52,11 +53,36 @@ public class RouteRecalculation {
     @JoinColumn(name = "trigger_edge_id", nullable = false)
     private MapEdge triggerEdge;
 
+    // 트리거를 발생시킨 CCTV
+    @Column(name = "cctv_code", nullable = false, length = 50)
+    private String cctvCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trigger_type", nullable = false, length = 20)
+    private RecalculationTriggerType triggerType;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "congestion_level", nullable = false, length = 20)
     private CongestionLevel congestionLevel;
 
-    // 우회 경로를 이루는 노드 id 순서 (출발 -> 도착)
+    // 트리거 시점에 BE가 계산한 density
+    @Column(name = "density", nullable = false)
+    private double density;
+
+    // 트리거 시점의 활성 경로(가장 최근 APPROVED 경로, 없으면 트리거 엣지를 그대로 포함한 정상 경로)
+    @ElementCollection
+    @CollectionTable(
+            name = "route_recalculation_previous_nodes",
+            joinColumns = @JoinColumn(name = "route_recalculation_id")
+    )
+    @OrderColumn(name = "node_order")
+    @Column(name = "node_id", nullable = false)
+    private List<UUID> previousNodeIds;
+
+    @Column(name = "previous_total_weight", nullable = false)
+    private double previousTotalWeight;
+
+    // 새로 계산된 후보 경로를 이루는 노드 id 순서 (출발 -> 도착)
     @ElementCollection
     @CollectionTable(
             name = "route_recalculation_nodes",
@@ -64,7 +90,7 @@ public class RouteRecalculation {
     )
     @OrderColumn(name = "node_order")
     @Column(name = "node_id", nullable = false)
-    private List<UUID> recalculatedNodeIds = new ArrayList<>();
+    private List<UUID> recalculatedNodeIds;
 
     @Column(name = "total_weight", nullable = false)
     private double totalWeight;
@@ -80,11 +106,29 @@ public class RouteRecalculation {
     @Column(name = "resolved_at")
     private Instant resolvedAt;
 
-    private RouteRecalculation(TrainingSession trainingSession, MapEdge triggerEdge,
-            CongestionLevel congestionLevel, List<UUID> recalculatedNodeIds, double totalWeight) {
+    // 승인/거절한 관리자. 시스템이 자동으로 CANCELLED 처리한 경우엔 null.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resolved_by_id")
+    private User resolvedBy;
+
+    @Column(name = "reject_reason", length = 500)
+    private String rejectReason;
+
+    @Column(name = "cancel_reason", length = 500)
+    private String cancelReason;
+
+    private RouteRecalculation(TrainingSession trainingSession, MapEdge triggerEdge, String cctvCode,
+            RecalculationTriggerType triggerType, CongestionLevel congestionLevel, double density,
+            List<UUID> previousNodeIds, double previousTotalWeight,
+            List<UUID> recalculatedNodeIds, double totalWeight) {
         this.trainingSession = trainingSession;
         this.triggerEdge = triggerEdge;
+        this.cctvCode = cctvCode;
+        this.triggerType = triggerType;
         this.congestionLevel = congestionLevel;
+        this.density = density;
+        this.previousNodeIds = previousNodeIds;
+        this.previousTotalWeight = previousTotalWeight;
         this.recalculatedNodeIds = recalculatedNodeIds;
         this.totalWeight = totalWeight;
         this.status = RecalculationStatus.PENDING;
@@ -92,20 +136,31 @@ public class RouteRecalculation {
 
     // 재탐색 결과를 승인 대기 상태로 저장하는 정적 팩토리 메서드
     public static RouteRecalculation createPending(TrainingSession trainingSession, MapEdge triggerEdge,
-            CongestionLevel congestionLevel, List<UUID> recalculatedNodeIds, double totalWeight) {
-        return new RouteRecalculation(trainingSession, triggerEdge, congestionLevel, recalculatedNodeIds,
-                totalWeight);
+            String cctvCode, RecalculationTriggerType triggerType, CongestionLevel congestionLevel, double density,
+            List<UUID> previousNodeIds, double previousTotalWeight,
+            List<UUID> recalculatedNodeIds, double totalWeight) {
+        return new RouteRecalculation(trainingSession, triggerEdge, cctvCode, triggerType, congestionLevel, density,
+                previousNodeIds, previousTotalWeight, recalculatedNodeIds, totalWeight);
     }
 
     // 상태 전이 검증은 이 엔티티가 아니라 RouteRecalculationService가 담당한다
     // (TrainingSessionService.start()/end()/forceEnd(), IoTLightService와 동일한 컨벤션).
-    public void approve(Instant resolvedAt) {
+    public void approve(Instant resolvedAt, User resolvedBy) {
         this.status = RecalculationStatus.APPROVED;
         this.resolvedAt = resolvedAt;
+        this.resolvedBy = resolvedBy;
     }
 
-    public void reject(Instant resolvedAt) {
+    public void reject(Instant resolvedAt, User resolvedBy, String reason) {
         this.status = RecalculationStatus.REJECTED;
         this.resolvedAt = resolvedAt;
+        this.resolvedBy = resolvedBy;
+        this.rejectReason = reason;
+    }
+
+    public void cancel(Instant resolvedAt, String reason) {
+        this.status = RecalculationStatus.CANCELLED;
+        this.resolvedAt = resolvedAt;
+        this.cancelReason = reason;
     }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
@@ -2,13 +2,28 @@ package com.saferoute.domain.evacuation.recalculation.repository;
 
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRecalculationRepository extends JpaRepository<RouteRecalculation, UUID> {
 
     // Pi가 혼잡 이벤트를 짧은 주기로 반복 전송하므로, 같은 세션+엣지에 대해
-    // 이미 PENDING이 있으면 새로 트리거하지 않는다.
-    boolean existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+    // 이미 PENDING이 있으면 그 요청을 조회해 레벨이 같으면 무시하고, 다르면 취소 후 새로 만든다.
+    Optional<RouteRecalculation> findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
             UUID trainingSessionId, UUID triggerEdgeId, RecalculationStatus status);
+
+    // 같은 세션+엣지에서 가장 최근에 승인된 경로 - "현재 활성 경로"의 대용으로 쓴다
+    // (이 시스템엔 활성 경로를 별도로 저장하는 개념이 없음).
+    Optional<RouteRecalculation> findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
+            UUID trainingSessionId, UUID triggerEdgeId, RecalculationStatus status);
+
+    List<RouteRecalculation> findAllByTrainingSession_IdOrderByRequestedAtDesc(UUID trainingSessionId);
+
+    List<RouteRecalculation> findAllByTrainingSession_IdAndStatusOrderByRequestedAtDesc(
+            UUID trainingSessionId, RecalculationStatus status);
+
+    // 훈련 종료 시 해당 세션의 남은 PENDING을 일괄 무효화하기 위한 조회
+    List<RouteRecalculation> findAllByTrainingSession_IdAndStatus(UUID trainingSessionId, RecalculationStatus status);
 }

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -1,24 +1,31 @@
 package com.saferoute.domain.evacuation.recalculation.service;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationDetailResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationSummaryResponse;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
 import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.training.entity.TrainingSession;
-import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.domain.user.entity.User;
+import com.saferoute.domain.user.repository.UserRepository;
 import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,24 +37,43 @@ public class RouteRecalculationService {
 
     private final RouteRecalculationRepository routeRecalculationRepository;
     private final EvacuationRouteService evacuationRouteService;
+    private final IoTLightService ioTLightService;
+    private final UserRepository userRepository;
     private final TrainingEventPublisher trainingEventPublisher;
 
-    // 혼잡 감지로 트리거되는 우회 경로 재탐색. 같은 세션+엣지에 이미 PENDING이 있으면 새로 만들지 않고,
-    // 우회 경로 자체가 없으면 로그만 남기고 승인 대기 항목을 만들지 않는다 (관리자 "재탐색 실패" 알림은 범위 밖).
+    // 혼잡 감지로 트리거되는 우회 경로 재탐색.
+    // - 같은 세션+엣지에 이미 PENDING이 있고 레벨이 그대로면 반복 트리거를 무시한다.
+    // - 레벨이 바뀌었으면 기존 PENDING을 CANCELLED로 무효화하고 새로 계산한다.
+    // - triggerType이 ENDED(혼잡 종료)면 우회가 아니라 정상 경로로의 복구 후보를 계산한다.
     @Transactional
-    public void trigger(TrainingSession session, MapEdge triggerEdge, CongestionLevel level) {
-        if (routeRecalculationRepository.existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-                session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING)) {
+    public void trigger(TrainingSession session, MapEdge triggerEdge, CongestionLevel level,
+            RecalculationTriggerType triggerType, String cctvCode, double density) {
+        Optional<RouteRecalculation> existingPending = routeRecalculationRepository
+                .findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+                        session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING);
+
+        if (triggerType == RecalculationTriggerType.ENDED) {
+            existingPending.ifPresent(pending -> cancel(pending, "혼잡 종료로 무효화됨"));
+            triggerRecovery(session, triggerEdge, level, cctvCode, density);
             return;
         }
 
+        if (existingPending.isPresent()) {
+            RouteRecalculation pending = existingPending.get();
+            if (pending.getCongestionLevel() == level) {
+                return;
+            }
+            cancel(pending, "혼잡 단계 변경으로 무효화됨 (" + pending.getCongestionLevel() + " -> " + level + ")");
+        }
+
         UUID floorId = triggerEdge.getFloor().getId();
-        // TODO: 양방향 엣지에서 실제로는 반대편 기준 우회도 필요할 수 있음 - 일단 fromNode 기준으로 고정
         UUID startNodeId = triggerEdge.getFromNode().getId();
 
-        EvacuationRoute route;
+        RouteSnapshot previous = resolveActiveRoute(session, triggerEdge, floorId, startNodeId);
+
+        EvacuationRoute candidate;
         try {
-            route = evacuationRouteService.findShortestRoute(floorId, startNodeId, Set.of(triggerEdge.getId()));
+            candidate = evacuationRouteService.findShortestRoute(floorId, startNodeId, Set.of(triggerEdge.getId()));
         } catch (ApiException exception) {
             if (exception.getErrorCode() == EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND) {
                 log.warn("우회 경로를 찾을 수 없어 재탐색 승인 대기 항목을 생성하지 않음: sessionId={}, edgeId={}",
@@ -57,39 +83,134 @@ public class RouteRecalculationService {
             throw exception;
         }
 
-        List<UUID> newPathNodeIds = route.path().stream().map(node -> node.getId()).toList();
+        savePending(session, triggerEdge, cctvCode, triggerType, level, density, previous, candidate);
+    }
 
-        RouteRecalculation recalculation;
+    // 혼잡 종료 시 정상(트리거 엣지를 포함한 직행) 경로로의 복구 후보를 계산한다.
+    // 현재 활성 경로가 이미 그 엣지를 포함한 직행 경로라면(=승인된 우회가 없다면) 복구할 게 없으므로 아무것도 하지 않는다.
+    private void triggerRecovery(TrainingSession session, MapEdge triggerEdge, CongestionLevel level,
+            String cctvCode, double density) {
+        Optional<RouteRecalculation> latestApproved = routeRecalculationRepository
+                .findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
+                        session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED);
+        if (latestApproved.isEmpty()) {
+            return;
+        }
+        RouteRecalculation activeDetour = latestApproved.get();
+
+        UUID floorId = triggerEdge.getFloor().getId();
+        UUID startNodeId = triggerEdge.getFromNode().getId();
+
+        EvacuationRoute recovery;
         try {
-            recalculation = routeRecalculationRepository.save(
-                    RouteRecalculation.createPending(session, triggerEdge, level, newPathNodeIds, route.totalWeight())
-            );
-        } catch (DataIntegrityViolationException exception) {
-            // 동시에 들어온 중복 혼잡 이벤트가 exists() 체크를 함께 통과한 경우, DB 유니크 제약으로 걸러진 것이므로 조용히 무시한다.
-            log.debug("동시 요청으로 인한 중복 재탐색 저장을 무시함: sessionId={}, edgeId={}", session.getId(), triggerEdge.getId());
+            recovery = evacuationRouteService.findShortestRoute(floorId, startNodeId);
+        } catch (ApiException exception) {
+            if (exception.getErrorCode() == EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND) {
+                log.warn("복구 경로를 찾을 수 없어 재탐색 승인 대기 항목을 생성하지 않음: sessionId={}, edgeId={}",
+                        session.getId(), triggerEdge.getId());
+                return;
+            }
+            throw exception;
+        }
+
+        List<UUID> recoveryNodeIds = recovery.path().stream().map(node -> node.getId()).toList();
+        if (recoveryNodeIds.equals(activeDetour.getRecalculatedNodeIds())) {
+            // 복구 후보가 현재 활성 경로와 동일 - 새로운 승인 요청을 만들 필요가 없다.
             return;
         }
 
+        RouteSnapshot previous = new RouteSnapshot(activeDetour.getRecalculatedNodeIds(), activeDetour.getTotalWeight());
+        RouteRecalculation recalculation = save(RouteRecalculation.createPending(
+                session, triggerEdge, cctvCode, RecalculationTriggerType.ENDED, level, density,
+                previous.nodeIds(), previous.totalWeight(), recoveryNodeIds, recovery.totalWeight()));
         trainingEventPublisher.publishRouteRecalculationRequestedAfterCommit(recalculation);
     }
 
+    // "현재 활성 경로"를 별도로 저장하지 않으므로, 가장 최근 승인된 경로가 있으면 그것을,
+    // 없으면 트리거 엣지를 그대로 포함한 정상(직행) 경로를 활성 경로로 취급한다.
+    private RouteSnapshot resolveActiveRoute(TrainingSession session, MapEdge triggerEdge, UUID floorId, UUID startNodeId) {
+        Optional<RouteRecalculation> latestApproved = routeRecalculationRepository
+                .findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
+                        session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED);
+        if (latestApproved.isPresent()) {
+            RouteRecalculation approved = latestApproved.get();
+            return new RouteSnapshot(approved.getRecalculatedNodeIds(), approved.getTotalWeight());
+        }
+
+        try {
+            EvacuationRoute direct = evacuationRouteService.findShortestRoute(floorId, startNodeId);
+            List<UUID> nodeIds = direct.path().stream().map(node -> node.getId()).toList();
+            return new RouteSnapshot(nodeIds, direct.totalWeight());
+        } catch (ApiException exception) {
+            // 정상 경로조차 없으면(EXIT 미지정 등) 비교 기준 없이 후보만 제시한다.
+            return new RouteSnapshot(List.of(), 0.0);
+        }
+    }
+
+    private void savePending(TrainingSession session, MapEdge triggerEdge, String cctvCode,
+            RecalculationTriggerType triggerType, CongestionLevel level, double density,
+            RouteSnapshot previous, EvacuationRoute candidate) {
+        List<UUID> candidateNodeIds = candidate.path().stream().map(node -> node.getId()).toList();
+        RouteRecalculation recalculation = save(RouteRecalculation.createPending(
+                session, triggerEdge, cctvCode, triggerType, level, density,
+                previous.nodeIds(), previous.totalWeight(), candidateNodeIds, candidate.totalWeight()));
+        trainingEventPublisher.publishRouteRecalculationRequestedAfterCommit(recalculation);
+    }
+
+    private RouteRecalculation save(RouteRecalculation recalculation) {
+        return routeRecalculationRepository.save(recalculation);
+    }
+
+    private void cancel(RouteRecalculation recalculation, String reason) {
+        recalculation.cancel(Instant.now(), reason);
+        trainingEventPublisher.publishRouteRecalculationCancelledAfterCommit(recalculation);
+    }
+
+    // 훈련 세션 종료(정상/강제/타임아웃) 시 그 세션의 남은 PENDING을 전부 무효화한다.
     @Transactional
-    public RouteRecalculationResponse approve(UUID recalculationId) {
+    public void cancelAllPendingForSession(UUID sessionId, String reason) {
+        List<RouteRecalculation> pendingList = routeRecalculationRepository
+                .findAllByTrainingSession_IdAndStatus(sessionId, RecalculationStatus.PENDING);
+        for (RouteRecalculation pending : pendingList) {
+            cancel(pending, reason);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<RouteRecalculationSummaryResponse> getRecalculations(UUID trainingSessionId, RecalculationStatus status) {
+        List<RouteRecalculation> recalculations = status != null
+                ? routeRecalculationRepository.findAllByTrainingSession_IdAndStatusOrderByRequestedAtDesc(
+                        trainingSessionId, status)
+                : routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(trainingSessionId);
+        return recalculations.stream().map(RouteRecalculationSummaryResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public RouteRecalculationDetailResponse getRecalculationDetail(UUID recalculationId) {
+        return RouteRecalculationDetailResponse.from(findOrThrow(recalculationId));
+    }
+
+    @Transactional
+    public RouteRecalculationResponse approve(UUID recalculationId, String approverEmail) {
         RouteRecalculation recalculation = findOrThrow(recalculationId);
         validatePending(recalculation);
+        User approver = findUserOrThrow(approverEmail);
 
-        recalculation.approve(Instant.now());
+        recalculation.approve(Instant.now(), approver);
         trainingEventPublisher.publishEvacuationRouteUpdatedAfterCommit(recalculation);
+        ioTLightService.applyRouteGuidance(recalculation.getRecalculatedNodeIds());
 
         return RouteRecalculationResponse.from(recalculation);
     }
 
     @Transactional
-    public RouteRecalculationResponse reject(UUID recalculationId) {
+    public RouteRecalculationResponse reject(UUID recalculationId, String rejecterEmail, String reason) {
         RouteRecalculation recalculation = findOrThrow(recalculationId);
         validatePending(recalculation);
+        User rejecter = findUserOrThrow(rejecterEmail);
 
-        recalculation.reject(Instant.now());
+        recalculation.reject(Instant.now(), rejecter, reason);
+        trainingEventPublisher.publishRouteRecalculationRejectedAfterCommit(recalculation);
 
         return RouteRecalculationResponse.from(recalculation);
     }
@@ -99,11 +220,19 @@ public class RouteRecalculationService {
                 .orElseThrow(() -> new ApiException(EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND));
     }
 
+    private User findUserOrThrow(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ApiException(TrainingErrorCode.ADMIN_NOT_FOUND));
+    }
+
     // 상태 전이 검증은 엔티티가 아니라 여기서 한다
     // (TrainingSessionService.start()/end()/forceEnd(), IoTLightService와 동일한 컨벤션).
     private void validatePending(RouteRecalculation recalculation) {
         if (recalculation.getStatus() != RecalculationStatus.PENDING) {
             throw new ApiException(EvacuationErrorCode.INVALID_RECALCULATION_STATUS_TRANSITION);
         }
+    }
+
+    private record RouteSnapshot(List<UUID> nodeIds, double totalWeight) {
     }
 }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -9,6 +9,7 @@ import com.saferoute.domain.training.dto.TrainingStatusResponse;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.entity.User;
@@ -40,6 +41,7 @@ public class TrainingSessionService {
   private final UserRepository userRepository;
   private final TrainingSessionRepository trainingSessionRepository;
   private final TrainingScenarioRepository trainingScenarioRepository;
+  private final RouteRecalculationService routeRecalculationService;
   private final TrainingEventPublisher trainingEventPublisher;
 
   public TrainingSessionResponse create(CreateSessionRequest request, UUID scenarioId) {
@@ -116,6 +118,7 @@ public class TrainingSessionService {
 
     session.complete(Instant.now());
     session.getScenario().markCompleted();
+    routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 종료로 무효화됨");
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
     return TrainingSessionResponse.from(session);
@@ -132,6 +135,7 @@ public class TrainingSessionService {
 
     session.stop(Instant.now());
     session.getScenario().markError();
+    routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 강제 종료로 무효화됨");
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
     return TrainingSessionResponse.from(session);
@@ -147,6 +151,7 @@ public class TrainingSessionService {
     for (TrainingSession session : timedOutSessions) {
       session.fail(Instant.now());
       session.getScenario().markError();
+      routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 타임아웃으로 무효화됨");
       trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
       log.info("훈련 세션 타임아웃 처리: sessionId={}", session.getId());
     }

--- a/src/main/java/com/saferoute/global/api/response/EvacuationSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/EvacuationSuccessCode.java
@@ -14,7 +14,9 @@ public enum EvacuationSuccessCode implements BaseCode {
     MAP_EDGE_CREATED(HttpStatus.CREATED, "EVAC_SUCCESS_003", "엣지가 생성되었습니다."),
     MAP_EDGE_DELETED(HttpStatus.OK, "EVAC_SUCCESS_004", "엣지가 삭제되었습니다."),
     ROUTE_RECALCULATION_APPROVED(HttpStatus.OK, "EVAC_SUCCESS_005", "재탐색 결과가 승인되었습니다."),
-    ROUTE_RECALCULATION_REJECTED(HttpStatus.OK, "EVAC_SUCCESS_006", "재탐색 결과가 거절되었습니다.");
+    ROUTE_RECALCULATION_REJECTED(HttpStatus.OK, "EVAC_SUCCESS_006", "재탐색 결과가 거절되었습니다."),
+    ROUTE_RECALCULATION_LIST_FOUND(HttpStatus.OK, "EVAC_SUCCESS_007", "재탐색 목록을 조회했습니다."),
+    ROUTE_RECALCULATION_DETAIL_FOUND(HttpStatus.OK, "EVAC_SUCCESS_008", "재탐색 상세를 조회했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -112,6 +112,13 @@ public class SecurityConfig {
                                 "/api/v1/floors/*/grid/cells"
                         ).hasRole("MANAGER")
 
+                        // 재탐색 승인 대기 목록/상세는 관리자 화면 전용이라 일반 GET 허용 규칙보다 먼저 좁혀둔다.
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/route-recalculations",
+                                "/api/v1/route-recalculations/*"
+                        ).hasRole("MANAGER")
+
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/api/**"

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/RouteRecalculationEventData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/RouteRecalculationEventData.java
@@ -12,17 +12,22 @@ public record RouteRecalculationEventData(
         CongestionLevel congestionLevel,
         List<UUID> recalculatedNodeIds,
         double totalWeight,
-        RecalculationStatus status
+        RecalculationStatus status,
+        String reason
 ) {
 
     public static RouteRecalculationEventData from(RouteRecalculation recalculation) {
+        String reason = recalculation.getStatus() == RecalculationStatus.REJECTED
+                ? recalculation.getRejectReason()
+                : recalculation.getCancelReason();
         return new RouteRecalculationEventData(
                 recalculation.getId(),
                 recalculation.getTriggerEdge().getId(),
                 recalculation.getCongestionLevel(),
                 recalculation.getRecalculatedNodeIds(),
                 recalculation.getTotalWeight(),
-                recalculation.getStatus()
+                recalculation.getStatus(),
+                reason
         );
     }
 }

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
@@ -21,8 +21,15 @@ public enum TrainingEventType {
     // RouteRecalculationService.trigger()가 재탐색 결과를 PENDING으로 저장했을 때 발행된다. (이슈 #48)
     ROUTE_RECALCULATION_REQUESTED,
 
-    // RouteRecalculationService.approve()가 재탐색 결과를 승인했을 때 발행된다. (이슈 #49에서 구현 예정)
+    // RouteRecalculationService.approve()가 재탐색 결과를 승인했을 때 발행된다.
     EVACUATION_ROUTE_UPDATED,
+
+    // RouteRecalculationService.reject()가 재탐색 결과를 거절했을 때 발행된다.
+    ROUTE_RECALCULATION_REJECTED,
+
+    // RouteRecalculationService가 PENDING 후보를 시스템적으로 무효화했을 때
+    // (혼잡 레벨 변경, 훈련 종료, 혼잡 종료) 발행된다.
+    ROUTE_RECALCULATION_CANCELLED,
 
     // IoTLightService.changeDirection() 호출 시 TrainingEventPublisher.publishIoTLightStatusUpdated()가 발행한다.
     IOT_LIGHT_STATUS_UPDATED

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -254,6 +254,56 @@ public class TrainingEventPublisher {
         );
     }
 
+    // DB 트랜잭션이 실제로 커밋된 이후에만 발행한다 (publishTrainingStatusUpdatedAfterCommit 참고).
+    public void publishRouteRecalculationRejectedAfterCommit(RouteRecalculation recalculation) {
+        publishAfterCommit(
+                () -> publishRouteRecalculationRejected(recalculation),
+                "커밋 후 재탐색 거절 이벤트 발행 실패: recalculationId=" + recalculation.getId()
+        );
+    }
+
+    public void publishRouteRecalculationRejected(RouteRecalculation recalculation) {
+        UUID sessionId = recalculation.getTrainingSession().getId();
+        TrainingEventMessage<RouteRecalculationEventData> message = TrainingEventMessage.of(
+                TrainingEventType.ROUTE_RECALCULATION_REJECTED,
+                sessionId,
+                RouteRecalculationEventData.from(recalculation)
+        );
+
+        messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
+
+        log.debug(
+                "재탐색 거절 이벤트 발행: sessionId={}, recalculationId={}",
+                sessionId,
+                recalculation.getId()
+        );
+    }
+
+    // DB 트랜잭션이 실제로 커밋된 이후에만 발행한다 (publishTrainingStatusUpdatedAfterCommit 참고).
+    public void publishRouteRecalculationCancelledAfterCommit(RouteRecalculation recalculation) {
+        publishAfterCommit(
+                () -> publishRouteRecalculationCancelled(recalculation),
+                "커밋 후 재탐색 취소 이벤트 발행 실패: recalculationId=" + recalculation.getId()
+        );
+    }
+
+    public void publishRouteRecalculationCancelled(RouteRecalculation recalculation) {
+        UUID sessionId = recalculation.getTrainingSession().getId();
+        TrainingEventMessage<RouteRecalculationEventData> message = TrainingEventMessage.of(
+                TrainingEventType.ROUTE_RECALCULATION_CANCELLED,
+                sessionId,
+                RouteRecalculationEventData.from(recalculation)
+        );
+
+        messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
+
+        log.debug(
+                "재탐색 취소 이벤트 발행: sessionId={}, recalculationId={}",
+                sessionId,
+                recalculation.getId()
+        );
+    }
+
     private void publishAfterCommit(Runnable publish, String failureLogMessage) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
             publish.run();

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.congestion.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,6 +27,7 @@ import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
@@ -216,7 +218,7 @@ class CongestionEventServiceTest {
         // headcount=5 -> density=1.25 -> NORMAL
         service.reportCongestionEvent(cctv, request(5));
 
-        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
         verify(currentCctvStateRepository).updateIfLatest(any());
     }
 
@@ -236,8 +238,10 @@ class CongestionEventServiceTest {
         // headcount=13 -> density=3.25 -> CROWDED
         service.reportCongestionEvent(cctv, request(13));
 
-        verify(routeRecalculationService).trigger(eq(session), eq(edgeA), eq(CongestionLevel.CROWDED));
-        verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED));
+        verify(routeRecalculationService).trigger(eq(session), eq(edgeA), eq(CongestionLevel.CROWDED),
+                eq(RecalculationTriggerType.STARTED), eq("CCTV_001"), anyDouble());
+        verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED),
+                eq(RecalculationTriggerType.STARTED), eq("CCTV_001"), anyDouble());
         verify(trainingEventPublisher, times(2))
                 .publishCongestionEventReceived(eq(sessionId), any(), any());
     }
@@ -257,7 +261,7 @@ class CongestionEventServiceTest {
         // headcount=13 -> density=3.25 -> CROWDED, 그래도 Edge가 없으니 트리거는 없음
         service.reportCongestionEvent(cctv, request(13));
 
-        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
         verify(trainingEventPublisher).publishCongestionEventReceived(eq(sessionId), isNull(), any());
     }
 
@@ -278,7 +282,7 @@ class CongestionEventServiceTest {
 
         assertThat(result.created()).isFalse();
         verify(trainingEventPublisher, never()).publishCongestionEventReceived(any(), any(), any());
-        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
         verify(congestionEventRepository, never()).updateEventStatus(anyString(), any(), any());
     }
 
@@ -318,7 +322,8 @@ class CongestionEventServiceTest {
 
         assertThat(result.created()).isFalse();
         verify(trainingEventPublisher).publishCongestionEventReceived(any(), any(), any());
-        verify(routeRecalculationService).trigger(eq(session), any(), eq(CongestionLevel.CROWDED));
+        verify(routeRecalculationService).trigger(eq(session), any(), eq(CongestionLevel.CROWDED),
+                eq(RecalculationTriggerType.STARTED), eq("CCTV_001"), anyDouble());
     }
 
     @Test
@@ -338,7 +343,7 @@ class CongestionEventServiceTest {
 
         assertThat(result.created()).isFalse();
         verify(trainingEventPublisher, never()).publishCongestionEventReceived(any(), any(), any());
-        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.congestion.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -26,6 +27,7 @@ import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
@@ -203,7 +205,7 @@ class CongestionObservationServiceTest {
         // avgHeadcount=5 -> density=1.25 -> NORMAL
         service.reportObservation(cctv, request(5.0));
 
-        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
         verify(currentCctvStateRepository).updateIfLatest(any());
     }
 
@@ -222,8 +224,10 @@ class CongestionObservationServiceTest {
         // avgHeadcount=13 -> density=3.25 -> CROWDED
         service.reportObservation(cctv, request(13.0));
 
-        verify(routeRecalculationService).trigger(eq(session), eq(edgeA), eq(CongestionLevel.CROWDED));
-        verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED));
+        verify(routeRecalculationService).trigger(eq(session), eq(edgeA), eq(CongestionLevel.CROWDED),
+                eq(RecalculationTriggerType.LEVEL_UP), eq("CCTV_001"), anyDouble());
+        verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED),
+                eq(RecalculationTriggerType.LEVEL_UP), eq("CCTV_001"), anyDouble());
         verify(trainingEventPublisher, times(2)).publishCongestionUpdated(eq(sessionId), any(), any());
     }
 
@@ -241,7 +245,7 @@ class CongestionObservationServiceTest {
         // avgHeadcount=13 -> density=3.25 -> CROWDED, 그래도 Edge가 없으니 트리거는 없음
         service.reportObservation(cctv, request(13.0));
 
-        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
         verify(trainingEventPublisher).publishCongestionUpdated(eq(sessionId), isNull(), any());
     }
 
@@ -259,7 +263,7 @@ class CongestionObservationServiceTest {
 
         assertThat(result.created()).isFalse();
         verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
-        verify(routeRecalculationService, never()).trigger(any(), any(), any());
+        verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/evacuation/controller/RouteRecalculationControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/controller/RouteRecalculationControllerTest.java
@@ -1,15 +1,20 @@
 package com.saferoute.domain.evacuation.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationDetailResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
+import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationSummaryResponse;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.global.api.error.EvacuationErrorCode;
 import com.saferoute.global.api.exception.ApiException;
@@ -25,8 +30,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @WebMvcTest(
         controllers = RouteRecalculationController.class,
@@ -38,6 +45,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc(addFilters = false)
 class RouteRecalculationControllerTest {
 
+    private static final String MANAGER_EMAIL = "manager@saferoute.com";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -45,19 +54,90 @@ class RouteRecalculationControllerTest {
     private RouteRecalculationService routeRecalculationService;
 
     private final UUID recalculationId = UUID.randomUUID();
+    private final UUID sessionId = UUID.randomUUID();
+
+    private RequestPostProcessor asManager() {
+        return request -> {
+            request.setUserPrincipal(new UsernamePasswordAuthenticationToken(MANAGER_EMAIL, null));
+            return request;
+        };
+    }
 
     private RouteRecalculationResponse response(RecalculationStatus status) {
         return new RouteRecalculationResponse(
-                recalculationId, UUID.randomUUID(), UUID.randomUUID(), CongestionLevel.CROWDED,
-                List.of(UUID.randomUUID()), 12.5, status, Instant.now(), Instant.now());
+                recalculationId, sessionId, UUID.randomUUID(), CongestionLevel.CROWDED,
+                List.of(UUID.randomUUID()), 12.5, status, Instant.now(), Instant.now(), MANAGER_EMAIL, null);
+    }
+
+    private RouteRecalculationSummaryResponse summary(RecalculationStatus status) {
+        return new RouteRecalculationSummaryResponse(
+                recalculationId, sessionId, "CCTV_001", UUID.randomUUID(),
+                RecalculationTriggerType.STARTED, CongestionLevel.CROWDED, 3.5, status, Instant.now());
+    }
+
+    private RouteRecalculationDetailResponse detail(RecalculationStatus status) {
+        return new RouteRecalculationDetailResponse(
+                recalculationId, sessionId, "CCTV_001", UUID.randomUUID(),
+                RecalculationTriggerType.STARTED, CongestionLevel.CROWDED, 3.5,
+                new RouteRecalculationDetailResponse.RouteSegment(List.of(UUID.randomUUID()), 15.0),
+                new RouteRecalculationDetailResponse.RouteSegment(List.of(UUID.randomUUID()), 22.0),
+                status, Instant.now(), null, null, null, null);
+    }
+
+    @Test
+    @DisplayName("목록 조회 시 200과 요약 목록을 반환한다")
+    void getRecalculations_returnsOk() throws Exception {
+        given(routeRecalculationService.getRecalculations(sessionId, RecalculationStatus.PENDING))
+                .willReturn(List.of(summary(RecalculationStatus.PENDING)));
+
+        mockMvc.perform(get("/api/v1/route-recalculations")
+                        .param("trainingSessionId", sessionId.toString())
+                        .param("status", "PENDING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].recalculationId").value(recalculationId.toString()));
+    }
+
+    @Test
+    @DisplayName("상태 필터 없이 목록을 조회할 수 있다")
+    void getRecalculations_withoutStatusFilter_returnsOk() throws Exception {
+        given(routeRecalculationService.getRecalculations(sessionId, null))
+                .willReturn(List.of(summary(RecalculationStatus.APPROVED)));
+
+        mockMvc.perform(get("/api/v1/route-recalculations")
+                        .param("trainingSessionId", sessionId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].status").value("APPROVED"));
+    }
+
+    @Test
+    @DisplayName("상세 조회 시 200과 previousRoute/candidateRoute를 반환한다")
+    void getRecalculationDetail_returnsOk() throws Exception {
+        given(routeRecalculationService.getRecalculationDetail(recalculationId))
+                .willReturn(detail(RecalculationStatus.PENDING));
+
+        mockMvc.perform(get("/api/v1/route-recalculations/{id}", recalculationId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.previousRoute.totalWeight").value(15.0))
+                .andExpect(jsonPath("$.result.candidateRoute.totalWeight").value(22.0));
+    }
+
+    @Test
+    @DisplayName("상세 조회에서 존재하지 않으면 404를 반환한다")
+    void getRecalculationDetail_returnsNotFoundWhenMissing() throws Exception {
+        willThrow(new ApiException(EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND))
+                .given(routeRecalculationService).getRecalculationDetail(recalculationId);
+
+        mockMvc.perform(get("/api/v1/route-recalculations/{id}", recalculationId))
+                .andExpect(status().isNotFound());
     }
 
     @Test
     @DisplayName("승인 성공 시 200과 APPROVED 상태를 반환한다")
     void approve_returnsOk() throws Exception {
-        given(routeRecalculationService.approve(recalculationId)).willReturn(response(RecalculationStatus.APPROVED));
+        given(routeRecalculationService.approve(recalculationId, MANAGER_EMAIL))
+                .willReturn(response(RecalculationStatus.APPROVED));
 
-        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId))
+        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId).with(asManager()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.status").value("APPROVED"));
     }
@@ -65,9 +145,10 @@ class RouteRecalculationControllerTest {
     @Test
     @DisplayName("거절 성공 시 200과 REJECTED 상태를 반환한다")
     void reject_returnsOk() throws Exception {
-        given(routeRecalculationService.reject(recalculationId)).willReturn(response(RecalculationStatus.REJECTED));
+        given(routeRecalculationService.reject(eq(recalculationId), eq(MANAGER_EMAIL), any()))
+                .willReturn(response(RecalculationStatus.REJECTED));
 
-        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/reject", recalculationId))
+        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/reject", recalculationId).with(asManager()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.status").value("REJECTED"));
     }
@@ -76,9 +157,9 @@ class RouteRecalculationControllerTest {
     @DisplayName("존재하지 않는 재탐색이면 404를 반환한다")
     void approve_returnsNotFoundWhenMissing() throws Exception {
         willThrow(new ApiException(EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND))
-                .given(routeRecalculationService).approve(any());
+                .given(routeRecalculationService).approve(any(), any());
 
-        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId))
+        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId).with(asManager()))
                 .andExpect(status().isNotFound());
     }
 
@@ -86,9 +167,9 @@ class RouteRecalculationControllerTest {
     @DisplayName("이미 처리된 재탐색이면 409를 반환한다")
     void approve_returnsConflictWhenAlreadyResolved() throws Exception {
         willThrow(new ApiException(EvacuationErrorCode.INVALID_RECALCULATION_STATUS_TRANSITION))
-                .given(routeRecalculationService).approve(any());
+                .given(routeRecalculationService).approve(any(), any());
 
-        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId))
+        mockMvc.perform(patch("/api/v1/route-recalculations/{id}/approve", recalculationId).with(asManager()))
                 .andExpect(status().isConflict());
     }
 }

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -11,20 +11,26 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
 import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.user.entity.User;
+import com.saferoute.domain.user.repository.UserRepository;
 import com.saferoute.global.api.error.EvacuationErrorCode;
+import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -42,6 +48,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class RouteRecalculationServiceTest {
 
+    private static final String MANAGER_EMAIL = "manager@saferoute.com";
+
     @InjectMocks
     private RouteRecalculationService routeRecalculationService;
 
@@ -52,10 +60,18 @@ class RouteRecalculationServiceTest {
     private EvacuationRouteService evacuationRouteService;
 
     @Mock
+    private IoTLightService ioTLightService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private TrainingEventPublisher trainingEventPublisher;
 
     private TrainingSession session;
     private MapEdge triggerEdge;
+    private UUID floorId;
+    private UUID startNodeId;
 
     @BeforeEach
     void setUp() {
@@ -63,68 +79,101 @@ class RouteRecalculationServiceTest {
         org.mockito.Mockito.lenient().when(session.getId()).thenReturn(UUID.randomUUID());
 
         Floor floor = mock(Floor.class);
-        org.mockito.Mockito.lenient().when(floor.getId()).thenReturn(UUID.randomUUID());
+        floorId = UUID.randomUUID();
+        org.mockito.Mockito.lenient().when(floor.getId()).thenReturn(floorId);
 
         MapNode fromNode = MapNode.create(floor, "HALLWAY1", NodeType.HALLWAY, "HALLWAY1", 0, 0, false);
-        ReflectionTestUtils.setField(fromNode, "id", UUID.randomUUID());
+        startNodeId = UUID.randomUUID();
+        ReflectionTestUtils.setField(fromNode, "id", startNodeId);
 
         triggerEdge = MapEdge.create(floor, fromNode, mock(MapNode.class), 5.0, true);
         ReflectionTestUtils.setField(triggerEdge, "id", UUID.randomUUID());
         ReflectionTestUtils.setField(triggerEdge, "floor", floor);
     }
 
+    private void givenNoExistingPending() {
+        given(routeRecalculationRepository.findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+                any(), any(), any())).willReturn(Optional.empty());
+    }
+
+    private void givenNoApprovedHistory() {
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
+                any(), any(), any())).willReturn(Optional.empty());
+    }
+
+    private void givenNoDirectRoute() {
+        given(evacuationRouteService.findShortestRoute(floorId, startNodeId))
+                .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
+    }
+
     @Test
-    @DisplayName("같은 세션+엣지에 이미 PENDING이 있으면 새로 트리거하지 않는다")
-    void trigger_skipsWhenPendingAlreadyExists() {
-        // given
-        given(routeRecalculationRepository.existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-                session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING)).willReturn(true);
+    @DisplayName("같은 세션+엣지에 이미 같은 레벨의 PENDING이 있으면 새로 트리거하지 않는다")
+    void trigger_skipsWhenSameLevelPendingExists() {
+        RouteRecalculation existing = pendingRecalculation(CongestionLevel.CROWDED);
+        given(routeRecalculationRepository.findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+                session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING))
+                .willReturn(Optional.of(existing));
 
-        // when
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED);
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+                RecalculationTriggerType.LEVEL_UP, "CCTV_001", 3.5);
 
-        // then
         verify(evacuationRouteService, never()).findShortestRoute(any(), any(), anySet());
         verify(routeRecalculationRepository, never()).save(any());
     }
 
     @Test
-    @DisplayName("우회 경로가 없으면 로그만 남기고 승인 대기 항목을 만들지 않는다")
-    void trigger_skipsWhenNoDetourRouteFound() {
-        // given
-        given(routeRecalculationRepository.existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-                any(), any(), any())).willReturn(false);
+    @DisplayName("레벨이 바뀌었으면 기존 PENDING을 CANCELLED로 무효화하고 새로 계산한다")
+    void trigger_cancelsAndRecreatesWhenLevelChanges() {
+        RouteRecalculation existing = pendingRecalculation(CongestionLevel.CROWDED);
+        given(routeRecalculationRepository.findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
+                session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING))
+                .willReturn(Optional.of(existing));
+        givenNoApprovedHistory();
+        givenNoDirectRoute();
         given(evacuationRouteService.findShortestRoute(any(), any(), anySet()))
                 .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
 
-        // when
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED);
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.VERY_CROWDED,
+                RecalculationTriggerType.LEVEL_UP, "CCTV_001", 5.5);
 
-        // then
+        assertThat(existing.getStatus()).isEqualTo(RecalculationStatus.CANCELLED);
+        verify(trainingEventPublisher).publishRouteRecalculationCancelledAfterCommit(existing);
+    }
+
+    @Test
+    @DisplayName("우회 경로가 없으면 로그만 남기고 승인 대기 항목을 만들지 않는다")
+    void trigger_skipsWhenNoDetourRouteFound() {
+        givenNoExistingPending();
+        givenNoApprovedHistory();
+        givenNoDirectRoute();
+        given(evacuationRouteService.findShortestRoute(any(), any(), anySet()))
+                .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
+
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+                RecalculationTriggerType.STARTED, "CCTV_001", 3.5);
+
         verify(routeRecalculationRepository, never()).save(any());
         verify(trainingEventPublisher, never()).publishRouteRecalculationRequestedAfterCommit(any());
     }
 
     @Test
-    @DisplayName("우회 경로를 찾으면 PENDING 저장 + DynamoDB 이력 저장 + WS 발행을 한다")
+    @DisplayName("우회 경로를 찾으면 PENDING 저장 + WS 발행을 한다")
     void trigger_createsPendingRecalculationAndPublishesEvent() {
-        // given
+        givenNoExistingPending();
+        givenNoApprovedHistory();
+        givenNoDirectRoute();
+
         MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
         ReflectionTestUtils.setField(exitNode, "id", UUID.randomUUID());
         EvacuationRoute route = new EvacuationRoute(List.of(exitNode), 12.5);
-
-        given(routeRecalculationRepository.existsByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-                any(), any(), any())).willReturn(false);
         given(evacuationRouteService.findShortestRoute(any(), any(), anySet())).willReturn(route);
 
-        RouteRecalculation saved = RouteRecalculation.createPending(
-                session, triggerEdge, CongestionLevel.CROWDED, List.of(exitNode.getId()), 12.5);
+        RouteRecalculation saved = pendingRecalculation(CongestionLevel.CROWDED);
         given(routeRecalculationRepository.save(any())).willReturn(saved);
 
-        // when
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED);
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+                RecalculationTriggerType.STARTED, "CCTV_001", 3.5);
 
-        // then
         ArgumentCaptor<Set<UUID>> excludedEdgesCaptor = ArgumentCaptor.forClass(Set.class);
         verify(evacuationRouteService).findShortestRoute(any(), any(), excludedEdgesCaptor.capture());
         assertThat(excludedEdgesCaptor.getValue()).containsExactly(triggerEdge.getId());
@@ -133,10 +182,95 @@ class RouteRecalculationServiceTest {
         verify(trainingEventPublisher, times(1)).publishRouteRecalculationRequestedAfterCommit(saved);
     }
 
-    private RouteRecalculation pendingRecalculation() {
+    @Test
+    @DisplayName("ENDED인데 승인된 우회 경로가 없으면 복구할 게 없어 아무것도 하지 않는다")
+    void trigger_ended_doesNothingWithoutApprovedDetour() {
+        givenNoExistingPending();
+        givenNoApprovedHistory();
+
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.NORMAL,
+                RecalculationTriggerType.ENDED, "CCTV_001", 1.0);
+
+        verify(routeRecalculationRepository, never()).save(any());
+        verify(evacuationRouteService, never()).findShortestRoute(any(), any());
+    }
+
+    @Test
+    @DisplayName("ENDED이고 승인된 우회 경로가 있으면 정상 경로로의 복구 후보를 PENDING으로 만든다")
+    void trigger_ended_createsRecoveryCandidateWhenApprovedDetourExists() {
+        givenNoExistingPending();
+        RouteRecalculation approvedDetour = approvedRecalculation(List.of(UUID.randomUUID()), 20.0);
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
+                session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED))
+                .willReturn(Optional.of(approvedDetour));
+
+        MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
+        ReflectionTestUtils.setField(exitNode, "id", UUID.randomUUID());
+        EvacuationRoute directRoute = new EvacuationRoute(List.of(exitNode), 12.5);
+        given(evacuationRouteService.findShortestRoute(floorId, startNodeId)).willReturn(directRoute);
+
+        RouteRecalculation saved = pendingRecalculation(CongestionLevel.NORMAL);
+        given(routeRecalculationRepository.save(any())).willReturn(saved);
+
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.NORMAL,
+                RecalculationTriggerType.ENDED, "CCTV_001", 1.0);
+
+        verify(routeRecalculationRepository, times(1)).save(any());
+        verify(trainingEventPublisher, times(1)).publishRouteRecalculationRequestedAfterCommit(saved);
+    }
+
+    @Test
+    @DisplayName("ENDED 복구 후보가 현재 활성 경로와 동일하면 새 승인 요청을 만들지 않는다")
+    void trigger_ended_skipsWhenRecoveryMatchesActiveRoute() {
+        givenNoExistingPending();
+        UUID sharedNodeId = UUID.randomUUID();
+        RouteRecalculation approvedDetour = approvedRecalculation(List.of(sharedNodeId), 20.0);
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
+                session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED))
+                .willReturn(Optional.of(approvedDetour));
+
+        MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
+        ReflectionTestUtils.setField(exitNode, "id", sharedNodeId);
+        EvacuationRoute directRoute = new EvacuationRoute(List.of(exitNode), 20.0);
+        given(evacuationRouteService.findShortestRoute(floorId, startNodeId)).willReturn(directRoute);
+
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.NORMAL,
+                RecalculationTriggerType.ENDED, "CCTV_001", 1.0);
+
+        verify(routeRecalculationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("훈련 세션의 남은 PENDING을 일괄 CANCELLED 처리한다")
+    void cancelAllPendingForSession_cancelsEachPending() {
+        RouteRecalculation pendingA = pendingRecalculation(CongestionLevel.CROWDED);
+        RouteRecalculation pendingB = pendingRecalculation(CongestionLevel.VERY_CROWDED);
+        UUID sessionId = UUID.randomUUID();
+        given(routeRecalculationRepository.findAllByTrainingSession_IdAndStatus(sessionId, RecalculationStatus.PENDING))
+                .willReturn(List.of(pendingA, pendingB));
+
+        routeRecalculationService.cancelAllPendingForSession(sessionId, "훈련 종료로 무효화됨");
+
+        assertThat(pendingA.getStatus()).isEqualTo(RecalculationStatus.CANCELLED);
+        assertThat(pendingB.getStatus()).isEqualTo(RecalculationStatus.CANCELLED);
+        assertThat(pendingA.getCancelReason()).isEqualTo("훈련 종료로 무효화됨");
+        verify(trainingEventPublisher, times(2)).publishRouteRecalculationCancelledAfterCommit(any());
+    }
+
+    private RouteRecalculation pendingRecalculation(CongestionLevel level) {
         RouteRecalculation recalculation = RouteRecalculation.createPending(
-                session, triggerEdge, CongestionLevel.CROWDED, List.of(UUID.randomUUID()), 12.5);
+                session, triggerEdge, "CCTV_001", RecalculationTriggerType.STARTED, level, 3.5,
+                List.of(UUID.randomUUID()), 10.0, List.of(UUID.randomUUID()), 12.5);
         ReflectionTestUtils.setField(recalculation, "id", UUID.randomUUID());
+        return recalculation;
+    }
+
+    private RouteRecalculation approvedRecalculation(List<UUID> nodeIds, double totalWeight) {
+        RouteRecalculation recalculation = RouteRecalculation.createPending(
+                session, triggerEdge, "CCTV_001", RecalculationTriggerType.STARTED, CongestionLevel.CROWDED, 3.5,
+                List.of(UUID.randomUUID()), 10.0, nodeIds, totalWeight);
+        ReflectionTestUtils.setField(recalculation, "id", UUID.randomUUID());
+        recalculation.approve(Instant.now(), mock(User.class));
         return recalculation;
     }
 
@@ -146,7 +280,7 @@ class RouteRecalculationServiceTest {
         UUID recalculationId = UUID.randomUUID();
         given(routeRecalculationRepository.findById(recalculationId)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> routeRecalculationService.approve(recalculationId))
+        assertThatThrownBy(() -> routeRecalculationService.approve(recalculationId, MANAGER_EMAIL))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("errorCode", EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND);
     }
@@ -154,11 +288,11 @@ class RouteRecalculationServiceTest {
     @Test
     @DisplayName("PENDING이 아니면 승인 시 INVALID_RECALCULATION_STATUS_TRANSITION을 던진다")
     void approve_whenNotPending_throws() {
-        RouteRecalculation recalculation = pendingRecalculation();
-        recalculation.approve(java.time.Instant.now());
+        RouteRecalculation recalculation = pendingRecalculation(CongestionLevel.CROWDED);
+        recalculation.approve(Instant.now(), mock(User.class));
         given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
 
-        assertThatThrownBy(() -> routeRecalculationService.approve(recalculation.getId()))
+        assertThatThrownBy(() -> routeRecalculationService.approve(recalculation.getId(), MANAGER_EMAIL))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("errorCode", EvacuationErrorCode.INVALID_RECALCULATION_STATUS_TRANSITION);
 
@@ -166,42 +300,64 @@ class RouteRecalculationServiceTest {
     }
 
     @Test
-    @DisplayName("PENDING이면 승인 시 상태를 APPROVED로 바꾸고 WS 이벤트를 발행한다")
-    void approve_whenPending_succeedsAndPublishes() {
-        RouteRecalculation recalculation = pendingRecalculation();
+    @DisplayName("승인자를 찾을 수 없으면 ADMIN_NOT_FOUND를 던진다")
+    void approve_whenApproverMissing_throws() {
+        RouteRecalculation recalculation = pendingRecalculation(CongestionLevel.CROWDED);
         given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
+        given(userRepository.findByEmail(MANAGER_EMAIL)).willReturn(Optional.empty());
 
-        RouteRecalculationResponse response = routeRecalculationService.approve(recalculation.getId());
+        assertThatThrownBy(() -> routeRecalculationService.approve(recalculation.getId(), MANAGER_EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TrainingErrorCode.ADMIN_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("PENDING이면 승인 시 상태를 APPROVED로 바꾸고 WS 발행 및 유도등 반영을 한다")
+    void approve_whenPending_succeedsAndPublishes() {
+        RouteRecalculation recalculation = pendingRecalculation(CongestionLevel.CROWDED);
+        given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
+        User manager = mock(User.class);
+        org.mockito.Mockito.lenient().when(manager.getUsername()).thenReturn("manager");
+        given(userRepository.findByEmail(MANAGER_EMAIL)).willReturn(Optional.of(manager));
+
+        RouteRecalculationResponse response = routeRecalculationService.approve(recalculation.getId(), MANAGER_EMAIL);
 
         assertThat(response.status()).isEqualTo(RecalculationStatus.APPROVED);
         assertThat(recalculation.getStatus()).isEqualTo(RecalculationStatus.APPROVED);
         assertThat(recalculation.getResolvedAt()).isNotNull();
+        assertThat(recalculation.getResolvedBy()).isEqualTo(manager);
         verify(trainingEventPublisher, times(1)).publishEvacuationRouteUpdatedAfterCommit(recalculation);
+        verify(ioTLightService, times(1)).applyRouteGuidance(recalculation.getRecalculatedNodeIds());
     }
 
     @Test
     @DisplayName("PENDING이 아니면 거절 시 INVALID_RECALCULATION_STATUS_TRANSITION을 던진다")
     void reject_whenNotPending_throws() {
-        RouteRecalculation recalculation = pendingRecalculation();
-        recalculation.reject(java.time.Instant.now());
+        RouteRecalculation recalculation = pendingRecalculation(CongestionLevel.CROWDED);
+        recalculation.reject(Instant.now(), mock(User.class), null);
         given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
 
-        assertThatThrownBy(() -> routeRecalculationService.reject(recalculation.getId()))
+        assertThatThrownBy(() -> routeRecalculationService.reject(recalculation.getId(), MANAGER_EMAIL, "사유"))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue("errorCode", EvacuationErrorCode.INVALID_RECALCULATION_STATUS_TRANSITION);
     }
 
     @Test
-    @DisplayName("PENDING이면 거절 시 상태를 REJECTED로 바꾸고 WS 이벤트는 발행하지 않는다")
-    void reject_whenPending_succeedsWithoutPublishing() {
-        RouteRecalculation recalculation = pendingRecalculation();
+    @DisplayName("PENDING이면 거절 시 상태를 REJECTED로 바꾸고 사유를 저장한다")
+    void reject_whenPending_succeedsWithoutEvacuationUpdate() {
+        RouteRecalculation recalculation = pendingRecalculation(CongestionLevel.CROWDED);
         given(routeRecalculationRepository.findById(recalculation.getId())).willReturn(Optional.of(recalculation));
+        User manager = mock(User.class);
+        given(userRepository.findByEmail(MANAGER_EMAIL)).willReturn(Optional.of(manager));
 
-        RouteRecalculationResponse response = routeRecalculationService.reject(recalculation.getId());
+        RouteRecalculationResponse response =
+                routeRecalculationService.reject(recalculation.getId(), MANAGER_EMAIL, "현장 확인 결과 통행 가능");
 
         assertThat(response.status()).isEqualTo(RecalculationStatus.REJECTED);
         assertThat(recalculation.getStatus()).isEqualTo(RecalculationStatus.REJECTED);
+        assertThat(recalculation.getRejectReason()).isEqualTo("현장 확인 결과 통행 가능");
         verify(trainingEventPublisher, never()).publishEvacuationRouteUpdatedAfterCommit(any());
-        verify(trainingEventPublisher, never()).publishRouteRecalculationRequested(any());
+        verify(trainingEventPublisher, times(1)).publishRouteRecalculationRejectedAfterCommit(recalculation);
+        verify(ioTLightService, never()).applyRouteGuidance(any());
     }
 }

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -50,6 +51,9 @@ class TrainingSessionServiceTest {
 
     @Mock
     private TrainingScenarioRepository trainingScenarioRepository;
+
+    @Mock
+    private RouteRecalculationService routeRecalculationService;
 
     @Mock
     private TrainingEventPublisher trainingEventPublisher;


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #95 
- Branch: feat/#95

## 주요 내용

- RouteRecalculation에 CANCELLED 상태와 triggerType/density/previousNodeIds/resolvedBy/rejectReason/cancelReason 추가
- 혼잡 레벨이 바뀌면 기존 PENDING을 취소하고 새로 계산, 혼잡 종료(CONGESTION_ENDED)면 정상 경로로의 복구 후보를 제시
- GET /api/v1/route-recalculations(목록, 세션+상태 필터), GET .../{id}(상세, previousRoute·candidateRoute 비교) 추가 — MANAGER 권한만 접근
- 승인/거절 시 Authentication으로 관리자를 식별해 기록, 거절 사유 저장
- 승인 시 IoTLightService.applyRouteGuidance로 유도등 방향 자동 반영 (실패해도 승인 자체는 막지 않음)
- 훈련 세션 종료(정상/강제/타임아웃) 시 남은 PENDING 일괄 무효화

### ⚠️ 배포 시 수동 작업
- route_recalculations 테이블의 기존 유니크 제약을 제거해야 함
/ (ddl-auto: update가 자동으로 지우지 않음): 
  `ALTER TABLE route_recalculations DROP CONSTRAINT uk_route_recalculation_session_edge_status;
` 
  같은 세션+엣지에서 레벨이 여러 번 오르내리며 CANCELLED/APPROVED 행이 여러 개 쌓일 수 있게 되어, 이 제약이 남아있으면 두 번째 승인 시점에 실패함. 로컬/운영 DB 모두 적용 필요. => 운영 DB는 적용 완료

### 범위 밖
- 경로 변경 이력 DynamoDB 저장은 포함하지 않음 (PostgreSQL RouteRecalculation 테이블 자체가 이미 이력을 보존하고, 별도 조회 API도 없어 제외 — 필요 시 별도 논의)

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?