### PR TITLE
[fix] #104: CCTV 혼잡 설정 조회 LazyInitializationException 수정

### DIFF
--- a/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
@@ -26,7 +26,9 @@ public interface CctvJpaRepository extends JpaRepository<Cctv, UUID> {
     @Query("select cctv from Cctv cctv where cctv.id = :cctvId")
     Optional<Cctv> findByIdWithLocation(@Param("cctvId") UUID cctvId);
 
+    // 인증 서비스의 트랜잭션이 끝난 뒤 혼잡 설정 조회에서 위치 정보를 사용하므로 함께 초기화한다.
     // 라즈베리파이가 보내온 code 로 기기 식별 (전역 unique)
+    @EntityGraph(attributePaths = {"customNode", "customNode.floor", "customNode.floor.building"})
     Optional<Cctv> findByCode(String code);
 
     Optional<Cctv> findByDeviceTokenHash(String deviceTokenHash);

--- a/src/test/java/com/saferoute/domain/device/repository/CctvJpaRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/device/repository/CctvJpaRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.saferoute.domain.device.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.config.JpaAuditingConfig;
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class CctvJpaRepositoryTest {
+
+    @Autowired
+    private CctvJpaRepository cctvJpaRepository;
+
+    @Autowired
+    private BuildingRepository buildingRepository;
+
+    @Autowired
+    private FloorRepository floorRepository;
+
+    @Autowired
+    private MapNodeJpaRepository mapNodeJpaRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("CCTV 코드 조회 시 혼잡 설정에 필요한 위치 연관관계를 함께 조회한다")
+    void findByCode_fetchesLocationGraph() {
+        Building building = buildingRepository.save(Building.create(
+                "테스트관",
+                "서울특별시 안전구 테스트로 123",
+                1,
+                BuildingType.CLASSROOM
+        ));
+        Floor floor = floorRepository.save(Floor.create(building, 1));
+        MapNode customNode = mapNodeJpaRepository.save(MapNode.createCustom(
+                floor,
+                "CCTV_001",
+                "복도 CCTV",
+                0.5,
+                0.5,
+                CustomDeviceType.CCTV
+        ));
+        cctvJpaRepository.save(Cctv.create("CCTV_001", "복도 CCTV", customNode));
+        entityManager.flush();
+        entityManager.clear();
+
+        Cctv found = cctvJpaRepository.findByCode("CCTV_001").orElseThrow();
+
+        assertThat(Hibernate.isInitialized(found.getCustomNode())).isTrue();
+        assertThat(Hibernate.isInitialized(found.getCustomNode().getFloor())).isTrue();
+        assertThat(Hibernate.isInitialized(found.getCustomNode().getFloor().getBuilding())).isTrue();
+
+        entityManager.clear();
+        assertThatCode(() -> found.getCustomNode().getFloor().getBuilding().getId())
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #104

## 변경 사항

### CCTV 위치 연관관계 초기화

디바이스 혼잡 설정 조회 과정에서 `Cctv` 엔티티의 지연 로딩 관계에 접근할 때 발생하던 `LazyInitializationException`을 수정했습니다.

기존에는 `CctvJpaRepository.findByCode()`가 CCTV만 조회해, 인증 서비스의 트랜잭션이 종료된 이후 다음 연관관계에 접근할 수 없었습니다.

```text
Cctv → customNode → floor → building
```

`@EntityGraph`를 적용해 혼잡 설정 조회에 필요한 연관관계를 함께 조회하도록 변경했습니다.

```java
@EntityGraph(attributePaths = {
        "customNode",
        "customNode.floor",
        "customNode.floor.building"
})
Optional<Cctv> findByCode(String code);
```

### 회귀 테스트 추가

다음 내용을 검증하는 JPA 테스트를 추가했습니다.

- CCTV 코드 조회 시 `customNode`가 초기화되는지 확인
- `floor`가 초기화되는지 확인
- `building`이 초기화되는지 확인
- 영속성 컨텍스트 종료 후에도 위치 연관관계에 접근할 수 있는지 확인

## 문제 원인

`DeviceAuthorizationService.validateCctv()`에서 조회한 `Cctv` 엔티티가 트랜잭션 종료 후 `CongestionConfigQueryService.getConfigFor()`로 전달됐습니다.

이후 아래 코드에서 초기화되지 않은 Lazy 연관관계에 접근하면서 예외가 발생했습니다.

```java
Floor floor = cctv.getCustomNode().getFloor();
var buildingId = floor.getBuilding().getId();
```

발생 예외:

```text
org.hibernate.LazyInitializationException:
Could not initialize proxy
[com.saferoute.domain.evacuation.graph.entity.MapNode] - no session
```

## 영향 범위

수정 전에는 AI 클라이언트가 다음 API를 호출할 때 HTTP 500이 발생했습니다.

```http
GET /api/v1/device/congestion-config?cctvCode=CCTV_001
```

이로 인해 다음 기능이 시작되지 않았습니다.

- AI 서버 설정 조회
- 영상 추론
- 미리보기 표시
- 혼잡 관측값 전송
- 혼잡 이벤트 전송
- 모니터링 이미지 업로드

## 테스트

관련 테스트와 전체 백엔드 테스트를 실행했습니다.

```bash
./gradlew test
```

결과:

```text
BUILD SUCCESSFUL
```

## 배포 후 확인 사항

- [ ] 유효한 `deviceToken`으로 혼잡 설정 조회 시 HTTP 200 반환
- [ ] 훈련 세션이 없을 때 `trainingActive=false` 반환
- [ ] `RUNNING` 훈련 세션이 있을 때 `trainingActive=true` 반환
- [ ] AI 실행 중 `LazyInitializationException`이 반복되지 않는지 확인
- [ ] 혼잡 관측값과 모니터링 이미지가 정상적으로 전송되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * CCTV 코드 조회 시 층과 건물 정보가 함께 로드되어, 조회 후에도 건물 식별자에 안정적으로 접근할 수 있습니다.

* **테스트**
  * 영속성 컨텍스트 초기화 후에도 CCTV와 연결된 건물 정보가 정상적으로 제공되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->