### PR TITLE
[feat] #106: cctv 이름 및 위치 수정 API 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/device/controller/CctvController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/CctvController.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.device.controller;
 
 import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.request.UpdateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
 import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
@@ -82,6 +83,17 @@ public class CctvController {
         return ResponseEntity.ok(ApiResponse.success(
                 CctvSuccessCode.CCTV_GRID_CELLS_CONFIGURED,
                 cctvService.configureGridCells(cctvId, request)
+        ));
+    }
+
+    @PatchMapping("/{cctvId}")
+    public ResponseEntity<ApiResponse<CctvResponse>> updateCctv(
+            @PathVariable UUID cctvId,
+            @Valid @RequestBody UpdateCctvRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                CctvSuccessCode.CCTV_UPDATED,
+                cctvService.updateCctv(cctvId, request)
         ));
     }
 

--- a/src/main/java/com/saferoute/domain/device/dto/request/UpdateCctvRequest.java
+++ b/src/main/java/com/saferoute/domain/device/dto/request/UpdateCctvRequest.java
@@ -1,0 +1,14 @@
+package com.saferoute.domain.device.dto.request;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateCctvRequest(
+        @NotBlank @Size(max = 100) String name,
+        @NotNull @DecimalMin("0.0") @DecimalMax("1.0") Double x,
+        @NotNull @DecimalMin("0.0") @DecimalMax("1.0") Double y
+) {
+}

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.device.service;
 
 import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.request.UpdateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
 import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
@@ -104,6 +105,14 @@ public class CctvService {
         saveMappings(cctv, gridCells);
         congestionConfigService.incrementVersionForGridChange();
         return CctvResponse.of(cctv, gridCells);
+    }
+
+    @Transactional
+    public CctvResponse updateCctv(UUID cctvId, UpdateCctvRequest request) {
+        Cctv cctv = findCctvOrThrow(cctvId);
+        cctv.rename(request.name());
+        cctv.getCustomNode().moveTo(request.x(), request.y());
+        return toResponse(cctv);
     }
 
     @Transactional

