### PR TITLE
[FEAT] #116: 도면 이미지 조회용 Presigned GET URL 발급 API 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
+++ b/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.floor.controller;
 import com.saferoute.domain.floor.dto.request.CreateFloorRequest;
 import com.saferoute.domain.floor.dto.request.UpdateFloorRequest;
 import com.saferoute.domain.floor.dto.request.UploadFloorRequest;
+import com.saferoute.domain.floor.dto.response.FloorImageUrlResponse;
 import com.saferoute.domain.floor.dto.response.FloorResponse;
 import com.saferoute.domain.floor.service.FloorService;
 import com.saferoute.global.api.response.ApiResponse;
@@ -70,6 +71,17 @@ public class FloorController {
     ) {
         return ResponseEntity.ok(ApiResponse.success(FloorSuccessCode.FLOOR_DETAIL_FOUND,
                 floorService.getFloor(buildingId, floorId, authentication.getName())));
+    }
+
+    // 도면 이미지 조회용 Presigned GET URL 발급
+    @GetMapping("/{floorId}/image-url")
+    public ResponseEntity<ApiResponse<FloorImageUrlResponse>> getFloorImageUrl(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID floorId,
+            Authentication authentication
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(FloorSuccessCode.FLOOR_IMAGE_URL_ISSUED,
+                floorService.getFloorImageUrl(buildingId, floorId, authentication.getName())));
     }
 
     // 층 정보 수정

--- a/src/main/java/com/saferoute/domain/floor/dto/response/FloorImageUrlResponse.java
+++ b/src/main/java/com/saferoute/domain/floor/dto/response/FloorImageUrlResponse.java
@@ -1,0 +1,16 @@
+package com.saferoute.domain.floor.dto.response;
+
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import java.time.Instant;
+
+// 프론트가 mapImageKey 대신 이 URL로 도면 이미지를 직접 렌더링한다. URL은 만료되므로
+// 화면에 값을 오래 들고 있지 말고, 만료 시점에 다시 요청해서 새 URL을 받아야 한다.
+public record FloorImageUrlResponse(
+        String imageUrl,
+        Instant expiresAt
+) {
+
+    public static FloorImageUrlResponse from(PresignedGetUrl presignedGetUrl) {
+        return new FloorImageUrlResponse(presignedGetUrl.viewUrl(), presignedGetUrl.expiresAt());
+    }
+}

--- a/src/main/java/com/saferoute/domain/floor/service/FloorService.java
+++ b/src/main/java/com/saferoute/domain/floor/service/FloorService.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.floor.dto.request.CreateFloorRequest;
 import com.saferoute.domain.floor.dto.request.UpdateFloorRequest;
 import com.saferoute.domain.floor.dto.request.UploadFloorRequest;
+import com.saferoute.domain.floor.dto.response.FloorImageUrlResponse;
 import com.saferoute.domain.floor.dto.response.FloorResponse;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.entity.SegmentationStatus;
