### PR TITLE
Feat/#97 관리자 WebSocket 확장 — 이미지 조회 URL 보강

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionImageUrlController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionImageUrlController.java
@@ -1,0 +1,35 @@
+package com.saferoute.domain.congestion.controller;
+
+import com.saferoute.domain.congestion.dto.response.CongestionImageUrlResponse;
+import com.saferoute.domain.congestion.service.CongestionImageUrlService;
+import com.saferoute.global.api.response.ApiResponse;
+import com.saferoute.global.api.response.CongestionSuccessCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "혼잡 이미지", description = "관리자 화면의 혼잡 이미지 조회 URL 발급 API")
+@RestController
+@RequiredArgsConstructor
+public class CongestionImageUrlController {
+
+    private final CongestionImageUrlService congestionImageUrlService;
+
+    @GetMapping("/api/v1/congestion-events/{eventId}/image-url")
+    public ResponseEntity<ApiResponse<CongestionImageUrlResponse>> getEventImageUrl(@PathVariable UUID eventId) {
+        CongestionImageUrlResponse response = congestionImageUrlService.getEventImageUrl(eventId);
+        return ResponseEntity.ok(ApiResponse.success(CongestionSuccessCode.CONGESTION_IMAGE_URL_ISSUED, response));
+    }
+
+    @GetMapping("/api/v1/congestion-observations/{eventId}/image-url")
+    public ResponseEntity<ApiResponse<CongestionImageUrlResponse>> getObservationImageUrl(
+            @PathVariable UUID eventId
+    ) {
+        CongestionImageUrlResponse response = congestionImageUrlService.getObservationImageUrl(eventId);
+        return ResponseEntity.ok(ApiResponse.success(CongestionSuccessCode.CONGESTION_IMAGE_URL_ISSUED, response));
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/dto/response/CongestionImageUrlResponse.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/response/CongestionImageUrlResponse.java
@@ -1,0 +1,16 @@
+package com.saferoute.domain.congestion.dto.response;
+
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import java.time.Instant;
+
+// 관리자 화면이 S3 object key 대신 이 URL로 이미지를 직접 렌더링한다. URL은 만료되므로
+// 화면에 값을 오래 들고 있지 말고, 열람 시점에 다시 요청해서 새 URL을 받아야 한다.
+public record CongestionImageUrlResponse(
+        String imageUrl,
+        Instant expiresAt
+) {
+
+    public static CongestionImageUrlResponse from(PresignedGetUrl presignedGetUrl) {
+        return new CongestionImageUrlResponse(presignedGetUrl.viewUrl(), presignedGetUrl.expiresAt());
+    }
+}

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionImageUrlService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionImageUrlService.java
@@ -1,0 +1,49 @@
+package com.saferoute.domain.congestion.service;
+
+import com.saferoute.domain.congestion.dto.response.CongestionImageUrlResponse;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.global.api.error.CongestionErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 관리자 화면이 즉시 이벤트/관측값 이미지를 열람할 때 쓰는 Presigned GET URL 발급.
+// S3 버킷은 Public이 아니라서 object key만으로는 브라우저에서 열 수 없다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CongestionImageUrlService {
+
+    private final CongestionEventRepository congestionEventRepository;
+    private final ObservationRepository observationRepository;
+    private final S3PresignedUrlService s3PresignedUrlService;
+
+    public CongestionImageUrlResponse getEventImageUrl(UUID eventId) {
+        CongestionEventItem item = congestionEventRepository.findByEventId(eventId.toString())
+                .orElseThrow(() -> new ApiException(CongestionErrorCode.EVENT_NOT_FOUND));
+
+        if (item.getImageUploadStatus() != ImageUploadStatus.COMPLETED || item.getEventImageKey() == null) {
+            throw new ApiException(CongestionErrorCode.EVENT_IMAGE_OBJECT_NOT_FOUND);
+        }
+
+        return CongestionImageUrlResponse.from(s3PresignedUrlService.createGetUrl(item.getEventImageKey()));
+    }
+
+    public CongestionImageUrlResponse getObservationImageUrl(UUID eventId) {
+        ObservationItem item = observationRepository.findByEventId(eventId.toString())
+                .orElseThrow(() -> new ApiException(CongestionErrorCode.EVENT_NOT_FOUND));
+
+        if (item.getMonitoringImageKey() == null) {
+            throw new ApiException(CongestionErrorCode.EVENT_IMAGE_OBJECT_NOT_FOUND);
+        }
+
+        return CongestionImageUrlResponse.from(s3PresignedUrlService.createGetUrl(item.getMonitoringImageKey()));
+    }
+}

--- a/src/main/java/com/saferoute/global/api/response/CongestionSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/CongestionSuccessCode.java
@@ -1,0 +1,17 @@
+package com.saferoute.global.api.response;
+
+import com.saferoute.global.api.code.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CongestionSuccessCode implements BaseCode {
+
+    CONGESTION_IMAGE_URL_ISSUED(HttpStatus.OK, "CONGESTION_SUCCESS_001", "이미지 조회 URL이 발급되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -119,6 +119,13 @@ public class SecurityConfig {
                                 "/api/v1/route-recalculations/*"
                         ).hasRole("MANAGER")
 
+                        // 혼잡 이미지 조회 URL도 관리자 화면 전용이다.
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/congestion-events/*/image-url",
+                                "/api/v1/congestion-observations/*/image-url"
+                        ).hasRole("MANAGER")
+
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/api/**"

--- a/src/main/java/com/saferoute/infrastructure/s3/config/S3Properties.java
+++ b/src/main/java/com/saferoute/infrastructure/s3/config/S3Properties.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "aws.s3")
 public record S3Properties(
         @NotBlank String bucket,
-        @NotNull Duration presignedUrlExpiration
+        @NotNull Duration presignedUrlExpiration,
+        @NotNull Duration presignedGetUrlExpiration
 ) {
 }

--- a/src/main/java/com/saferoute/infrastructure/s3/dto/PresignedGetUrl.java
+++ b/src/main/java/com/saferoute/infrastructure/s3/dto/PresignedGetUrl.java
@@ -1,0 +1,9 @@
+package com.saferoute.infrastructure.s3.dto;
+
+import java.time.Instant;
+
+public record PresignedGetUrl(
+        String viewUrl,
+        Instant expiresAt
+) {
+}

--- a/src/main/java/com/saferoute/infrastructure/s3/service/S3PresignedUrlService.java
+++ b/src/main/java/com/saferoute/infrastructure/s3/service/S3PresignedUrlService.java
@@ -3,12 +3,16 @@ package com.saferoute.infrastructure.s3.service;
 import com.saferoute.global.api.error.S3ErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.config.S3Properties;
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
 import com.saferoute.infrastructure.s3.dto.PresignedPutUrl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
@@ -35,6 +39,30 @@ public class S3PresignedUrlService {
             PresignedPutObjectRequest presignedRequest =
                     s3Presigner.presignPutObject(presignRequest);
             return new PresignedPutUrl(
+                    presignedRequest.url().toString(),
+                    presignedRequest.expiration()
+            );
+        } catch (SdkException exception) {
+            throw new ApiException(S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED, exception);
+        }
+    }
+
+    // 관리자 화면이 S3 object key만으로는 이미지를 열람할 수 없어(버킷은 Public이 아님) 조회용으로 발급한다.
+    public PresignedGetUrl createGetUrl(String objectKey) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(s3Properties.bucket())
+                .key(objectKey)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(s3Properties.presignedGetUrlExpiration())
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        try {
+            PresignedGetObjectRequest presignedRequest =
+                    s3Presigner.presignGetObject(presignRequest);
+            return new PresignedGetUrl(
                     presignedRequest.url().toString(),
                     presignedRequest.expiration()
             );

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,8 @@ aws:
   s3:
     bucket: ${S3_BUCKET}
     presigned-url-expiration: 1m
+    # 관리자 화면이 이미지를 불러오는 동안 만료되지 않도록 업로드용(1분)보다 넉넉하게 잡는다.
+    presigned-get-url-expiration: 5m
 
   dynamodb:
     table-name: ${DYNAMODB_TABLE:saferoute-telemetry}

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionImageUrlControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionImageUrlControllerTest.java
@@ -1,0 +1,87 @@
+package com.saferoute.domain.congestion.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.saferoute.domain.congestion.dto.response.CongestionImageUrlResponse;
+import com.saferoute.domain.congestion.service.CongestionImageUrlService;
+import com.saferoute.global.api.error.CongestionErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.config.SecurityConfig;
+import com.saferoute.global.security.JwtAuthenticationFilter;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = CongestionImageUrlController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {JwtAuthenticationFilter.class, SecurityConfig.class}
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class CongestionImageUrlControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CongestionImageUrlService congestionImageUrlService;
+
+    private final UUID eventId = UUID.randomUUID();
+
+    @Test
+    @DisplayName("이벤트 이미지 URL 조회 성공 시 200을 반환한다")
+    void getEventImageUrl_returnsOk() throws Exception {
+        given(congestionImageUrlService.getEventImageUrl(eventId))
+                .willReturn(new CongestionImageUrlResponse("https://example.com/view", Instant.now()));
+
+        mockMvc.perform(get("/api/v1/congestion-events/{eventId}/image-url", eventId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.imageUrl").value("https://example.com/view"));
+    }
+
+    @Test
+    @DisplayName("이벤트를 찾을 수 없으면 404를 반환한다")
+    void getEventImageUrl_returnsNotFoundWhenMissing() throws Exception {
+        willThrow(new ApiException(CongestionErrorCode.EVENT_NOT_FOUND))
+                .given(congestionImageUrlService).getEventImageUrl(any());
+
+        mockMvc.perform(get("/api/v1/congestion-events/{eventId}/image-url", eventId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("이벤트 이미지가 아직 없으면 409를 반환한다")
+    void getEventImageUrl_returnsConflictWhenImageNotReady() throws Exception {
+        willThrow(new ApiException(CongestionErrorCode.EVENT_IMAGE_OBJECT_NOT_FOUND))
+                .given(congestionImageUrlService).getEventImageUrl(any());
+
+        mockMvc.perform(get("/api/v1/congestion-events/{eventId}/image-url", eventId))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("관측값 이미지 URL 조회 성공 시 200을 반환한다")
+    void getObservationImageUrl_returnsOk() throws Exception {
+        given(congestionImageUrlService.getObservationImageUrl(eventId))
+                .willReturn(new CongestionImageUrlResponse("https://example.com/view", Instant.now()));
+
+        mockMvc.perform(get("/api/v1/congestion-observations/{eventId}/image-url", eventId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.imageUrl").value("https://example.com/view"));
+    }
+}

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionImageUrlServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionImageUrlServiceTest.java
@@ -1,0 +1,125 @@
+package com.saferoute.domain.congestion.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.saferoute.domain.congestion.dto.response.CongestionImageUrlResponse;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
+import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.global.api.error.CongestionErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionImageUrlServiceTest {
+
+    private static final UUID EVENT_ID = UUID.randomUUID();
+    private static final UUID SESSION_ID = UUID.randomUUID();
+
+    @InjectMocks
+    private CongestionImageUrlService service;
+
+    @Mock
+    private CongestionEventRepository congestionEventRepository;
+
+    @Mock
+    private ObservationRepository observationRepository;
+
+    @Mock
+    private S3PresignedUrlService s3PresignedUrlService;
+
+    @Test
+    void 완료된_이벤트_이미지의_조회_URL을_발급한다() {
+        CongestionEventItem item = CongestionEventItem.received(
+                EVENT_ID, SESSION_ID, "CCTV_001", CongestionEventType.CONGESTION_STARTED,
+                2_000L, 9, 4.5, CongestionLevel.CROWDED, 4.5, CongestionLevel.CROWDED, 1L,
+                "training/s/events/CCTV_001/e.jpg"
+        );
+        item.setImageUploadStatus(ImageUploadStatus.COMPLETED);
+        given(congestionEventRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        Instant expiresAt = Instant.parse("2026-08-24T00:05:00Z");
+        given(s3PresignedUrlService.createGetUrl("training/s/events/CCTV_001/e.jpg"))
+                .willReturn(new PresignedGetUrl("https://example.com/view", expiresAt));
+
+        CongestionImageUrlResponse response = service.getEventImageUrl(EVENT_ID);
+
+        assertThat(response.imageUrl()).isEqualTo("https://example.com/view");
+        assertThat(response.expiresAt()).isEqualTo(expiresAt);
+    }
+
+    @Test
+    void 이벤트를_찾을_수_없으면_EVENT_NOT_FOUND를_던진다() {
+        given(congestionEventRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getEventImageUrl(EVENT_ID))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.EVENT_NOT_FOUND);
+    }
+
+    @Test
+    void 이벤트_이미지가_아직_완료되지_않았으면_EVENT_IMAGE_OBJECT_NOT_FOUND를_던진다() {
+        CongestionEventItem item = CongestionEventItem.received(
+                EVENT_ID, SESSION_ID, "CCTV_001", CongestionEventType.CONGESTION_STARTED,
+                2_000L, 9, 4.5, CongestionLevel.CROWDED, 4.5, CongestionLevel.CROWDED, 1L, null
+        );
+        given(congestionEventRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+
+        assertThatThrownBy(() -> service.getEventImageUrl(EVENT_ID))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.EVENT_IMAGE_OBJECT_NOT_FOUND);
+    }
+
+    @Test
+    void 관측값_이미지의_조회_URL을_발급한다() {
+        ObservationItem item = ObservationItem.create(
+                EVENT_ID, SESSION_ID, null, "CCTV_001", 5.0, 8, 25, 2.5,
+                CongestionLevel.CAUTION, 1_000L, 2_000L, 2_000L,
+                "training/s/monitoring/CCTV_001/2000.jpg", 1L
+        );
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+        Instant expiresAt = Instant.parse("2026-08-24T00:05:00Z");
+        given(s3PresignedUrlService.createGetUrl("training/s/monitoring/CCTV_001/2000.jpg"))
+                .willReturn(new PresignedGetUrl("https://example.com/view", expiresAt));
+
+        CongestionImageUrlResponse response = service.getObservationImageUrl(EVENT_ID);
+
+        assertThat(response.imageUrl()).isEqualTo("https://example.com/view");
+    }
+
+    @Test
+    void 관측값_이미지_키가_없으면_EVENT_IMAGE_OBJECT_NOT_FOUND를_던진다() {
+        ObservationItem item = ObservationItem.create(
+                EVENT_ID, SESSION_ID, null, "CCTV_001", 5.0, 8, 25, 2.5,
+                CongestionLevel.CAUTION, 1_000L, 2_000L, 2_000L, null, 1L
+        );
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.of(item));
+
+        assertThatThrownBy(() -> service.getObservationImageUrl(EVENT_ID))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.EVENT_IMAGE_OBJECT_NOT_FOUND);
+    }
+
+    @Test
+    void 관측값을_찾을_수_없으면_EVENT_NOT_FOUND를_던진다() {
+        given(observationRepository.findByEventId(EVENT_ID.toString())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getObservationImageUrl(EVENT_ID))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.EVENT_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/saferoute/infrastructure/s3/S3PresignedUrlServiceTest.java
+++ b/src/test/java/com/saferoute/infrastructure/s3/S3PresignedUrlServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import com.saferoute.global.api.error.S3ErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.config.S3Properties;
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
 import com.saferoute.infrastructure.s3.dto.PresignedPutUrl;
 import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
 import java.net.URI;
@@ -20,8 +21,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
@@ -34,13 +38,16 @@ class S3PresignedUrlServiceTest {
     @Mock
     private PresignedPutObjectRequest presignedRequest;
 
+    @Mock
+    private PresignedGetObjectRequest presignedGetRequest;
+
     private S3PresignedUrlService service;
 
     @BeforeEach
     void setUp() {
         service = new S3PresignedUrlService(
                 s3Presigner,
-                new S3Properties("test-bucket", Duration.ofMinutes(1))
+                new S3Properties("test-bucket", Duration.ofMinutes(1), Duration.ofMinutes(5))
         );
     }
 
@@ -76,6 +83,44 @@ class S3PresignedUrlServiceTest {
                 .willThrow(SdkClientException.create("presign failed"));
 
         assertThatThrownBy(() -> service.createPutUrl("key", "image/jpeg"))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED
+                );
+    }
+
+    @Test
+    void createsFiveMinuteGetUrlForObjectKey() throws Exception {
+        String key = "training/session-id/events/CCTV_001/event-id.jpg";
+        Instant expiration = Instant.parse("2026-08-20T00:05:00Z");
+        given(presignedGetRequest.url()).willReturn(URI.create("https://example.com/view").toURL());
+        given(presignedGetRequest.expiration()).willReturn(expiration);
+        given(s3Presigner.presignGetObject(org.mockito.ArgumentMatchers.any(
+                GetObjectPresignRequest.class))).willReturn(presignedGetRequest);
+
+        PresignedGetUrl result = service.createGetUrl(key);
+
+        ArgumentCaptor<GetObjectPresignRequest> captor =
+                ArgumentCaptor.forClass(GetObjectPresignRequest.class);
+        verify(s3Presigner).presignGetObject(captor.capture());
+        GetObjectPresignRequest request = captor.getValue();
+        GetObjectRequest getObjectRequest = request.getObjectRequest();
+
+        assertThat(request.signatureDuration()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(getObjectRequest.bucket()).isEqualTo("test-bucket");
+        assertThat(getObjectRequest.key()).isEqualTo(key);
+        assertThat(result.viewUrl()).isEqualTo("https://example.com/view");
+        assertThat(result.expiresAt()).isEqualTo(expiration);
+    }
+
+    @Test
+    void mapsAwsFailureToApiErrorForGetUrl() {
+        given(s3Presigner.presignGetObject(org.mockito.ArgumentMatchers.any(
+                GetObjectPresignRequest.class)))
+                .willThrow(SdkClientException.create("presign failed"));
+
+        assertThatThrownBy(() -> service.createGetUrl("key"))
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue(
                         "errorCode",

--- a/src/test/java/com/saferoute/infrastructure/s3/S3ServiceTest.java
+++ b/src/test/java/com/saferoute/infrastructure/s3/S3ServiceTest.java
@@ -42,7 +42,8 @@ class S3ServiceTest {
     void setUp() {
         S3Properties properties = new S3Properties(
                 "test-bucket",
-                Duration.ofMinutes(1)
+                Duration.ofMinutes(1),
+                Duration.ofMinutes(5)
         );
         s3Service = new S3Service(s3Client, properties);
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,6 +32,7 @@ aws:
   s3:
     bucket: test-bucket
     presigned-url-expiration: 10m
+    presigned-get-url-expiration: 10m
 
   dynamodb:
     table-name: test-saferoute-telemetry


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #97
- Branch: feat/#97

## 주요 내용

- 이슈 12(관리자 WebSocket 확장)의 남은 부분인 이미지 조회 URL 발급 구현 (관측값/즉시이벤트 WebSocket 메시지 자체는 이미 #93, #91에서 완료돼 있었음)
- S3PresignedUrlService에 createGetUrl 추가 — 업로드용(PUT, 1분)과 별도로 조회용 만료 시간(기본 5분)을 둬서 관리자 화면이 이미지를 불러오는 동안 URL이 만료되지 않게 함
- GET /api/v1/congestion-events/{eventId}/image-url, GET /api/v1/congestion-observations/{eventId}/image-url 추가
- 이벤트 이미지는 imageUploadStatus가 COMPLETED일 때만, 관측값 이미지는 monitoringImageKey가 있을 때만 발급 (아니면 409)
- 재탐색 목록/상세와 동일하게 MANAGER 권한만 접근 가능
- WebSocket으로 오는 eventImageKey는 여전히 S3 object key만 담고 있어서, 프론트는 이 API로 받은 imageUrl을 써야 실제로 이미지를 렌더링할 수 있음

## ✅ Check List

- [x] 테스트 통과 (배포 후 실제 발급된 URL로 브라우저에서 이미지 로딩 확인 권장 (AWS 서명 자체는 유닛 테스트가 mock이라 커버 안 됨)
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?