--- a/src/main/java/com/saferoute/global/api/response/CctvSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/CctvSuccessCode.java
@@ -15,7 +15,8 @@ public enum CctvSuccessCode implements BaseCode {
     CCTV_GRID_CELLS_CONFIGURED(HttpStatus.OK, "CCTV_SUCCESS_004", "CCTV 감시 영역이 설정되었습니다."),
     CCTV_GRID_CELLS_FOUND(HttpStatus.OK, "CCTV_SUCCESS_005", "CCTV 감시 영역 조회에 성공했습니다."),
     CCTV_ENABLED(HttpStatus.OK, "CCTV_SUCCESS_006", "CCTV가 활성화되었습니다."),
-    CCTV_DISABLED(HttpStatus.OK, "CCTV_SUCCESS_007", "CCTV가 비활성화되었습니다.");
+    CCTV_DISABLED(HttpStatus.OK, "CCTV_SUCCESS_007", "CCTV가 비활성화되었습니다."),
+    CCTV_UPDATED(HttpStatus.OK, "CCTV_SUCCESS_008", "CCTV 정보가 수정되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
@@ -126,22 +126,48 @@ class CctvControllerTest {
     @Test
     void updateCctv_returnsUpdatedNameAndPosition() throws Exception {
         UpdateCctvRequest request = new UpdateCctvRequest("1층 출입구 CCTV", 0.4, 0.6);
-        given(cctvService.updateCctv(eq(cctvId), any())).willReturn(response(true));
+        given(cctvService.updateCctv(eq(cctvId), any()))
+                .willReturn(response(true, request.name(), request.x(), request.y()));
 
         mockMvc.perform(patch("/api/v1/cctvs/{cctvId}", cctvId)
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("CCTV_SUCCESS_008"))
-                .andExpect(jsonPath("$.result.name").value("3층 복도 CCTV"))
-                .andExpect(jsonPath("$.result.x").value(0.6))
-                .andExpect(jsonPath("$.result.y").value(0.4));
+                .andExpect(jsonPath("$.result.name").value(request.name()))
+                .andExpect(jsonPath("$.result.x").value(request.x()))
+                .andExpect(jsonPath("$.result.y").value(request.y()));
     }
 
     @Test
-    void updateCctv_rejectsBlankNameAndOutOfRangeCoordinates() throws Exception {
-        UpdateCctvRequest request = new UpdateCctvRequest(" ", -0.1, 1.1);
+    void updateCctv_rejectsBlankName() throws Exception {
+        UpdateCctvRequest request = new UpdateCctvRequest(" ", 0.4, 0.6);
 
+        performInvalidUpdate(request);
+    }
+
+    @Test
+    void updateCctv_rejectsNameLongerThan100Characters() throws Exception {
+        UpdateCctvRequest request = new UpdateCctvRequest("a".repeat(101), 0.4, 0.6);
+
+        performInvalidUpdate(request);
+    }
+
+    @Test
+    void updateCctv_rejectsXBelowMinimum() throws Exception {
+        UpdateCctvRequest request = new UpdateCctvRequest("1층 출입구 CCTV", -0.1, 0.6);
+
+        performInvalidUpdate(request);
+    }
+
+    @Test
+    void updateCctv_rejectsYAboveMaximum() throws Exception {
+        UpdateCctvRequest request = new UpdateCctvRequest("1층 출입구 CCTV", 0.4, 1.1);
+
+        performInvalidUpdate(request);
+    }
+
+    private void performInvalidUpdate(UpdateCctvRequest request) throws Exception {
         mockMvc.perform(patch("/api/v1/cctvs/{cctvId}", cctvId)
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(request)))
@@ -158,14 +184,18 @@ class CctvControllerTest {
     }
 
     private CctvResponse response(boolean enabled) {
+        return response(enabled, "3층 복도 CCTV", 0.6, 0.4);
+    }
+
+    private CctvResponse response(boolean enabled, String name, double x, double y) {
         return new CctvResponse(
                 cctvId,
                 "CCTV_001",
-                "3층 복도 CCTV",
+                name,
                 floorId,
                 UUID.randomUUID(),
-                0.6,
-                0.4,
+                x,
+                y,
                 enabled,
                 0.5,
                 1,

--- a/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.request.UpdateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvGridCellResponse;
 import com.saferoute.domain.device.dto.response.CctvResponse;
 import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
@@ -120,6 +121,31 @@ class CctvControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.monitoredGridCellCount").value(1));
+    }
+
+    @Test
+    void updateCctv_returnsUpdatedNameAndPosition() throws Exception {
+        UpdateCctvRequest request = new UpdateCctvRequest("1층 출입구 CCTV", 0.4, 0.6);
+        given(cctvService.updateCctv(eq(cctvId), any())).willReturn(response(true));
+
+        mockMvc.perform(patch("/api/v1/cctvs/{cctvId}", cctvId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("CCTV_SUCCESS_008"))
+                .andExpect(jsonPath("$.result.name").value("3층 복도 CCTV"))
+                .andExpect(jsonPath("$.result.x").value(0.6))
+                .andExpect(jsonPath("$.result.y").value(0.4));
+    }
+
+    @Test
+    void updateCctv_rejectsBlankNameAndOutOfRangeCoordinates() throws Exception {
+        UpdateCctvRequest request = new UpdateCctvRequest(" ", -0.1, 1.1);
+
+        mockMvc.perform(patch("/api/v1/cctvs/{cctvId}", cctvId)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.device.dto.request.ConfigureCctvGridCellsRequest;
 import com.saferoute.domain.device.dto.request.CreateCctvRequest;
+import com.saferoute.domain.device.dto.request.UpdateCctvRequest;
 import com.saferoute.domain.device.dto.response.CctvResponse;
 import com.saferoute.domain.device.dto.response.CctvRegistrationResponse;
 import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
@@ -163,6 +164,23 @@ class CctvServiceTest {
         verify(cctvGridCellRepository).deleteAllByCctvId(cctvId);
         verify(cctvGridCellRepository).saveAll(any());
         verify(congestionConfigService).incrementVersionForGridChange();
+    }
+
+    @Test
+    @DisplayName("CCTV 정보 수정 시 이름과 연결 노드 위치를 함께 변경한다")
+    void updateCctv_success() {
+        UUID cctvId = UUID.randomUUID();
+        Cctv cctv = cctv(cctvId);
+        MapNode node = cctv.getCustomNode();
+        given(cctvJpaRepository.findByIdWithLocation(cctvId)).willReturn(Optional.of(cctv));
+
+        cctvService.updateCctv(
+                cctvId,
+                new UpdateCctvRequest("1층 출입구 CCTV", 0.4, 0.6)
+        );
+
+        verify(cctv).rename("1층 출입구 CCTV");
+        verify(node).moveTo(0.4, 0.6);
     }
 
     private CreateCctvRequest request() {


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #106 
- Branch: feat/#106

CCTV 이름과 위치를 한 번에 수정할 수 있는 전용 API를 추가했습니다.

```http
PATCH /api/v1/cctvs/{cctvId}
Content-Type: application/json

{
  "name": "1층 출입구 CCTV",
  "x": 0.4,
  "y": 0.6
}
```

### 주요 변경 사항

- CCTV 이름 및 위치 수정 API 추가
- CCTV 이름과 연결된 커스텀 노드 좌표를 하나의 트랜잭션으로 수정
- 수정된 `CctvResponse` 반환
- CCTV 수정 성공 코드 `CCTV_SUCCESS_008` 추가
- 요청값 유효성 검증 추가
  - 이름: 공백 불가, 최대 100자
  - 좌표: `0.0` 이상 `1.0` 이하
- Controller 및 Service 테스트 추가

## 참고 사항

- CCTV 이름은 `Cctv` 엔티티에 반영됩니다.
- 위치는 CCTV와 연결된 `MapNode`의 `x`, `y` 좌표에 반영됩니다.
- 이름과 위치는 단일 트랜잭션에서 함께 변경됩니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * CCTV 이름과 위치 정보를 수정할 수 있는 API를 추가했습니다.
  * 이름과 좌표 입력값을 자동으로 검증합니다.

* **테스트**
  * CCTV 수정 성공 및 잘못된 이름·좌표 입력에 대한 검증을 추가했습니다.
  * 수정된 이름과 위치가 정상 반영되는지 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->