### PR TITLE
Feat/#113 유도등 삭제 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -102,5 +103,11 @@ public class IoTLightController {
     public ResponseEntity<ApiResponse<IoTLightResponse>> disableLight(@PathVariable UUID lightId) {
         IoTLightResponse response = iotLightService.disableLight(lightId);
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_DISABLED, response));
+    }
+
+    @DeleteMapping("/{lightId}")
+    public ResponseEntity<ApiResponse<Void>> deleteLight(@PathVariable UUID lightId) {
+        iotLightService.deleteLight(lightId);
+        return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_DELETED, null));
     }
 }

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -135,6 +135,16 @@ public class IoTLightService {
         return IoTLightResponse.from(light);
     }
 
+    // 유도등의 도면 위치 노드(customNode)를 지우면 iot_lights FK의 ON DELETE CASCADE로 유도등 자체도 함께 삭제된다.
+    // 노드 삭제 전 연결된 엣지(from/to 어느 쪽이든)를 먼저 지우는 것은 MapGraphRepositoryImpl.deleteNode와 동일한 처리다.
+    @Transactional
+    public void deleteLight(UUID lightId) {
+        IoTLight light = findLightOrThrow(lightId);
+        MapNode customNode = light.getCustomNode();
+        mapEdgeJpaRepository.deleteByFromNode_IdOrToNode_Id(customNode.getId(), customNode.getId());
+        mapNodeJpaRepository.delete(customNode);
+    }
+
     // 검증(enabled/guidance) -> Pi 호출 -> 상태 저장 -> 이벤트 발행 순서로 조립한다.
     // direction은 훈련별 동적 상태라 DB에 저장하지 않고 IoTLightDirectionStore(서버 메모리)에 저장한다 (IoTLight 참고).
     public LightDirectionResponse changeDirection(UUID lightId, ChangeLightDirectionRequest request) {

--- a/src/main/java/com/saferoute/global/api/response/IoTLightSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/IoTLightSuccessCode.java
@@ -17,7 +17,8 @@ public enum IoTLightSuccessCode implements BaseCode {
     IOT_LIGHT_ENABLED(HttpStatus.OK, "IOTLIGHT_SUCCESS_006", "유도등이 활성화되었습니다."),
     IOT_LIGHT_DISABLED(HttpStatus.OK, "IOTLIGHT_SUCCESS_007", "유도등이 비활성화되었습니다."),
     IOT_LIGHT_PI_ENDPOINT_UPDATED(HttpStatus.OK, "IOTLIGHT_SUCCESS_008", "라즈베리파이 주소가 설정되었습니다."),
-    IOT_LIGHT_DIRECTION_CHANGED(HttpStatus.OK, "IOTLIGHT_SUCCESS_009", "유도등 방향이 변경되었습니다.");
+    IOT_LIGHT_DIRECTION_CHANGED(HttpStatus.OK, "IOTLIGHT_SUCCESS_009", "유도등 방향이 변경되었습니다."),
+    IOT_LIGHT_DELETED(HttpStatus.OK, "IOTLIGHT_SUCCESS_010", "유도등이 삭제되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/device/controller/IoTLightControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/IoTLightControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -285,5 +286,25 @@ class IoTLightControllerTest {
                         .contentType("application/json")
                         .content("{}"))
                 .andExpect(status().isBadRequest());
+    }
+
+    // === deleteLight ===
+
+    @Test
+    @DisplayName("DELETE /lights/{lightId} - 유도등을 삭제하면 200을 반환한다")
+    void deleteLight_success() throws Exception {
+        mockMvc.perform(delete("/api/v1/lights/{lightId}", lightId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+    }
+
+    @Test
+    @DisplayName("DELETE /lights/{lightId} - 유도등이 없으면 404를 반환한다")
+    void deleteLight_notFound() throws Exception {
+        org.mockito.BDDMockito.willThrow(new ApiException(IoTLightErrorCode.IOT_LIGHT_NOT_FOUND))
+                .given(iotLightService).deleteLight(lightId);
+
+        mockMvc.perform(delete("/api/v1/lights/{lightId}", lightId))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
@@ -314,6 +314,38 @@ class IoTLightServiceTest {
         assertThat(response.enabled()).isFalse();
     }
 
+    // === deleteLight ===
+
+    @Test
+    @DisplayName("유도등을 삭제하면 연결된 엣지와 도면 위치 노드가 함께 삭제된다")
+    void deleteLight_success() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        given(iotLightJpaRepository.findById(light.getId())).willReturn(Optional.of(light));
+
+        // when
+        iotLightService.deleteLight(light.getId());
+
+        // then
+        verify(mapEdgeJpaRepository).deleteByFromNode_IdOrToNode_Id(customNode.getId(), customNode.getId());
+        verify(mapNodeJpaRepository).delete(customNode);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유도등을 삭제하려 하면 예외가 발생한다")
+    void deleteLight_notFound_throws() {
+        // given
+        UUID unknownId = UUID.randomUUID();
+        given(iotLightJpaRepository.findById(unknownId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> iotLightService.deleteLight(unknownId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.IOT_LIGHT_NOT_FOUND.getMessage());
+        verifyNoInteractions(mapEdgeJpaRepository, mapNodeJpaRepository);
+    }
+
     // === changeDirection ===
 
     @Test


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #113 
- Branch: Feat/#113

## 주요 내용

- `DELETE /api/v1/lights/{lightId}` API 추가 (기존에는 유도등 비활성화(`/disable`)만 있고 전용 삭제 API가 없었음)
- 유도등의 도면 위치 노드(customNode)에 연결된 엣지를 먼저 삭제한 뒤 노드를 삭제 — `iot_lights` FK의 `ON DELETE CASCADE`로 유도등 자체도 함께 삭제됨
- `IoTLightSuccessCode.IOT_LIGHT_DELETED` 추가
- 컨트롤러/서비스 성공·미존재(404) 케이스 테스트 추가

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?