### PR TITLE
Feat/#111 isExitTarget(최종 탈출구) 수정 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/UpdateMapNodePositionRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/UpdateMapNodePositionRequest.java
@@ -2,8 +2,9 @@ package com.saferoute.domain.evacuation.graph.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
-// 커스텀 편집 UI에서 드래그로 노드 위치 옮길 때 사용
+// 커스텀 편집 UI에서 드래그로 노드 위치 옮기거나 EXIT 대상 여부를 변경할 때 사용
 public record UpdateMapNodePositionRequest(
         @NotNull Double x,
-        @NotNull Double y
+        @NotNull Double y,
+        boolean isExitTarget
 ) {}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapNode.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapNode.java
@@ -111,4 +111,9 @@ public class MapNode {
         this.x = x;
         this.y = y;
     }
+
+    // 노드 수정 API에서 EXIT 대상(경로 목적지 후보) 여부를 변경할 때
+    public void changeExitTarget(boolean isExitTarget) {
+        this.isExitTarget = isExitTarget;
+    }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
@@ -32,8 +32,8 @@ public interface MapGraphRepository {
     // 엣지 단건 조회 (삭제 시 참조용)
     Optional<MapEdge> findEdgeById(UUID edgeId);
 
-    // 노드 위치 수정 (드래그 편집)
-    MapNode updateNodePosition(MapNode node, double x, double y);
+    // 노드 위치 및 EXIT 대상 여부 수정 (드래그 편집)
+    MapNode updateNodePosition(MapNode node, double x, double y, boolean isExitTarget);
 
     // 노드 삭제 - 연결된 엣지도 함께 삭제(cascade)
     void deleteNode(MapNode node);

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
@@ -82,8 +82,9 @@ public class MapGraphRepositoryImpl implements MapGraphRepository {
     }
 
     @Override
-    public MapNode updateNodePosition(MapNode node, double x, double y) {
+    public MapNode updateNodePosition(MapNode node, double x, double y, boolean isExitTarget) {
         node.moveTo(x, y);
+        node.changeExitTarget(isExitTarget);
         return node; // 영속 상태 엔티티라 dirty checking으로 트랜잭션 커밋 시 반영됨
     }
 

--- a/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
@@ -46,11 +46,12 @@ public class MapGraphService {
         return MapNodeResponse.from(node);
     }
 
-    // 노드 위치 수정 (드래그 편집)
+    // 노드 위치 및 EXIT 대상 여부 수정 (드래그 편집)
     @Transactional
     public MapNodeResponse updateNodePosition(UUID nodeId, UpdateMapNodePositionRequest request) {
         MapNode node = findNodeOrThrow(nodeId);
-        MapNode updated = mapGraphRepository.updateNodePosition(node, request.x(), request.y());
+        MapNode updated = mapGraphRepository.updateNodePosition(
+                node, request.x(), request.y(), request.isExitTarget());
         return MapNodeResponse.from(updated);
     }
 

--- a/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
@@ -50,6 +50,12 @@ public class MapGraphService {
     @Transactional
     public MapNodeResponse updateNodePosition(UUID nodeId, UpdateMapNodePositionRequest request) {
         MapNode node = findNodeOrThrow(nodeId);
+        if (!request.isExitTarget()) {
+            // 동일 층에 대한 동시 수정 요청을 직렬화해 마지막 EXIT 카운트 검증과 해제 사이의 경쟁을 방지
+            floorRepository.findByIdForUpdate(node.getFloor().getId())
+                    .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+            validateNotLastExitNode(node, EvacuationErrorCode.EXIT_NODE_UNSET_NOT_ALLOWED);
+        }
         MapNode updated = mapGraphRepository.updateNodePosition(
                 node, request.x(), request.y(), request.isExitTarget());
         return MapNodeResponse.from(updated);
@@ -62,19 +68,19 @@ public class MapGraphService {
         // 동일 층에 대한 동시 삭제 요청을 직렬화해 마지막 EXIT 카운트 검증과 삭제 사이의 경쟁을 방지
         floorRepository.findByIdForUpdate(node.getFloor().getId())
                 .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
-        validateNotLastExitNode(node);
+        validateNotLastExitNode(node, EvacuationErrorCode.EXIT_NODE_DELETE_NOT_ALLOWED);
         mapGraphRepository.deleteNode(node);
     }
 
-    // 대상 노드가 EXIT 대상(isExitTarget)이고, 해당 층에 남은 EXIT 대상 노드가 1개뿐이면 삭제 금지
-    // (출구가 여러 개인 층에서 하나를 지우는 정상 편집은 허용, 마지막 하나만 보호)
-    private void validateNotLastExitNode(MapNode node) {
+    // 대상 노드가 EXIT 대상(isExitTarget)이고, 해당 층에 남은 EXIT 대상 노드가 1개뿐이면 거부
+    // (출구가 여러 개인 층에서 하나를 지우거나 해제하는 정상 편집은 허용, 마지막 하나만 보호)
+    private void validateNotLastExitNode(MapNode node, EvacuationErrorCode errorCode) {
         if (!node.isExitTarget()) {
             return;
         }
         long exitCount = mapGraphRepository.countExitTargetNodesByFloor(node.getFloor().getId());
         if (exitCount <= 1) {
-            throw new ApiException(EvacuationErrorCode.EXIT_NODE_DELETE_NOT_ALLOWED);
+            throw new ApiException(errorCode);
         }
     }
 

--- a/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
@@ -17,7 +17,8 @@ public enum EvacuationErrorCode implements BaseErrorCode {
     EXIT_NODE_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVAC006", "마지막 출구 노드는 삭제할 수 없습니다."),
     EXIT_NODE_NOT_DESIGNATED(HttpStatus.NOT_FOUND, "EVAC007", "지정된 출구 노드가 없습니다."),
     ROUTE_RECALCULATION_NOT_FOUND(HttpStatus.NOT_FOUND, "EVAC008", "재탐색 요청을 찾을 수 없습니다."),
-    INVALID_RECALCULATION_STATUS_TRANSITION(HttpStatus.CONFLICT, "EVAC009", "이미 처리된 재탐색 요청입니다.");
+    INVALID_RECALCULATION_STATUS_TRANSITION(HttpStatus.CONFLICT, "EVAC009", "이미 처리된 재탐색 요청입니다."),
+    EXIT_NODE_UNSET_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVAC010", "마지막 출구 노드는 EXIT 대상에서 해제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/evacuation/controller/MapGraphEditControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/controller/MapGraphEditControllerTest.java
@@ -190,7 +190,8 @@ class MapGraphEditControllerTest {
         UpdateMapNodePositionRequest request =
                 new UpdateMapNodePositionRequest(
                         10.0,
-                        20.0
+                        20.0,
+                        true
                 );
 
         MapNodeResponse response = new MapNodeResponse(
@@ -200,7 +201,7 @@ class MapGraphEditControllerTest {
                 "방1",
                 10.0,
                 20.0,
-                false
+                true
         );
 
         given(
@@ -222,7 +223,8 @@ class MapGraphEditControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.x").value(10.0))
-                .andExpect(jsonPath("$.result.y").value(20.0));
+                .andExpect(jsonPath("$.result.y").value(20.0))
+                .andExpect(jsonPath("$.result.isExitTarget").value(true));
     }
 
     @Test
@@ -231,7 +233,8 @@ class MapGraphEditControllerTest {
         UpdateMapNodePositionRequest request =
                 new UpdateMapNodePositionRequest(
                         10.0,
-                        20.0
+                        20.0,
+                        true
                 );
 
         given(

--- a/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
@@ -150,18 +150,19 @@ class MapGraphRepositoryImplTest {
     }
 
     @Test
-    @DisplayName("노드 위치를 수정하면 dirty checking으로 반영된다 (save 호출 없음)")
+    @DisplayName("노드 위치와 EXIT 대상 여부를 수정하면 dirty checking으로 반영된다 (save 호출 없음)")
     void updateNodePosition_success() {
         // given
         Floor floor = mock(Floor.class);
         MapNode node = MapNode.create(floor, "ROOM1", NodeType.ROOM, "방1", 0, 0, false);
 
         // when
-        MapNode result = mapGraphRepository.updateNodePosition(node, 10, 20);
+        MapNode result = mapGraphRepository.updateNodePosition(node, 10, 20, true);
 
         // then
         assertThat(result.getX()).isEqualTo(10);
         assertThat(result.getY()).isEqualTo(20);
+        assertThat(result.isExitTarget()).isTrue();
         verify(mapNodeJpaRepository, never()).save(any(MapNode.class));
     }
 

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
@@ -2,6 +2,9 @@ package com.saferoute.domain.evacuation.graph.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -164,6 +167,41 @@ class MapGraphServiceTest {
         assertThatThrownBy(() -> mapGraphService.updateNodePosition(unknownNodeId, request))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(EvacuationErrorCode.MAP_NODE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("층에 남은 EXIT 대상 노드가 하나뿐이면 isExitTarget을 해제할 수 없다")
+    void updateNodePosition_lastExitNodeUnset_throws() {
+        // given
+        MapNode node = createNode("EXIT1", NodeType.EXIT, true);
+        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0, false);
+        given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
+        given(floorRepository.findByIdForUpdate(floorId)).willReturn(Optional.of(floor));
+        given(mapGraphRepository.countExitTargetNodesByFloor(floorId)).willReturn(1L);
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphService.updateNodePosition(node.getId(), request))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.EXIT_NODE_UNSET_NOT_ALLOWED.getMessage());
+        verify(mapGraphRepository, never()).updateNodePosition(any(), anyDouble(), anyDouble(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("층에 EXIT 대상 노드가 여러 개면 그중 하나는 isExitTarget을 해제할 수 있다")
+    void updateNodePosition_notLastExitNodeUnset_success() {
+        // given
+        MapNode node = createNode("EXIT1", NodeType.EXIT, true);
+        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0, false);
+        given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
+        given(floorRepository.findByIdForUpdate(floorId)).willReturn(Optional.of(floor));
+        given(mapGraphRepository.countExitTargetNodesByFloor(floorId)).willReturn(2L);
+        given(mapGraphRepository.updateNodePosition(node, 10.0, 20.0, false)).willReturn(node);
+
+        // when
+        mapGraphService.updateNodePosition(node.getId(), request);
+
+        // then
+        verify(mapGraphRepository).updateNodePosition(node, 10.0, 20.0, false);
     }
 
     // === deleteNode ===

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
@@ -140,16 +140,16 @@ class MapGraphServiceTest {
     void updateNodePosition_success() {
         // given
         MapNode node = createNode("ROOM1", NodeType.ROOM);
-        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0);
+        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0, true);
         given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
-        given(mapGraphRepository.updateNodePosition(node, 10.0, 20.0)).willReturn(node);
+        given(mapGraphRepository.updateNodePosition(node, 10.0, 20.0, true)).willReturn(node);
 
         // when
         MapNodeResponse response = mapGraphService.updateNodePosition(node.getId(), request);
 
         // then
         assertThat(response.id()).isEqualTo(node.getId());
-        verify(mapGraphRepository).updateNodePosition(node, 10.0, 20.0);
+        verify(mapGraphRepository).updateNodePosition(node, 10.0, 20.0, true);
     }
 
     @Test
@@ -157,7 +157,7 @@ class MapGraphServiceTest {
     void updateNodePosition_nodeNotFound_throws() {
         // given
         UUID unknownNodeId = UUID.randomUUID();
-        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0);
+        UpdateMapNodePositionRequest request = new UpdateMapNodePositionRequest(10.0, 20.0, true);
         given(mapGraphRepository.findNodeById(unknownNodeId)).willReturn(Optional.empty());
 
         // when & then


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #111
- Branch: feat/#111

## 주요 내용

- 노드 수정 API(`PATCH /api/v1/nodes/{nodeId}`)에서 좌표(x, y)뿐 아니라 `isExitTarget`도 함께 수정할 수 있도록 개선
- 층에 EXIT 대상 노드가 1개만 남은 경우, 그 노드의 `isExitTarget`을 해제하지 못하도록 검증 추가 (기존 삭제 시 마지막 출구 보호 로직을 재사용)
- 동시 수정 요청 간 경쟁을 막기 위해 삭제 로직과 동일하게 층 로우를 잠근 뒤 EXIT 카운트를 검증하도록 처리

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?