@@ -18,6 +19,7 @@ import com.saferoute.global.api.error.BuildingErrorCode;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.S3UploadResponse;
+import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
 import com.saferoute.infrastructure.s3.service.S3Service;
 import com.saferoute.domain.user.service.SchoolContextService;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,7 @@ public class FloorService {
     private final BuildingRepository buildingRepository;
     private final FloorAnalysisService floorAnalysisService;
     private final S3Service s3Service;
+    private final S3PresignedUrlService s3PresignedUrlService;
     private final SchoolContextService schoolContextService;
 
     public List<FloorResponse> getFloors(UUID buildingId, String email) {
@@ -113,6 +116,17 @@ public class FloorService {
     @Transactional(readOnly = true)
     public FloorResponse getFloor(UUID buildingId, UUID floorId, String email) {
         return FloorResponse.from(findFloor(buildingId, floorId, email));
+    }
+
+    @Transactional(readOnly = true)
+    public FloorImageUrlResponse getFloorImageUrl(UUID buildingId, UUID floorId, String email) {
+        Floor floor = findFloor(buildingId, floorId, email);
+
+        if (floor.getMapImageKey() == null) {
+            throw new ApiException(FloorErrorCode.MAP_IMAGE_NOT_FOUND);
+        }
+
+        return FloorImageUrlResponse.from(s3PresignedUrlService.createGetUrl(floor.getMapImageKey()));
     }
 
     @Transactional

--- a/src/main/java/com/saferoute/global/api/error/FloorErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/FloorErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum FloorErrorCode implements BaseErrorCode {
 
     FLOOR_NOT_FOUND(HttpStatus.NOT_FOUND, "FLOOR001", "도면을 찾을 수 없습니다."),
-    DUPLICATE_FLOOR_NUM(HttpStatus.CONFLICT, "FLOOR002", "이미 등록된 층 번호입니다.");
+    DUPLICATE_FLOOR_NUM(HttpStatus.CONFLICT, "FLOOR002", "이미 등록된 층 번호입니다."),
+    MAP_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "FLOOR003", "등록된 도면 이미지가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/api/response/FloorSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/FloorSuccessCode.java
@@ -13,7 +13,8 @@ public enum FloorSuccessCode implements BaseCode {
     FLOOR_LIST_FOUND(HttpStatus.OK, "FLOOR_SUCCESS_002", "도면 목록 조회에 성공했습니다."),
     FLOOR_DETAIL_FOUND(HttpStatus.OK, "FLOOR_SUCCESS_003", "도면 상세 조회에 성공했습니다."),
     FLOOR_DELETED(HttpStatus.OK, "FLOOR_SUCCESS_004", "도면이 삭제되었습니다."),
-    FLOOR_UPDATED(HttpStatus.OK, "FLOOR_SUCCESS_005", "도면 정보 수정에 성공했습니다.");
+    FLOOR_UPDATED(HttpStatus.OK, "FLOOR_SUCCESS_005", "도면 정보 수정에 성공했습니다."),
+    FLOOR_IMAGE_URL_ISSUED(HttpStatus.OK, "FLOOR_SUCCESS_006", "도면 이미지 URL 발급에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,8 +40,8 @@ aws:
   s3:
     bucket: ${S3_BUCKET}
     presigned-url-expiration: 1m
-    # 관리자 화면이 이미지를 불러오는 동안 만료되지 않도록 업로드용(1분)보다 넉넉하게 잡는다.
-    presigned-get-url-expiration: 5m
+    # 훈련이 진행되는 동안 도면/관측 이미지를 계속 띄워놔야 하므로 업로드용(1분)보다 넉넉하게 1시간으로 잡는다.
+    presigned-get-url-expiration: 1h
 
   dynamodb:
     table-name: ${DYNAMODB_TABLE:saferoute-telemetry}

--- a/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
+++ b/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
@@ -1,16 +1,24 @@
 package com.saferoute.domain.floor.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import com.saferoute.domain.analysis.service.FloorAnalysisService;
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.floor.dto.response.FloorImageUrlResponse;
+import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
 import com.saferoute.global.api.error.BuildingErrorCode;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
 import com.saferoute.infrastructure.s3.service.S3Service;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -41,6 +49,9 @@ class FloorServiceTest {
     private S3Service s3Service;
 
     @Mock
+    private S3PresignedUrlService s3PresignedUrlService;
+
+    @Mock
     private SchoolContextService schoolContextService;
 
     @Test
@@ -67,5 +78,63 @@ class FloorServiceTest {
                 .isInstanceOf(ApiException.class)
                 .extracting(exception -> ((ApiException) exception).getErrorCode())
                 .isEqualTo(FloorErrorCode.FLOOR_NOT_FOUND);
+    }
+
+    @Test
+    void issuesFloorImageUrlWhenMapImageExists() {
+        UUID buildingId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        Floor floor = mock(Floor.class);
+        Instant expiresAt = Instant.now().plusSeconds(3600);
+
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(buildingRepository.findByIdAndSchoolName(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(building));
+        given(floorRepository.findByIdAndBuilding_Id(floorId, building.getId()))
+                .willReturn(Optional.of(floor));
+        given(floor.getMapImageKey()).willReturn("floors/map.png");
+        given(s3PresignedUrlService.createGetUrl("floors/map.png"))
+                .willReturn(new PresignedGetUrl("https://example.com/floors/map.png", expiresAt));
+
+        FloorImageUrlResponse response = floorService.getFloorImageUrl(buildingId, floorId, EMAIL);
+
+        assertThat(response.imageUrl()).isEqualTo("https://example.com/floors/map.png");
+        assertThat(response.expiresAt()).isEqualTo(expiresAt);
+    }
+
+    @Test
+    void rejectsFloorImageUrlWhenMapImageMissing() {
+        UUID buildingId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        Floor floor = mock(Floor.class);
+
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(buildingRepository.findByIdAndSchoolName(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(building));
+        given(floorRepository.findByIdAndBuilding_Id(floorId, building.getId()))
+                .willReturn(Optional.of(floor));
+        given(floor.getMapImageKey()).willReturn(null);
+
+        assertThatThrownBy(() -> floorService.getFloorImageUrl(buildingId, floorId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(FloorErrorCode.MAP_IMAGE_NOT_FOUND);
+    }
+
+    @Test
+    void hidesFloorImageUrlTargetFromAnotherSchool() {
+        UUID buildingId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(buildingRepository.findByIdAndSchoolName(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> floorService.getFloorImageUrl(buildingId, floorId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(BuildingErrorCode.BUILDING_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #116
- Branch: feat/#116

## 주요 내용

- 도면 이미지 조회용 Presigned GET URL 발급 API 추가 (`GET /api/v1/buildings/{buildingId}/floors/{floorId}/image-url`)
- 기존 `Congestion` 도메인의 presigned URL 발급 패턴(`S3PresignedUrlService`, `PresignedGetUrl`)을 그대로 재사용
- 도면 조회 시 기존 기관 스코프 검증(`FloorService.findFloor`)을 그대로 통과시켜 타 기관 도면 접근 차단
- `mapImageKey`가 없는 도면(미업로드 상태) 조회 시 `FloorErrorCode.MAP_IMAGE_NOT_FOUND` 반환
- Presigned GET URL 만료 시간을 5분 → 1시간으로 연장 (`Congestion`과 공유 설정값, 훈련 진행 중 계속 열람해야 하는 용도라 5분은 부족)
- 프론트는 응답의 `imageUrl`을 그대로 사용하고, 만료 시 재요청해서 새 URL을 받는 방식

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 층 도면 이미지를 직접 표시할 수 있는 임시 이미지 URL 발급 기능을 추가했습니다.
  * 발급된 URL의 만료 시각을 함께 제공합니다.
  * 이미지가 등록되지 않은 층이나 접근 권한이 없는 건물은 안내된 오류로 처리됩니다.

* **개선**
  * 도면 이미지 URL의 유효 시간이 1시간으로 연장되었습니다.

* **테스트**
  * 정상 발급, 이미지 미등록, 접근 권한 확인 시나리오를 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->