### PR TITLE
[FEAT] #118: 시나리오-세션 1:1 제약 추가 + 목록 API에 리포트 여부 반영

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
       DB_URL: ${DB_URL:?DB_URL is required}
       DB_USERNAME: ${DB_USERNAME:?DB_USERNAME is required}
       DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
-      JPA_DDL_AUTO: ${JPA_DDL_AUTO:-update}
+      JPA_DDL_AUTO: ${JPA_DDL_AUTO:-create}
 
       AWS_REGION: ${AWS_REGION:-us-east-2}
       AWS_DEFAULT_REGION: ${AWS_REGION:-us-east-2}

--- a/src/main/java/com/saferoute/domain/report/repository/TrainingReportRepository.java
+++ b/src/main/java/com/saferoute/domain/report/repository/TrainingReportRepository.java
@@ -1,13 +1,29 @@
 package com.saferoute.domain.report.repository;
 
 import com.saferoute.domain.report.entity.TrainingReport;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TrainingReportRepository extends JpaRepository<TrainingReport, UUID> {
+
+  // 목록 조회에서 시나리오별 리포트 존재 여부/id를 N+1 없이 계산하기 위해,
+  // 시나리오당 세션이 1개뿐이라는 전제로 시나리오 id -> 리포트 id를 바로 매핑한다.
+  @Query("""
+      select tr.trainingSession.scenario.id as scenarioId, tr.id as reportId
+      from TrainingReport tr
+      where tr.trainingSession.scenario.id in :scenarioIds
+      """)
+  List<ScenarioReportId> findReportIdsByScenarioIds(@Param("scenarioIds") Collection<UUID> scenarioIds);
+
+  interface ScenarioReportId {
+    UUID getScenarioId();
+    UUID getReportId();
+  }
 
   @Query("""
       select tr

--- a/src/main/java/com/saferoute/domain/training/dto/ScenarioResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/ScenarioResponse.java
@@ -23,14 +23,16 @@ public class ScenarioResponse {
     private ScenarioStatus status;
     // 훈련 세션이 하나도 없는 시나리오만 삭제 가능. 단건 조회에선 항상 null (목록 조회 전용 필드).
     private Boolean deletable;
+    // 이 시나리오의 훈련 리포트 id. 리포트가 아직 없으면 null (목록 조회 전용 필드).
+    private UUID reportId;
     private Instant createdAt;
     private Instant updatedAt;
 
     public static ScenarioResponse from(TrainingScenario scenario) {
-        return from(scenario, null);
+        return from(scenario, null, null);
     }
 
-    public static ScenarioResponse from(TrainingScenario scenario, Boolean deletable) {
+    public static ScenarioResponse from(TrainingScenario scenario, Boolean deletable, UUID reportId) {
         return ScenarioResponse.builder()
                 .id(scenario.getId())
                 .name(scenario.getName())
@@ -42,6 +44,7 @@ public class ScenarioResponse {
                 .fireSpreadSpeed(scenario.getFireSpreadSpeed())
                 .status(scenario.getStatus())
                 .deletable(deletable)
+                .reportId(reportId)
                 .createdAt(scenario.getCreatedAt())
                 .updatedAt(scenario.getUpdatedAt())
                 .build();

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -12,14 +12,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -84,11 +81,6 @@ public class TrainingScenario {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
-
-    // 훈련 세션은 시나리오와 생명주기를 공유하지 않는다.
-    // 시나리오를 지워도 과거 훈련 기록은 보존되어야 하므로 Cascade를 걸지 않는다.
-    @OneToMany(mappedBy = "scenario")
-    private List<TrainingSession> trainingSessions = new ArrayList<>();
 
     public static TrainingScenario create(String name,
                                           Integer expectedParticipants,

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingSession.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingSession.java
@@ -62,8 +62,9 @@ public class TrainingSession {
   @JoinColumn(name = "user_id", nullable = false)
   private User admin;
 
+  // 시나리오당 세션은 1개만 존재한다. 재훈련이 필요하면 시나리오를 새로 만든다.
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "training_scenario_id", nullable = false)
+  @JoinColumn(name = "training_scenario_id", nullable = false, unique = true)
   private TrainingScenario scenario;
 
   @OneToOne(mappedBy = "trainingSession", cascade = CascadeType.ALL)

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
 import com.saferoute.domain.training.entity.TrainingScenario;
+import com.saferoute.domain.report.repository.TrainingReportRepository;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.entity.User;
@@ -16,8 +17,10 @@ import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.error.UserErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,11 +32,12 @@ public class TrainingScenarioService {
 
     private final TrainingScenarioRepository scenarioRepository;
     private final TrainingSessionRepository trainingSessionRepository;
+    private final TrainingReportRepository trainingReportRepository;
     private final BuildingRepository buildingRepository;
     private final UserRepository userRepository;
     private final SchoolContextService schoolContextService;
 
-    // 목록 조회 (deletable = 연결된 훈련 세션이 하나도 없는 시나리오인지 여부)
+    // 목록 조회 (deletable = 연결된 훈련 세션이 하나도 없는 시나리오인지 여부, reportId = 리포트가 있으면 그 id)
     public List<ScenarioResponse> getScenarios(String email) {
         String schoolName = schoolContextService.getSchoolName(email);
         List<TrainingScenario> scenarios =
@@ -44,9 +48,17 @@ public class TrainingScenarioService {
 
         List<UUID> scenarioIds = scenarios.stream().map(TrainingScenario::getId).toList();
         Set<UUID> scenarioIdsWithSession = trainingSessionRepository.findScenarioIdsWithAnySession(scenarioIds);
+        Map<UUID, UUID> reportIdsByScenarioId = trainingReportRepository.findReportIdsByScenarioIds(scenarioIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        TrainingReportRepository.ScenarioReportId::getScenarioId,
+                        TrainingReportRepository.ScenarioReportId::getReportId));
 
         return scenarios.stream()
-                .map(scenario -> ScenarioResponse.from(scenario, !scenarioIdsWithSession.contains(scenario.getId())))
+                .map(scenario -> ScenarioResponse.from(
+                        scenario,
+                        !scenarioIdsWithSession.contains(scenario.getId()),
+                        reportIdsByScenarioId.get(scenario.getId())))
                 .toList();
     }
 

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,7 +72,14 @@ public class TrainingSessionService {
         scenario
     );
 
-    return TrainingSessionResponse.from(trainingSessionRepository.save(trainingSession));
+    // existsByScenario_Id 체크와 save는 원자적이지 않아 동시 요청이 둘 다 통과할 수 있다.
+    // 이 경우 뒤늦게 실패하는 쪽은 UNIQUE 제약 위반으로 걸러지므로, saveAndFlush로 INSERT를
+    // 즉시 실행시켜 그 예외를 여기서 도메인 에러로 변환한다.
+    try {
+      return TrainingSessionResponse.from(trainingSessionRepository.saveAndFlush(trainingSession));
+    } catch (DataIntegrityViolationException e) {
+      throw new ApiException(TrainingErrorCode.SESSION_ALREADY_EXISTS);
+    }
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -56,6 +56,10 @@ public class TrainingSessionService {
     TrainingScenario scenario = trainingScenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, schoolName)
         .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND));
 
+    if (trainingSessionRepository.existsByScenario_Id(scenarioId)) {
+      throw new ApiException(TrainingErrorCode.SESSION_ALREADY_EXISTS);
+    }
+
     if (request.getStatus() == TrainingStatus.RUNNING && request.getStartedAt() == null) {
       throw new ApiException(ErrorCode.INVALID_INPUT);
     }

--- a/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
@@ -15,7 +15,8 @@ public enum TrainingErrorCode implements BaseErrorCode {
     INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, "TRAINING004", "현재 상태에서는 요청한 전이를 수행할 수 없습니다."),
     UNSUPPORTED_STATUS(HttpStatus.CONFLICT, "TRAINING005", "지원하지 않는 훈련 상태입니다."),
     RUNNING_TRAINING_SESSION_NOT_FOUND(HttpStatus.CONFLICT,"TRAINING006", "진행 중인 훈련 세션을 찾을 수 없습니다."),
-    SCENARIO_DELETE_NOT_ALLOWED(HttpStatus.CONFLICT, "TRAINING007", "훈련 세션이 존재하는 시나리오는 삭제할 수 없습니다.");
+    SCENARIO_DELETE_NOT_ALLOWED(HttpStatus.CONFLICT, "TRAINING007", "훈련 세션이 존재하는 시나리오는 삭제할 수 없습니다."),
+    SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "TRAINING008", "이미 훈련 세션이 존재하는 시나리오입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     hibernate:
       # 기존 DB 호환을 위해 우선 update를 사용한다.
       # 추후 Flyway 등의 마이그레이션을 도입하면 validate로 변경한다.
-      ddl-auto: ${JPA_DDL_AUTO:update}
+      ddl-auto: ${JPA_DDL_AUTO:create}
     properties:
       hibernate:
         format_sql: false

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.report.repository.TrainingReportRepository;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
 import com.saferoute.domain.training.entity.TrainingScenario;
@@ -48,6 +49,9 @@ class TrainingScenarioServiceTest {
     private TrainingSessionRepository trainingSessionRepository;
 
     @Mock
+    private TrainingReportRepository trainingReportRepository;
+
+    @Mock
     private BuildingRepository buildingRepository;
 
     @Mock
@@ -81,6 +85,8 @@ class TrainingScenarioServiceTest {
                 .willReturn(List.of(scenario));
         given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
                 .willReturn(Set.of());
+        given(trainingReportRepository.findReportIdsByScenarioIds(List.of(scenarioId)))
+                .willReturn(List.of());
 
         List<ScenarioResponse> responses = trainingScenarioService.getScenarios(EMAIL);
 
@@ -98,6 +104,8 @@ class TrainingScenarioServiceTest {
                 .willReturn(List.of(scenario));
         given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
                 .willReturn(Set.of(scenarioId));
+        given(trainingReportRepository.findReportIdsByScenarioIds(List.of(scenarioId)))
+                .willReturn(List.of());
 
         List<ScenarioResponse> responses = trainingScenarioService.getScenarios(EMAIL);
 
@@ -106,7 +114,60 @@ class TrainingScenarioServiceTest {
     }
 
     @Test
-    @DisplayName("시나리오가 하나도 없으면 세션 조회 없이 빈 목록을 반환한다")
+    @DisplayName("리포트가 생성된 시나리오는 목록에서 reportId를 함께 응답한다")
+    void getScenarios_scenarioWithReport_returnsReportId() {
+        UUID scenarioId = UUID.randomUUID();
+        UUID reportId = UUID.randomUUID();
+        TrainingScenario scenario = scenarioWithId(scenarioId);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
+                .willReturn(List.of(scenario));
+        given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
+                .willReturn(Set.of(scenarioId));
+        given(trainingReportRepository.findReportIdsByScenarioIds(List.of(scenarioId)))
+                .willReturn(List.of(scenarioReportId(scenarioId, reportId)));
+
+        List<ScenarioResponse> responses = trainingScenarioService.getScenarios(EMAIL);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getReportId()).isEqualTo(reportId);
+    }
+
+    @Test
+    @DisplayName("리포트가 없는 시나리오는 목록에서 reportId가 null이다")
+    void getScenarios_scenarioWithoutReport_returnsNullReportId() {
+        UUID scenarioId = UUID.randomUUID();
+        TrainingScenario scenario = scenarioWithId(scenarioId);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
+                .willReturn(List.of(scenario));
+        given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
+                .willReturn(Set.of());
+        given(trainingReportRepository.findReportIdsByScenarioIds(List.of(scenarioId)))
+                .willReturn(List.of());
+
+        List<ScenarioResponse> responses = trainingScenarioService.getScenarios(EMAIL);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getReportId()).isNull();
+    }
+
+    private TrainingReportRepository.ScenarioReportId scenarioReportId(UUID scenarioId, UUID reportId) {
+        return new TrainingReportRepository.ScenarioReportId() {
+            @Override
+            public UUID getScenarioId() {
+                return scenarioId;
+            }
+
+            @Override
+            public UUID getReportId() {
+                return reportId;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("시나리오가 하나도 없으면 세션/리포트 조회 없이 빈 목록을 반환한다")
     void getScenarios_noScenarios_returnsEmptyListWithoutQueryingSessions() {
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
         given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
@@ -116,6 +177,7 @@ class TrainingScenarioServiceTest {
 
         assertThat(responses).isEmpty();
         verify(trainingSessionRepository, never()).findScenarioIdsWithAnySession(org.mockito.ArgumentMatchers.any());
+        verify(trainingReportRepository, never()).findReportIdsByScenarioIds(org.mockito.ArgumentMatchers.any());
     }
 
     // === deleteScenario ===

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -117,6 +117,27 @@ class TrainingSessionServiceTest {
     }
 
     @Test
+    @DisplayName("이미 세션이 존재하는 시나리오로는 세션을 또 생성할 수 없다")
+    void create_scenarioAlreadyHasSession_throwsException() {
+        UUID adminId = UUID.randomUUID();
+        UUID scenarioId = UUID.randomUUID();
+        User manager = mock(User.class);
+        given(manager.getRole()).willReturn(UserRole.MANAGER);
+        given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
+        given(trainingScenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(mock(TrainingScenario.class)));
+        given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(true);
+
+        CreateSessionRequest request = new CreateSessionRequest(TrainingStatus.SCHEDULED, null, adminId);
+
+        assertThatThrownBy(() -> trainingSessionService.create(request, scenarioId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.SESSION_ALREADY_EXISTS);
+        verify(trainingSessionRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("다른 기관의 시나리오로 훈련 세션을 생성할 수 없다")
     void create_otherSchoolScenario_throwsNotFound() {
         UUID adminId = UUID.randomUUID();

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -138,6 +138,28 @@ class TrainingSessionServiceTest {
     }
 
     @Test
+    @DisplayName("existsByScenario_Id 통과 이후 동시 요청으로 인한 UNIQUE 제약 위반은 SESSION_ALREADY_EXISTS로 변환된다")
+    void create_concurrentInsertViolatesUniqueConstraint_throwsSessionAlreadyExists() {
+        UUID adminId = UUID.randomUUID();
+        UUID scenarioId = UUID.randomUUID();
+        User manager = mock(User.class);
+        given(manager.getRole()).willReturn(UserRole.MANAGER);
+        given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
+        given(trainingScenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(mock(TrainingScenario.class)));
+        given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(false);
+        given(trainingSessionRepository.saveAndFlush(any()))
+                .willThrow(new org.springframework.dao.DataIntegrityViolationException("unique constraint"));
+
+        CreateSessionRequest request = new CreateSessionRequest(TrainingStatus.SCHEDULED, null, adminId);
+
+        assertThatThrownBy(() -> trainingSessionService.create(request, scenarioId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.SESSION_ALREADY_EXISTS);
+    }
+
+    @Test
     @DisplayName("다른 기관의 시나리오로 훈련 세션을 생성할 수 없다")
     void create_otherSchoolScenario_throwsNotFound() {
         UUID adminId = UUID.randomUUID();

--- a/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
@@ -198,11 +198,20 @@ class WebSocketIntegrationTest {
         session.disconnect();
     }
 
+    // 시나리오당 세션은 1개만 허용되므로(UNIQUE 제약), setUp()의 trainingScenario를 재사용하지 않고
+    // 테스트마다 별도 시나리오를 만들어 추가 세션을 붙인다.
+    private TrainingScenario newScenario() {
+        TrainingScenario scenario = TrainingScenario.create(
+                "정기 훈련", 50, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, managerUser);
+        return trainingScenarioRepository.save(scenario);
+    }
+
     @Test
     @DisplayName("훈련을 시작하면 구독자가 TRAINING_STATUS_UPDATED(RUNNING) 이벤트를 수신한다")
     void startingTrainingPublishesRunningEvent() throws Exception {
+        TrainingScenario scenario = newScenario();
         TrainingSession scheduledSession = TrainingSession.create(
-                TrainingStatus.SCHEDULED, Instant.now(), managerUser, trainingScenario);
+                TrainingStatus.SCHEDULED, Instant.now(), managerUser, scenario);
         trainingSessionRepository.save(scheduledSession);
 
         try {
@@ -218,14 +227,16 @@ class WebSocketIntegrationTest {
             session.disconnect();
         } finally {
             trainingSessionRepository.deleteById(scheduledSession.getId());
+            trainingScenarioRepository.delete(scenario);
         }
     }
 
     @Test
     @DisplayName("훈련을 정상 종료하면 구독자가 TRAINING_STATUS_UPDATED(COMPLETED) 이벤트를 수신한다")
     void endingTrainingPublishesCompletedEvent() throws Exception {
+        TrainingScenario scenario = newScenario();
         TrainingSession runningSession = TrainingSession.create(
-                TrainingStatus.RUNNING, Instant.now(), managerUser, trainingScenario);
+                TrainingStatus.RUNNING, Instant.now(), managerUser, scenario);
         trainingSessionRepository.save(runningSession);
 
         try {
@@ -240,14 +251,16 @@ class WebSocketIntegrationTest {
             session.disconnect();
         } finally {
             trainingSessionRepository.deleteById(runningSession.getId());
+            trainingScenarioRepository.delete(scenario);
         }
     }
 
     @Test
     @DisplayName("훈련을 강제 종료하면 구독자가 TRAINING_STATUS_UPDATED(STOPPED) 이벤트를 수신한다")
     void forceEndingTrainingPublishesStoppedEvent() throws Exception {
+        TrainingScenario scenario = newScenario();
         TrainingSession runningSession = TrainingSession.create(
-                TrainingStatus.RUNNING, Instant.now(), managerUser, trainingScenario);
+                TrainingStatus.RUNNING, Instant.now(), managerUser, scenario);
         trainingSessionRepository.save(runningSession);
 
         try {
@@ -262,6 +275,7 @@ class WebSocketIntegrationTest {
             session.disconnect();
         } finally {
             trainingSessionRepository.deleteById(runningSession.getId());
+            trainingScenarioRepository.delete(scenario);
         }
     }
 


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #118 
- Branch: feat/#118

## 주요 내용
### 1. 시나리오당 세션 1개로 제약
- `TrainingSession.scenario` 조인 컬럼에 `UNIQUE` 제약 추가
- `TrainingSessionService.create()`에서 이미 세션이 있는 시나리오면 생성을 막도록 가드 추가 (`SESSION_ALREADY_EXISTS`, `TRAINING008`)
- 아무 곳에서도 쓰이지 않던 `TrainingScenario.trainingSessions`(List) 필드 제거
- 위 UNIQUE 제약으로 인해 같은 시나리오에 세션을 2개 붙이던 `WebSocketIntegrationTest` 픽스처를 시나리오 분리하도록 수정

### 2. 시나리오 목록 API에 리포트 id 추가
- `TrainingReportRepository`에 시나리오 id → 리포트 id 배치 조회 쿼리 추가 (`deletable` 계산과 동일한 N+1 방지 패턴)
- `TrainingScenarioService.getScenarios()`에서 리포트 id 매핑 계산 후 응답에 반영
- `ScenarioResponse`에 `reportId`(nullable) 필드 추가 — 리포트가 없으면 `null`, 있으면 해당 id로 프론트가 바로 리포트 조회 가능

## 코드래빗 리뷰 반영

**지적**: `TrainingSessionService.create()`에서 `existsByScenario_Id()` 체크와 `save()`가 원자적이지 않음. 두 요청이 동시에 들어오면 둘 다 체크를 통과할 수 있고, 이후 하나의 INSERT는 UNIQUE 제약 위반으로 실패하는데, 이 예외가 `SESSION_ALREADY_EXISTS`로 변환되지 않아 클라이언트가 409 대신 일반 영속성 오류를 받을 수 있음.

**수정**:
- `save()` → `saveAndFlush()`로 변경해 INSERT를 그 자리에서 즉시 실행시킴
- 그 시점에 발생하는 `DataIntegrityViolationException`을 잡아 `SESSION_ALREADY_EXISTS`로 변환
- `@Transactional`은 의도적으로 추가하지 않음 — 서비스 메서드 전체를 트랜잭션으로 묶으면 UUID 생성 전략상 INSERT가 커밋 시점까지 지연 flush될 수 있어, 오히려 예외가 try/catch를 우회하고 새어나갈 위험이 있음
- 동시성 케이스(`existsByScenario_Id`는 false를 반환했지만 `saveAndFlush`에서 제약 위반이 발생하는 상황) 테스트 추가

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 시나리오 목록에서 연결된 훈련 리포트 ID를 확인할 수 있습니다.
  * 시나리오별 훈련 세션을 하나로 제한합니다.

* **버그 수정**
  * 이미 훈련 세션이 있는 시나리오에 중복 세션을 생성할 수 없도록 개선했습니다.
  * 중복 생성 시 충돌 오류와 안내 메시지를 제공합니다.

* **테스트**
  * 리포트 ID 조회, 리포트가 없는 시나리오, 중복 세션 생성을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->