### PR TITLE
Feat/#99 경로 재계산 가중치 체계 구현(혼잡도 부분) 

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -36,7 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class RouteRecalculationService {
 
-    // "경로 혼잡 비용" 표: CAUTION은 1.5배, CROWDED는 3배 페널티만 주고 여전히 후보에 남긴다.
+    // CAUTION은 1.5배, CROWDED는 3배 페널티만 주고 여전히 후보에 남긴다.
     // VERY_CROWDED는 배율이 아니라 완전 제외(excludedEdgeIds)로 처리한다 - trigger()의
     // requiresRouteRecalculation() 게이트 상 CAUTION은 현재 이 메서드까지 도달하지 않지만,
     // 표 전체를 그대로 반영해둔다.
@@ -76,7 +76,7 @@ public class RouteRecalculationService {
 
         UUID floorId = triggerEdge.getFloor().getId();
         // TODO: 양방향 엣지에서는 실제로 반대편(toNode) 기준 우회도 필요할 수 있다 - 지금은
-        // fromNode 기준으로 고정한다 (BE-06 선행 위험으로 문서에 명시된 채 아직 미해결).
+        // fromNode 기준으로 고정한다
         UUID startNodeId = triggerEdge.getFromNode().getId();
 
         RouteSnapshot previous = resolveActiveRoute(session, triggerEdge, floorId, startNodeId);

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -21,6 +21,7 @@ import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -34,6 +35,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RouteRecalculationService {
+
+    // "경로 혼잡 비용" 표: CAUTION은 1.5배, CROWDED는 3배 페널티만 주고 여전히 후보에 남긴다.
+    // VERY_CROWDED는 배율이 아니라 완전 제외(excludedEdgeIds)로 처리한다 - trigger()의
+    // requiresRouteRecalculation() 게이트 상 CAUTION은 현재 이 메서드까지 도달하지 않지만,
+    // 표 전체를 그대로 반영해둔다.
+    private static final double CAUTION_WEIGHT_MULTIPLIER = 1.5;
+    private static final double CROWDED_WEIGHT_MULTIPLIER = 3.0;
 
     private final RouteRecalculationRepository routeRecalculationRepository;
     private final EvacuationRouteService evacuationRouteService;
@@ -67,13 +75,16 @@ public class RouteRecalculationService {
         }
 
         UUID floorId = triggerEdge.getFloor().getId();
+        // TODO: 양방향 엣지에서는 실제로 반대편(toNode) 기준 우회도 필요할 수 있다 - 지금은
+        // fromNode 기준으로 고정한다 (BE-06 선행 위험으로 문서에 명시된 채 아직 미해결).
         UUID startNodeId = triggerEdge.getFromNode().getId();
 
         RouteSnapshot previous = resolveActiveRoute(session, triggerEdge, floorId, startNodeId);
 
         EvacuationRoute candidate;
         try {
-            candidate = evacuationRouteService.findShortestRoute(floorId, startNodeId, Set.of(triggerEdge.getId()));
+            candidate = evacuationRouteService.findShortestRoute(
+                    floorId, startNodeId, excludedEdgesFor(triggerEdge, level), weightMultipliersFor(triggerEdge, level));
         } catch (ApiException exception) {
             if (exception.getErrorCode() == EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND) {
                 log.warn("우회 경로를 찾을 수 없어 재탐색 승인 대기 항목을 생성하지 않음: sessionId={}, edgeId={}",
@@ -84,6 +95,20 @@ public class RouteRecalculationService {
         }
 
         savePending(session, triggerEdge, cctvCode, triggerType, level, density, previous, candidate);
+    }
+
+    // VERY_CROWDED만 완전 제외한다 - 배율만으로는 다른 대안이 훨씬 나쁠 때 여전히 그 엣지를
+    // 통과하는 경로가 선택될 수 있어, "사실상 통행 불가"를 표현하려면 그래프에서 아예 빼야 한다.
+    private Set<UUID> excludedEdgesFor(MapEdge triggerEdge, CongestionLevel level) {
+        return level == CongestionLevel.VERY_CROWDED ? Set.of(triggerEdge.getId()) : Set.of();
+    }
+
+    private Map<UUID, Double> weightMultipliersFor(MapEdge triggerEdge, CongestionLevel level) {
+        return switch (level) {
+            case CAUTION -> Map.of(triggerEdge.getId(), CAUTION_WEIGHT_MULTIPLIER);
+            case CROWDED -> Map.of(triggerEdge.getId(), CROWDED_WEIGHT_MULTIPLIER);
+            case NORMAL, VERY_CROWDED -> Map.of();
+        };
     }
 
     // 혼잡 종료 시 정상(트리거 엣지를 포함한 직행) 경로로의 복구 후보를 계산한다.

--- a/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRouteService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRouteService.java
@@ -36,9 +36,20 @@ public class EvacuationRouteService {
         return findShortestRoute(floorId, startNodeId, Set.of());
     }
 
-    // 혼잡 재탐색용 - 지정된 엣지를 그래프에서 제외하고 우회 경로를 계산한다.
-    // congestion/danger 가중치 자체(현재 0 고정)와는 별개로, "엣지 제외" 방식의 임시 조치다.
+    // 혼잡 재탐색용 - 지정된 엣지를 그래프에서 제외하고 우회 경로를 계산한다 (VERY_CROWDED처럼
+    // 완전히 막힌 경우). 레벨별로 페널티만 주고 여전히 후보에 남기고 싶다면 weightMultipliers를 쓰는
+    // 4-인자 오버로드를 사용한다.
     public EvacuationRoute findShortestRoute(UUID floorId, UUID startNodeId, Set<UUID> excludedEdgeIds) {
+        return findShortestRoute(floorId, startNodeId, excludedEdgeIds, Map.of());
+    }
+
+    // 혼잡 단계별로 특정 엣지의 가중치에 배율을 적용한다 (문서 "경로 혼잡 비용" 표: CAUTION ×1.5,
+    // CROWDED ×3.0). 배율이 없는 엣지는 1.0을 적용한 것과 같다. VERY_CROWDED처럼 아예 후보에서
+    // 빼야 하는 경우는 배율이 아니라 excludedEdgeIds로 처리한다 - 배율만으로는 그래프가 다른 대안이
+    // 없을 때 여전히 그 엣지를 통과하는 경로를 고를 수 있기 때문이다.
+    public EvacuationRoute findShortestRoute(
+            UUID floorId, UUID startNodeId, Set<UUID> excludedEdgeIds, Map<UUID, Double> weightMultipliers
+    ) {
         List<MapNode> nodes = mapGraphRepository.findNodesByFloor(floorId);
         List<MapEdge> edges = mapGraphRepository.findEdgesByFloor(floorId).stream()
                 .filter(edge -> !excludedEdgeIds.contains(edge.getId()))
@@ -85,7 +96,7 @@ public class EvacuationRouteService {
                         ? edge.getFromNode().getId()
                         : edge.getToNode().getId();
 
-                double newDistance = distance.get(current.nodeId()) + calculateWeight(edge);
+                double newDistance = distance.get(current.nodeId()) + calculateWeight(edge, weightMultipliers);
                 if (newDistance < distance.getOrDefault(neighbor, Double.MAX_VALUE)) {
                     distance.put(neighbor, newDistance);
                     previous.put(neighbor, current.nodeId());
@@ -109,12 +120,15 @@ public class EvacuationRouteService {
         return adjacency;
     }
 
-    // weight = distance + α×congestion + β×danger
-    // TODO: congestion/danger 현재 0 고정 - 혼잡도(DynamoDB)·blocked 외 danger 데이터 연동 확정 후 반영
-    private double calculateWeight(MapEdge edge) {
+    // weight = (distance + α×congestion + β×danger) × 혼잡 재탐색용 배율
+    // TODO: congestion/danger 현재 0 고정 - 혼잡도(DynamoDB)·blocked 외 danger 데이터 연동 확정 후 반영.
+    // weightMultipliers는 그것과 별개로, RouteRecalculationService가 트리거 엣지에 "경로 혼잡 비용"
+    // 표(CAUTION ×1.5, CROWDED ×3.0)를 적용하기 위해 넘기는 값이다 - 두 메커니즘은 독립적이다.
+    private double calculateWeight(MapEdge edge, Map<UUID, Double> weightMultipliers) {
         double congestion = 0.0;
         double danger = 0.0;
-        return edge.getDistance() + CONGESTION_WEIGHT * congestion + DANGER_WEIGHT * danger;
+        double baseWeight = edge.getDistance() + CONGESTION_WEIGHT * congestion + DANGER_WEIGHT * danger;
+        return baseWeight * weightMultipliers.getOrDefault(edge.getId(), 1.0);
     }
 
     private EvacuationRoute buildRoute(Map<UUID, MapNode> nodeById, Map<UUID, UUID> previous,

--- a/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRouteService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/service/EvacuationRouteService.java
@@ -36,17 +36,16 @@ public class EvacuationRouteService {
         return findShortestRoute(floorId, startNodeId, Set.of());
     }
 
-    // 혼잡 재탐색용 - 지정된 엣지를 그래프에서 제외하고 우회 경로를 계산한다 (VERY_CROWDED처럼
-    // 완전히 막힌 경우). 레벨별로 페널티만 주고 여전히 후보에 남기고 싶다면 weightMultipliers를 쓰는
-    // 4-인자 오버로드를 사용한다.
+    // 혼잡 재탐색용 - 지정된 엣지를 그래프에서 제외하고 우회 경로를 계산한다 (VERY_CROWDED처럼 완전히 막힌 경우).
+    // 레벨별로 페널티만 주고 여전히 후보에 남기고 싶다면 weightMultipliers를 쓰는 4-인자 오버로드를 사용한다.
     public EvacuationRoute findShortestRoute(UUID floorId, UUID startNodeId, Set<UUID> excludedEdgeIds) {
         return findShortestRoute(floorId, startNodeId, excludedEdgeIds, Map.of());
     }
 
-    // 혼잡 단계별로 특정 엣지의 가중치에 배율을 적용한다 (문서 "경로 혼잡 비용" 표: CAUTION ×1.5,
-    // CROWDED ×3.0). 배율이 없는 엣지는 1.0을 적용한 것과 같다. VERY_CROWDED처럼 아예 후보에서
-    // 빼야 하는 경우는 배율이 아니라 excludedEdgeIds로 처리한다 - 배율만으로는 그래프가 다른 대안이
-    // 없을 때 여전히 그 엣지를 통과하는 경로를 고를 수 있기 때문이다.
+    // 혼잡 단계별로 특정 엣지의 가중치에 배율을 적용한다 (CAUTION ×1.5, CROWDED ×3.0). 
+    // 배율이 없는 엣지는 1.0을 적용한 것과 같다. 
+    // VERY_CROWDED처럼 아예 후보에서 빼야 하는 경우는 배율이 아니라 excludedEdgeIds로 처리한다 
+    // -> 배율만으로는 그래프가 다른 대안이 없을 때 여전히 그 엣지를 통과하는 경로를 고를 수 있기 때문이다.
     public EvacuationRoute findShortestRoute(
             UUID floorId, UUID startNodeId, Set<UUID> excludedEdgeIds, Map<UUID, Double> weightMultipliers
     ) {
@@ -123,7 +122,7 @@ public class EvacuationRouteService {
     // weight = (distance + α×congestion + β×danger) × 혼잡 재탐색용 배율
     // TODO: congestion/danger 현재 0 고정 - 혼잡도(DynamoDB)·blocked 외 danger 데이터 연동 확정 후 반영.
     // weightMultipliers는 그것과 별개로, RouteRecalculationService가 트리거 엣지에 "경로 혼잡 비용"
-    // 표(CAUTION ×1.5, CROWDED ×3.0)를 적용하기 위해 넘기는 값이다 - 두 메커니즘은 독립적이다.
+    // (CAUTION ×1.5, CROWDED ×3.0)를 적용하기 위해 넘기는 값이다 - 두 메커니즘은 독립적이다.
     private double calculateWeight(MapEdge edge, Map<UUID, Double> weightMultipliers) {
         double congestion = 0.0;
         double danger = 0.0;

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -32,6 +32,7 @@ import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -130,7 +131,7 @@ class RouteRecalculationServiceTest {
                 .willReturn(Optional.of(existing));
         givenNoApprovedHistory();
         givenNoDirectRoute();
-        given(evacuationRouteService.findShortestRoute(any(), any(), anySet()))
+        given(evacuationRouteService.findShortestRoute(any(), any(), anySet(), any()))
                 .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
 
         routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.VERY_CROWDED,
@@ -146,7 +147,7 @@ class RouteRecalculationServiceTest {
         givenNoExistingPending();
         givenNoApprovedHistory();
         givenNoDirectRoute();
-        given(evacuationRouteService.findShortestRoute(any(), any(), anySet()))
+        given(evacuationRouteService.findShortestRoute(any(), any(), anySet(), any()))
                 .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
 
         routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
@@ -157,8 +158,8 @@ class RouteRecalculationServiceTest {
     }
 
     @Test
-    @DisplayName("우회 경로를 찾으면 PENDING 저장 + WS 발행을 한다")
-    void trigger_createsPendingRecalculationAndPublishesEvent() {
+    @DisplayName("VERY_CROWDED면 트리거 엣지를 완전히 제외하고 우회 경로를 계산한다")
+    void trigger_veryCrowded_excludesTriggerEdgeEntirely() {
         givenNoExistingPending();
         givenNoApprovedHistory();
         givenNoDirectRoute();
@@ -166,7 +167,36 @@ class RouteRecalculationServiceTest {
         MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
         ReflectionTestUtils.setField(exitNode, "id", UUID.randomUUID());
         EvacuationRoute route = new EvacuationRoute(List.of(exitNode), 12.5);
-        given(evacuationRouteService.findShortestRoute(any(), any(), anySet())).willReturn(route);
+        given(evacuationRouteService.findShortestRoute(any(), any(), anySet(), any())).willReturn(route);
+
+        RouteRecalculation saved = pendingRecalculation(CongestionLevel.VERY_CROWDED);
+        given(routeRecalculationRepository.save(any())).willReturn(saved);
+
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.VERY_CROWDED,
+                RecalculationTriggerType.STARTED, "CCTV_001", 5.5);
+
+        ArgumentCaptor<Set<UUID>> excludedEdgesCaptor = ArgumentCaptor.forClass(Set.class);
+        ArgumentCaptor<Map<UUID, Double>> multipliersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(evacuationRouteService).findShortestRoute(
+                any(), any(), excludedEdgesCaptor.capture(), multipliersCaptor.capture());
+        assertThat(excludedEdgesCaptor.getValue()).containsExactly(triggerEdge.getId());
+        assertThat(multipliersCaptor.getValue()).isEmpty();
+
+        verify(routeRecalculationRepository, times(1)).save(any());
+        verify(trainingEventPublisher, times(1)).publishRouteRecalculationRequestedAfterCommit(saved);
+    }
+
+    @Test
+    @DisplayName("CROWDED면 트리거 엣지를 제외하지 않고 3배 가중치만 줘서 후보에 남긴다")
+    void trigger_crowded_appliesWeightMultiplierInsteadOfExcluding() {
+        givenNoExistingPending();
+        givenNoApprovedHistory();
+        givenNoDirectRoute();
+
+        MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
+        ReflectionTestUtils.setField(exitNode, "id", UUID.randomUUID());
+        EvacuationRoute route = new EvacuationRoute(List.of(exitNode), 12.5);
+        given(evacuationRouteService.findShortestRoute(any(), any(), anySet(), any())).willReturn(route);
 
         RouteRecalculation saved = pendingRecalculation(CongestionLevel.CROWDED);
         given(routeRecalculationRepository.save(any())).willReturn(saved);
@@ -175,8 +205,11 @@ class RouteRecalculationServiceTest {
                 RecalculationTriggerType.STARTED, "CCTV_001", 3.5);
 
         ArgumentCaptor<Set<UUID>> excludedEdgesCaptor = ArgumentCaptor.forClass(Set.class);
-        verify(evacuationRouteService).findShortestRoute(any(), any(), excludedEdgesCaptor.capture());
-        assertThat(excludedEdgesCaptor.getValue()).containsExactly(triggerEdge.getId());
+        ArgumentCaptor<Map<UUID, Double>> multipliersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(evacuationRouteService).findShortestRoute(
+                any(), any(), excludedEdgesCaptor.capture(), multipliersCaptor.capture());
+        assertThat(excludedEdgesCaptor.getValue()).isEmpty();
+        assertThat(multipliersCaptor.getValue()).containsEntry(triggerEdge.getId(), 3.0);
 
         verify(routeRecalculationRepository, times(1)).save(any());
         verify(trainingEventPublisher, times(1)).publishRouteRecalculationRequestedAfterCommit(saved);

--- a/src/test/java/com/saferoute/domain/evacuation/service/EvacuationRouteServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/service/EvacuationRouteServiceTest.java
@@ -118,6 +118,54 @@ class EvacuationRouteServiceTest {
     }
 
     @Test
+    @DisplayName("배율이 낮으면 제외가 아니라서 여전히 그 엣지를 통과하되 가중치만 반영한다")
+    void findShortestRoute_withLowWeightMultiplier_stillUsesEdgeWithPenalty() {
+        // given
+        MapEdge e1 = createEdge(room1, door1, 2);
+        MapEdge e2 = createEdge(door1, hallway1, 5);
+        MapEdge e3 = createEdge(hallway1, stair1, 10);
+        MapEdge e4 = createEdge(hallway1, hallway2, 3);
+        MapEdge e5 = createEdge(hallway2, stair2, 2); // CAUTION 배율(1.5) 적용 대상
+
+        given(mapGraphRepository.findNodesByFloor(floorId))
+                .willReturn(List.of(room1, door1, hallway1, hallway2, stair1, stair2));
+        given(mapGraphRepository.findEdgesByFloor(floorId))
+                .willReturn(List.of(e1, e2, e3, e4, e5));
+
+        // when
+        EvacuationRoute route = evacuationRouteService.findShortestRoute(
+                floorId, room1.getId(), java.util.Set.of(), java.util.Map.of(e5.getId(), 1.5));
+
+        // then: 2+5+3+(2*1.5) = 13, 대안(2+5+10=17)보다 여전히 저렴해서 e5를 그대로 씀
+        assertThat(route.totalWeight()).isEqualTo(2 + 5 + 3 + (2 * 1.5));
+        assertThat(route.path()).containsExactly(room1, door1, hallway1, hallway2, stair2);
+    }
+
+    @Test
+    @DisplayName("배율이 충분히 크면 제외 없이도 다른 대안 경로를 고른다")
+    void findShortestRoute_withHighWeightMultiplier_choosesAlternative() {
+        // given
+        MapEdge e1 = createEdge(room1, door1, 2);
+        MapEdge e2 = createEdge(door1, hallway1, 5);
+        MapEdge e3 = createEdge(hallway1, stair1, 10);
+        MapEdge e4 = createEdge(hallway1, hallway2, 3);
+        MapEdge e5 = createEdge(hallway2, stair2, 2); // CROWDED 배율(3.0)로도 부족해서 더 크게 줌
+
+        given(mapGraphRepository.findNodesByFloor(floorId))
+                .willReturn(List.of(room1, door1, hallway1, hallway2, stair1, stair2));
+        given(mapGraphRepository.findEdgesByFloor(floorId))
+                .willReturn(List.of(e1, e2, e3, e4, e5));
+
+        // when
+        EvacuationRoute route = evacuationRouteService.findShortestRoute(
+                floorId, room1.getId(), java.util.Set.of(), java.util.Map.of(e5.getId(), 10.0));
+
+        // then: 2+5+3+(2*10)=30 > 대안(2+5+10=17)이라 우회 경로(stair1)를 선택
+        assertThat(route.totalWeight()).isEqualTo(2 + 5 + 10);
+        assertThat(route.path()).containsExactly(room1, door1, hallway1, stair1);
+    }
+
+    @Test
     @DisplayName("도달 가능한 EXIT이 없으면 예외를 던진다")
     void findShortestRoute_noReachableExit_throws() {
         // given


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #99 
- Branch: feat/#99

## 주요 내용

- 혼잡 런타임 위험 상태와 경로 재계산 통합 구현 중 미구현 상태였던 "경로 혼잡 비용" 가중치 표 적용
- EvacuationRouteService.findShortestRoute에 Map<UUID, Double> weightMultipliers를 받는 4-인자 오버로드 추가 — 엣지별로 거리에 배율만 곱해서 페널티를 주고 그래프에는 그대로 남김 (기존 excludedEdgeIds처럼 완전히 막지 않음). 기존 2/3-인자 오버로드는 그대로 유지
- RouteRecalculationService.trigger()가 레벨별로 분기하도록 변경
  - CROWDED: 트리거 엣지에 3배 가중치만 적용 (완전 제외 아님) — 대안이 훨씬 나쁘면 여전히 그 엣지를 통과하는 경로가 선택될 수 있음
  - VERY_CROWDED: 기존처럼 트리거 엣지 완전 제외
  - CAUTION(1.5배)도 매핑은 반영해뒀지만, 현재 CongestionLevel.requiresRouteRecalculation() 게이트상 CAUTION은 trigger()까지 도달하지 않아 실제로는 아직 도달 불가능한 분기
- fromNode 고정 문제 TODO 주석 복원 (#95에서 파일을 다시 쓰며 실수로 누락됐던 것) — 문제 자체는 이번에도 해결하지 않고 알려진 리스크로 남김

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?