### PR TITLE
[FEAT] #121: 경로 이탈률 계산 - 유도등 방향 이력 로깅 및 CCTV 데이터 조인

### DIFF
--- a/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
@@ -12,6 +12,9 @@ public interface CctvGridCellRepository extends JpaRepository<CctvGridCell, UUID
 
     List<CctvGridCell> findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(UUID cctvId);
 
+    // 특정 GridCell들을 감시하는 CCTV를 역으로 찾는다 (Edge -> GridCell -> CCTV 조회, 경로 이탈률 계산에 사용).
+    List<CctvGridCell> findAllByGridCell_IdIn(List<UUID> gridCellIds);
+
     // 감시 면적 계산엔 셀 목록 전체가 아니라 개수만 필요하다 (Pi 설정 조회 API).
     int countByCctv_Id(UUID cctvId);
 

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -17,6 +17,11 @@ import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.LightDirectionEventItem;
+import com.saferoute.domain.telemetry.dynamo.repository.LightDirectionEventRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.error.IoTLightErrorCode;
 import com.saferoute.global.api.exception.ApiException;
@@ -24,6 +29,7 @@ import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import com.saferoute.domain.user.service.SchoolContextService;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +50,8 @@ public class IoTLightService {
     private final IoTLightDirectionStore iotLightDirectionStore;
     private final TrainingEventPublisher trainingEventPublisher;
     private final SchoolContextService schoolContextService;
+    private final TrainingSessionRepository trainingSessionRepository;
+    private final LightDirectionEventRepository lightDirectionEventRepository;
 
     @Transactional
     public IoTLightResponse createLight(CreateIoTLightRequest request, String email) {
@@ -159,8 +167,9 @@ public class IoTLightService {
         mapNodeJpaRepository.delete(customNode);
     }
 
-    // 검증(enabled/guidance) -> Pi 호출 -> 상태 저장 -> 이벤트 발행 순서로 조립한다.
-    // direction은 훈련별 동적 상태라 DB에 저장하지 않고 IoTLightDirectionStore(서버 메모리)에 저장한다 (IoTLight 참고).
+    // 검증(enabled/guidance) -> Pi 호출 -> 상태 저장 -> 이력 기록 -> 이벤트 발행 순서로 조립한다.
+    // 현재 방향은 훈련별 동적 상태라 DB에 저장하지 않고 IoTLightDirectionStore(서버 메모리)에 저장한다 (IoTLight 참고).
+    // 전환 이력만 경로 이탈률 계산을 위해 DynamoDB(LightDirectionEventItem)에 별도로 남긴다.
     public LightDirectionResponse changeDirection(
             UUID lightId, ChangeLightDirectionRequest request, String email) {
         IoTLight light = findLightForSchoolOrThrow(lightId, email);
@@ -183,9 +192,38 @@ public class IoTLightService {
 
         iotLightPiClient.sendDirection(light.getPiEndpoint(), light.getCode(), direction);
         iotLightDirectionStore.update(light.getId(), direction);
+        Instant changedAt = Instant.now();
+        logDirectionChange(light, direction, changedAt);
         trainingEventPublisher.publishIoTLightStatusUpdatedAfterCommit(light, direction);
 
-        return new LightDirectionResponse(light.getId(), direction, Instant.now());
+        return new LightDirectionResponse(light.getId(), direction, changedAt);
+    }
+
+    // 경로 이탈률 계산의 원천 데이터로 쓰기 위해 방향 전환 시점을 훈련 세션 기준으로 DynamoDB에 남긴다.
+    // 실행 중인 훈련 세션이 없으면(설정/점검 중 방향 전환) 남길 이력이 없으므로 조용히 넘어가고,
+    // 로깅 실패가 유도등 명령 자체의 성공 여부에 영향을 주지 않도록 예외를 흡수한다.
+    private void logDirectionChange(IoTLight light, IoTLightDirection direction, Instant changedAt) {
+        try {
+            UUID buildingId = light.getCustomNode().getFloor().getBuilding().getId();
+            Optional<TrainingSession> runningSession = trainingSessionRepository
+                    .findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(TrainingStatus.RUNNING, buildingId);
+            if (runningSession.isEmpty()) {
+                return;
+            }
+            LightDirectionEventItem item = LightDirectionEventItem.create(
+                    runningSession.get().getId(),
+                    light.getId(),
+                    light.getCode(),
+                    direction,
+                    light.getDecisionNode() != null ? light.getDecisionNode().getId() : null,
+                    light.getLeftEdge() != null ? light.getLeftEdge().getId() : null,
+                    light.getRightEdge() != null ? light.getRightEdge().getId() : null,
+                    changedAt.toEpochMilli()
+            );
+            lightDirectionEventRepository.save(item);
+        } catch (RuntimeException exception) {
+            log.warn("유도등 방향 전환 이력 기록 실패: lightId={}, direction={}", light.getId(), direction, exception);
+        }
     }
 
     // RouteRecalculation 승인 시 호출한다. 승인된 경로가 지나가는 분기점마다 그 경로를 안내하는

--- a/src/main/java/com/saferoute/domain/evacuation/deviation/controller/RouteDeviationController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/deviation/controller/RouteDeviationController.java
@@ -1,0 +1,35 @@
+package com.saferoute.domain.evacuation.deviation.controller;
+
+import com.saferoute.domain.evacuation.deviation.dto.RouteDeviationResponse;
+import com.saferoute.domain.evacuation.deviation.service.RouteDeviationService;
+import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "경로 이탈률", description = "유도등 안내 방향과 CCTV 탐지 결과를 비교한 경로 이탈률 조회 API")
+@RestController
+@RequestMapping("/api/v1/lights/{lightId}/deviation")
+@RequiredArgsConstructor
+public class RouteDeviationController {
+
+    private final RouteDeviationService routeDeviationService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<RouteDeviationResponse>> getDeviationRate(
+            @PathVariable UUID lightId,
+            @RequestParam UUID trainingSessionId,
+            Authentication authentication
+    ) {
+        RouteDeviationResponse response =
+                routeDeviationService.calculate(lightId, trainingSessionId, authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/deviation/dto/RouteDeviationResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/deviation/dto/RouteDeviationResponse.java
@@ -1,0 +1,14 @@
+package com.saferoute.domain.evacuation.deviation.dto;
+
+import java.util.UUID;
+
+// totalObservedWindows: 유도등이 좌/우 중 하나를 가리키던 중 CCTV가 인원을 탐지한 5초 관측 구간 수
+// deviatedWindows: 그중 유도등이 가리킨 방향과 다른 쪽 CCTV에서 인원이 탐지된 구간 수
+public record RouteDeviationResponse(
+        UUID lightId,
+        UUID trainingSessionId,
+        long totalObservedWindows,
+        long deviatedWindows,
+        double deviationRate
+) {
+}

--- a/src/main/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationService.java
@@ -1,0 +1,136 @@
+package com.saferoute.domain.evacuation.deviation.service;
+
+import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.repository.IoTLightJpaRepository;
+import com.saferoute.domain.evacuation.deviation.dto.RouteDeviationResponse;
+import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.LightDirectionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.LightDirectionEventRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.IoTLightErrorCode;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 유도등이 안내한 방향(LightDirectionEventItem 이력)과 CCTV가 실제로 인원을 탐지한 위치(ObservationItem)를
+// 시간 축으로 조인해 경로 이탈률을 계산한다. CCTV 한 대는 headcount/밀집도만 보고하므로 개별 이동 경로까지는
+// 알 수 없지만, "좌/우 통로를 각각 감시하는 CCTV가 분리되어 있다"는 전제(데모 구성) 하에 어느 쪽 CCTV에서
+// 인원이 탐지됐는지를 실제 이동 방향의 대리 지표로 사용한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RouteDeviationService {
+
+    private static final int OBSERVATION_QUERY_LIMIT = 2000;
+
+    private final IoTLightJpaRepository iotLightJpaRepository;
+    private final TrainingSessionRepository trainingSessionRepository;
+    private final LightDirectionEventRepository lightDirectionEventRepository;
+    private final ObservationRepository observationRepository;
+    private final MapEdgeGridCellRepository mapEdgeGridCellRepository;
+    private final CctvGridCellRepository cctvGridCellRepository;
+    private final SchoolContextService schoolContextService;
+
+    public RouteDeviationResponse calculate(UUID lightId, UUID trainingSessionId, String email) {
+        String schoolName = schoolContextService.getSchoolName(email);
+        IoTLight light = iotLightJpaRepository
+                .findByIdAndCustomNode_Floor_Building_SchoolName(lightId, schoolName)
+                .orElseThrow(() -> new ApiException(IoTLightErrorCode.IOT_LIGHT_NOT_FOUND));
+        TrainingSession session = trainingSessionRepository
+                .findByIdAndScenario_Building_SchoolName(trainingSessionId, schoolName)
+                .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+
+        if (!light.isGuidanceConfigured()) {
+            throw new ApiException(IoTLightErrorCode.GUIDANCE_NOT_CONFIGURED);
+        }
+
+        Set<String> leftCctvCodes = resolveCctvCodes(light.getLeftEdge().getId());
+        Set<String> rightCctvCodes = resolveCctvCodes(light.getRightEdge().getId());
+        Set<String> ambiguous = intersect(leftCctvCodes, rightCctvCodes);
+        leftCctvCodes.removeAll(ambiguous);
+        rightCctvCodes.removeAll(ambiguous);
+        if (leftCctvCodes.isEmpty() || rightCctvCodes.isEmpty()) {
+            throw new ApiException(IoTLightErrorCode.DEVIATION_CCTV_MAPPING_NOT_FOUND);
+        }
+
+        List<LightDirectionEventItem> directionEvents = lightDirectionEventRepository
+                .findAllBySessionIdAndLightCode(session.getId().toString(), light.getCode());
+
+        long total = 0;
+        long deviated = 0;
+        for (String cctvCode : union(leftCctvCodes, rightCctvCodes)) {
+            IoTLightDirection guidedSide = leftCctvCodes.contains(cctvCode)
+                    ? IoTLightDirection.LEFT
+                    : IoTLightDirection.RIGHT;
+            List<ObservationItem> observations = observationRepository.findAllBySessionIdAndCctvCode(
+                    session.getId().toString(), cctvCode, OBSERVATION_QUERY_LIMIT);
+            for (ObservationItem observation : observations) {
+                if (observation.getAvgHeadcount() == null || observation.getAvgHeadcount() <= 0) {
+                    continue;
+                }
+                IoTLightDirection activeDirection = activeDirectionAt(directionEvents, observation.getCapturedAt());
+                if (activeDirection == null || activeDirection == IoTLightDirection.OFF) {
+                    continue;
+                }
+                total++;
+                if (activeDirection != guidedSide) {
+                    deviated++;
+                }
+            }
+        }
+
+        double deviationRate = total == 0 ? 0.0 : (double) deviated / total;
+        return new RouteDeviationResponse(light.getId(), session.getId(), total, deviated, deviationRate);
+    }
+
+    // 관측 시각 시점에 유도등이 가리키고 있던 방향. 이력이 시간순으로 정렬되어 있으므로
+    // 해당 시각 이전(이하)의 마지막 전환 이벤트를 찾는다. 전환 이력이 아직 없으면 null.
+    private IoTLightDirection activeDirectionAt(List<LightDirectionEventItem> events, long timestamp) {
+        IoTLightDirection active = null;
+        for (LightDirectionEventItem event : events) {
+            if (event.getChangedAt() > timestamp) {
+                break;
+            }
+            active = event.getDirection();
+        }
+        return active;
+    }
+
+    // Edge -> GridCell -> CCTV 역방향 조회로, 이 통로를 감시하는 CCTV 코드 목록을 찾는다.
+    private Set<String> resolveCctvCodes(UUID edgeId) {
+        List<UUID> gridCellIds = mapEdgeGridCellRepository.findAllByMapEdge_Id(edgeId).stream()
+                .map(mapping -> mapping.getGridCell().getId())
+                .toList();
+        if (gridCellIds.isEmpty()) {
+            return new HashSet<>();
+        }
+        Set<String> codes = new HashSet<>();
+        cctvGridCellRepository.findAllByGridCell_IdIn(gridCellIds)
+                .forEach(mapping -> codes.add(mapping.getCctv().getCode()));
+        return codes;
+    }
+
+    private Set<String> intersect(Set<String> left, Set<String> right) {
+        Set<String> result = new HashSet<>(left);
+        result.retainAll(right);
+        return result;
+    }
+
+    private Set<String> union(Set<String> left, Set<String> right) {
+        Set<String> result = new HashSet<>(left);
+        result.addAll(right);
+        return result;
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationService.java
@@ -18,7 +18,9 @@ import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -68,26 +70,43 @@ public class RouteDeviationService {
         List<LightDirectionEventItem> directionEvents = lightDirectionEventRepository
                 .findAllBySessionIdAndLightCode(session.getId().toString(), light.getCode());
 
-        long total = 0;
-        long deviated = 0;
+        // windowStart(5초 관측 구간의 시작 시각) 기준으로 좌/우 CCTV 결과를 먼저 합산한다.
+        // 같은 구간을 좌/우 CCTV 레코드 각각으로 두 번 집계하지 않기 위함이다.
+        Map<Long, WindowHeadcount> windows = new TreeMap<>();
         for (String cctvCode : union(leftCctvCodes, rightCctvCodes)) {
-            IoTLightDirection guidedSide = leftCctvCodes.contains(cctvCode)
-                    ? IoTLightDirection.LEFT
-                    : IoTLightDirection.RIGHT;
+            boolean isLeft = leftCctvCodes.contains(cctvCode);
             List<ObservationItem> observations = observationRepository.findAllBySessionIdAndCctvCode(
                     session.getId().toString(), cctvCode, OBSERVATION_QUERY_LIMIT);
             for (ObservationItem observation : observations) {
                 if (observation.getAvgHeadcount() == null || observation.getAvgHeadcount() <= 0) {
                     continue;
                 }
-                IoTLightDirection activeDirection = activeDirectionAt(directionEvents, observation.getCapturedAt());
-                if (activeDirection == null || activeDirection == IoTLightDirection.OFF) {
-                    continue;
+                WindowHeadcount window = windows.computeIfAbsent(observation.getWindowStart(),
+                        key -> new WindowHeadcount());
+                window.capturedAt = observation.getCapturedAt();
+                if (isLeft) {
+                    window.left += observation.getAvgHeadcount();
+                } else {
+                    window.right += observation.getAvgHeadcount();
                 }
-                total++;
-                if (activeDirection != guidedSide) {
-                    deviated++;
-                }
+            }
+        }
+
+        long total = 0;
+        long deviated = 0;
+        for (WindowHeadcount headcount : windows.values()) {
+            // 방향 조회는 관측 구간의 실제 보고 시각(capturedAt)을 기준으로 한다. windowStart는 병합 키일 뿐이다.
+            IoTLightDirection activeDirection = activeDirectionAt(directionEvents, headcount.capturedAt);
+            if (activeDirection == null || activeDirection == IoTLightDirection.OFF) {
+                continue;
+            }
+            total++;
+            // 안내 방향의 반대쪽에서도 인원이 탐지되면(양쪽 모두 탐지된 경우 포함) 그 구간은 이탈로 집계한다.
+            boolean nonGuidedSideDetected = activeDirection == IoTLightDirection.LEFT
+                    ? headcount.right > 0
+                    : headcount.left > 0;
+            if (nonGuidedSideDetected) {
+                deviated++;
             }
         }
 
@@ -95,8 +114,14 @@ public class RouteDeviationService {
         return new RouteDeviationResponse(light.getId(), session.getId(), total, deviated, deviationRate);
     }
 
-    // 관측 시각 시점에 유도등이 가리키고 있던 방향. 이력이 시간순으로 정렬되어 있으므로
-    // 해당 시각 이전(이하)의 마지막 전환 이벤트를 찾는다. 전환 이력이 아직 없으면 null.
+    private static final class WindowHeadcount {
+        private double left;
+        private double right;
+        private long capturedAt;
+    }
+
+    // 주어진 시각(관측 구간의 windowStart)에 유도등이 가리키고 있던 방향. 이력이 시간순으로 정렬되어
+    // 있으므로 해당 시각 이전(이하)의 마지막 전환 이벤트를 찾는다. 전환 이력이 아직 없으면 null.
     private IoTLightDirection activeDirectionAt(List<LightDirectionEventItem> events, long timestamp) {
         IoTLightDirection active = null;
         for (LightDirectionEventItem event : events) {

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/LightDirectionEventItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/LightDirectionEventItem.java
@@ -49,7 +49,7 @@ public class LightDirectionEventItem {
         item.changedAt = changedAt;
         item.expiresAt = Math.floorDiv(changedAt, 1_000L) + TTL_SECONDS;
         item.pk = buildPk(item.trainingSessionId, lightCode);
-        item.sk = buildSk(changedAt);
+        item.sk = buildSk(changedAt, UUID.randomUUID().toString());
         return item;
     }
 
@@ -57,8 +57,10 @@ public class LightDirectionEventItem {
         return "LIGHT_DIRECTION#" + trainingSessionId + "#" + lightCode;
     }
 
-    public static String buildSk(long changedAt) {
-        return "TIME#" + changedAt;
+    // changedAt만으로는 같은 밀리초에 발생한 두 전환이 같은 정렬 키를 갖게 되어 뒤의 저장이 앞의 이력을
+    // 덮어쓸 수 있다. 시간순 정렬은 changedAt 접두사로 유지하면서, UUID를 tie-breaker로 덧붙여 유일성을 보장한다.
+    public static String buildSk(long changedAt, String tieBreaker) {
+        return "TIME#" + changedAt + "#" + tieBreaker;
     }
 
     @DynamoDbPartitionKey

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/LightDirectionEventItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/LightDirectionEventItem.java
@@ -1,0 +1,153 @@
+package com.saferoute.domain.telemetry.dynamo.entity;
+
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import java.util.UUID;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+// 유도등의 방향 전환 이력을 훈련 세션 단위로 기록한다. 실시간 현재 방향은 IoTLightDirectionStore(서버 메모리)가
+// 담당하고, 이 아이템은 "언제 어느 방향으로 바뀌었는지"의 시계열 이력만 담아 리포트/경로 이탈률 계산에 쓴다.
+@DynamoDbBean
+public class LightDirectionEventItem {
+
+    public static final long TTL_SECONDS = 30L * 24 * 60 * 60;
+
+    private String pk;
+    private String sk;
+    private String trainingSessionId;
+    private String lightId;
+    private String lightCode;
+    private IoTLightDirection direction;
+    private String decisionNodeId;
+    private String leftEdgeId;
+    private String rightEdgeId;
+    private Long changedAt;
+    private Long expiresAt;
+
+    public LightDirectionEventItem() {
+    }
+
+    public static LightDirectionEventItem create(
+            UUID trainingSessionId,
+            UUID lightId,
+            String lightCode,
+            IoTLightDirection direction,
+            UUID decisionNodeId,
+            UUID leftEdgeId,
+            UUID rightEdgeId,
+            long changedAt
+    ) {
+        LightDirectionEventItem item = new LightDirectionEventItem();
+        item.trainingSessionId = trainingSessionId.toString();
+        item.lightId = lightId.toString();
+        item.lightCode = lightCode;
+        item.direction = direction;
+        item.decisionNodeId = decisionNodeId != null ? decisionNodeId.toString() : null;
+        item.leftEdgeId = leftEdgeId != null ? leftEdgeId.toString() : null;
+        item.rightEdgeId = rightEdgeId != null ? rightEdgeId.toString() : null;
+        item.changedAt = changedAt;
+        item.expiresAt = Math.floorDiv(changedAt, 1_000L) + TTL_SECONDS;
+        item.pk = buildPk(item.trainingSessionId, lightCode);
+        item.sk = buildSk(changedAt);
+        return item;
+    }
+
+    public static String buildPk(String trainingSessionId, String lightCode) {
+        return "LIGHT_DIRECTION#" + trainingSessionId + "#" + lightCode;
+    }
+
+    public static String buildSk(long changedAt) {
+        return "TIME#" + changedAt;
+    }
+
+    @DynamoDbPartitionKey
+    public String getPk() {
+        return pk;
+    }
+
+    public void setPk(String pk) {
+        this.pk = pk;
+    }
+
+    @DynamoDbSortKey
+    public String getSk() {
+        return sk;
+    }
+
+    public void setSk(String sk) {
+        this.sk = sk;
+    }
+
+    public String getTrainingSessionId() {
+        return trainingSessionId;
+    }
+
+    public void setTrainingSessionId(String trainingSessionId) {
+        this.trainingSessionId = trainingSessionId;
+    }
+
+    public String getLightId() {
+        return lightId;
+    }
+
+    public void setLightId(String lightId) {
+        this.lightId = lightId;
+    }
+
+    public String getLightCode() {
+        return lightCode;
+    }
+
+    public void setLightCode(String lightCode) {
+        this.lightCode = lightCode;
+    }
+
+    public IoTLightDirection getDirection() {
+        return direction;
+    }
+
+    public void setDirection(IoTLightDirection direction) {
+        this.direction = direction;
+    }
+
+    public String getDecisionNodeId() {
+        return decisionNodeId;
+    }
+
+    public void setDecisionNodeId(String decisionNodeId) {
+        this.decisionNodeId = decisionNodeId;
+    }
+
+    public String getLeftEdgeId() {
+        return leftEdgeId;
+    }
+
+    public void setLeftEdgeId(String leftEdgeId) {
+        this.leftEdgeId = leftEdgeId;
+    }
+
+    public String getRightEdgeId() {
+        return rightEdgeId;
+    }
+
+    public void setRightEdgeId(String rightEdgeId) {
+        this.rightEdgeId = rightEdgeId;
+    }
+
+    public Long getChangedAt() {
+        return changedAt;
+    }
+
+    public void setChangedAt(Long changedAt) {
+        this.changedAt = changedAt;
+    }
+
+    public Long getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Long expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/LightDirectionEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/LightDirectionEventRepository.java
@@ -1,0 +1,44 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import com.saferoute.domain.telemetry.dynamo.entity.LightDirectionEventItem;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+
+@Repository
+public class LightDirectionEventRepository {
+
+    static final int DEFAULT_QUERY_LIMIT = 500;
+
+    private final DynamoDbTable<LightDirectionEventItem> table;
+
+    public LightDirectionEventRepository(
+            DynamoDbEnhancedClient enhancedClient,
+            @Value("${aws.dynamodb.table-name}") String tableName
+    ) {
+        this.table = enhancedClient.table(tableName, TableSchema.fromBean(LightDirectionEventItem.class));
+    }
+
+    public void save(LightDirectionEventItem item) {
+        table.putItem(item);
+    }
+
+    // 세션 내 한 유도등의 방향 전환 이력을 시간순으로 조회한다 (경로 이탈률 계산 시 특정 시점의 활성 방향을 찾는 데 사용).
+    public List<LightDirectionEventItem> findAllBySessionIdAndLightCode(String trainingSessionId, String lightCode) {
+        QueryEnhancedRequest request = QueryEnhancedRequest.builder()
+                .queryConditional(QueryConditional.keyEqualTo(Key.builder()
+                        .partitionValue(LightDirectionEventItem.buildPk(trainingSessionId, lightCode))
+                        .build()))
+                .scanIndexForward(true)
+                .limit(DEFAULT_QUERY_LIMIT)
+                .build();
+
+        return table.query(request).items().stream().toList();
+    }
+}

--- a/src/main/java/com/saferoute/global/api/error/IoTLightErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/IoTLightErrorCode.java
@@ -15,7 +15,9 @@ public enum IoTLightErrorCode implements BaseErrorCode {
     INVALID_GUIDANCE_EDGE(HttpStatus.BAD_REQUEST, "IOTLIGHT005", "leftEdge/rightEdge는 decisionNode에 연결된 엣지여야 합니다."),
     GUIDANCE_NOT_CONFIGURED(HttpStatus.BAD_REQUEST, "IOTLIGHT006", "경로 안내(좌/우 통로)가 설정되지 않은 유도등입니다."),
     LIGHT_DISABLED(HttpStatus.BAD_REQUEST, "IOTLIGHT007", "비활성화된 유도등에는 명령을 보낼 수 없습니다."),
-    DEVICE_UNREACHABLE(HttpStatus.BAD_GATEWAY, "IOTLIGHT008", "라즈베리파이 기기와 통신에 실패했습니다.");
+    DEVICE_UNREACHABLE(HttpStatus.BAD_GATEWAY, "IOTLIGHT008", "라즈베리파이 기기와 통신에 실패했습니다."),
+    DEVIATION_CCTV_MAPPING_NOT_FOUND(HttpStatus.BAD_REQUEST, "IOTLIGHT009",
+            "경로 이탈률을 계산하려면 좌/우 통로를 각각 감시하는 CCTV가 매핑되어 있어야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -126,6 +126,12 @@ public class SecurityConfig {
                                 "/api/v1/congestion-observations/*/image-url"
                         ).hasRole("MANAGER")
 
+                        // 경로 이탈률은 훈련 결과 분석용 관리자 화면 전용이다.
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/lights/*/deviation"
+                        ).hasRole("MANAGER")
+
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/api/**"

--- a/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
@@ -26,11 +26,17 @@ import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.LightDirectionEventItem;
+import com.saferoute.domain.telemetry.dynamo.repository.LightDirectionEventRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.error.IoTLightErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
 import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.domain.building.entity.Building;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -77,12 +83,22 @@ class IoTLightServiceTest {
     @Mock
     private SchoolContextService schoolContextService;
 
+    @Mock
+    private TrainingSessionRepository trainingSessionRepository;
+
+    @Mock
+    private LightDirectionEventRepository lightDirectionEventRepository;
+
     private final UUID floorId = UUID.randomUUID();
+    private final UUID buildingId = UUID.randomUUID();
     private Floor floor;
 
     @BeforeEach
     void setUp() {
         floor = mock(Floor.class);
+        Building building = mock(Building.class);
+        org.mockito.Mockito.lenient().when(floor.getBuilding()).thenReturn(building);
+        org.mockito.Mockito.lenient().when(building.getId()).thenReturn(buildingId);
         org.mockito.Mockito.lenient()
                 .when(schoolContextService.getSchoolName(EMAIL))
                 .thenReturn(SCHOOL_NAME);
@@ -482,6 +498,82 @@ class IoTLightServiceTest {
                 .isInstanceOf(ApiException.class)
                 .hasMessage(IoTLightErrorCode.DEVICE_UNREACHABLE.getMessage());
         verifyNoInteractions(iotLightDirectionStore, trainingEventPublisher);
+    }
+
+    @Test
+    @DisplayName("실행 중인 훈련 세션이 있으면 방향 전환 이력을 DynamoDB에 남긴다")
+    void changeDirection_runningSession_logsDirectionEvent() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        MapNode decisionNode = createNode("HALLWAY1", NodeType.HALLWAY);
+        MapNode leftTarget = createNode("HALLWAY2", NodeType.HALLWAY);
+        MapNode rightTarget = createNode("HALLWAY3", NodeType.HALLWAY);
+        light.configureGuidance(decisionNode, createEdge(decisionNode, leftTarget), createEdge(decisionNode, rightTarget));
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.LEFT);
+
+        TrainingSession session = mock(TrainingSession.class);
+        UUID sessionId = UUID.randomUUID();
+        org.mockito.Mockito.lenient().when(session.getId()).thenReturn(sessionId);
+
+        given(iotLightJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(light.getId(), SCHOOL_NAME)).willReturn(Optional.of(light));
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(
+                TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+
+        // when
+        iotLightService.changeDirection(light.getId(), request, EMAIL);
+
+        // then
+        org.mockito.ArgumentCaptor<LightDirectionEventItem> captor =
+                org.mockito.ArgumentCaptor.forClass(LightDirectionEventItem.class);
+        verify(lightDirectionEventRepository).save(captor.capture());
+        assertThat(captor.getValue().getLightCode()).isEqualTo("LIGHT_001");
+        assertThat(captor.getValue().getDirection()).isEqualTo(IoTLightDirection.LEFT);
+        assertThat(captor.getValue().getTrainingSessionId()).isEqualTo(sessionId.toString());
+    }
+
+    @Test
+    @DisplayName("실행 중인 훈련 세션이 없으면 방향 전환 이력을 남기지 않는다")
+    void changeDirection_noRunningSession_skipsLogging() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.OFF);
+
+        given(iotLightJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(light.getId(), SCHOOL_NAME)).willReturn(Optional.of(light));
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(
+                TrainingStatus.RUNNING, buildingId)).willReturn(Optional.empty());
+
+        // when
+        LightDirectionResponse response = iotLightService.changeDirection(light.getId(), request, EMAIL);
+
+        // then
+        assertThat(response.direction()).isEqualTo(IoTLightDirection.OFF);
+        verifyNoInteractions(lightDirectionEventRepository);
+    }
+
+    @Test
+    @DisplayName("방향 전환 이력 기록이 실패해도 유도등 명령 자체는 성공한다")
+    void changeDirection_loggingFails_stillSucceeds() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        ChangeLightDirectionRequest request = new ChangeLightDirectionRequest(IoTLightDirection.OFF);
+
+        given(iotLightJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(light.getId(), SCHOOL_NAME)).willReturn(Optional.of(light));
+        given(trainingSessionRepository.findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(
+                TrainingStatus.RUNNING, buildingId))
+                .willThrow(new RuntimeException("dynamo unavailable"));
+
+        // when
+        LightDirectionResponse response = iotLightService.changeDirection(light.getId(), request, EMAIL);
+
+        // then
+        assertThat(response.direction()).isEqualTo(IoTLightDirection.OFF);
+        verify(trainingEventPublisher).publishIoTLightStatusUpdatedAfterCommit(light, IoTLightDirection.OFF);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationServiceTest.java
@@ -1,0 +1,240 @@
+package com.saferoute.domain.evacuation.deviation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.entity.CctvGridCell;
+import com.saferoute.domain.device.entity.IoTLight;
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.repository.IoTLightJpaRepository;
+import com.saferoute.domain.evacuation.deviation.dto.RouteDeviationResponse;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
+import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.entity.LightDirectionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.LightDirectionEventRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.IoTLightErrorCode;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RouteDeviationServiceTest {
+
+    private static final String EMAIL = "manager@saferoute.com";
+    private static final String SCHOOL_NAME = "SafeRoute School";
+
+    @InjectMocks
+    private RouteDeviationService routeDeviationService;
+
+    @Mock
+    private IoTLightJpaRepository iotLightJpaRepository;
+
+    @Mock
+    private TrainingSessionRepository trainingSessionRepository;
+
+    @Mock
+    private LightDirectionEventRepository lightDirectionEventRepository;
+
+    @Mock
+    private ObservationRepository observationRepository;
+
+    @Mock
+    private MapEdgeGridCellRepository mapEdgeGridCellRepository;
+
+    @Mock
+    private CctvGridCellRepository cctvGridCellRepository;
+
+    @Mock
+    private SchoolContextService schoolContextService;
+
+    private Floor floor;
+    private final UUID lightId = UUID.randomUUID();
+    private final UUID sessionId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        floor = mock(Floor.class);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+    }
+
+    private MapNode node(String code, NodeType type) {
+        MapNode node = type == NodeType.CUSTOM
+                ? MapNode.createCustom(floor, code, code, 0, 0)
+                : MapNode.create(floor, code, type, code, 0, 0, false);
+        ReflectionTestUtils.setField(node, "id", UUID.randomUUID());
+        return node;
+    }
+
+    private MapEdge edge(MapNode from, MapNode to) {
+        MapEdge edge = MapEdge.create(floor, from, to, 3.0, true);
+        ReflectionTestUtils.setField(edge, "id", UUID.randomUUID());
+        return edge;
+    }
+
+    private IoTLight lightWithGuidance() {
+        MapNode customNode = node("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = IoTLight.create("LIGHT_001", "LIGHT_001", customNode);
+        ReflectionTestUtils.setField(light, "id", lightId);
+        MapNode decisionNode = node("HALLWAY1", NodeType.HALLWAY);
+        MapNode leftTarget = node("HALLWAY2", NodeType.HALLWAY);
+        MapNode rightTarget = node("HALLWAY3", NodeType.HALLWAY);
+        light.configureGuidance(decisionNode, edge(decisionNode, leftTarget), edge(decisionNode, rightTarget));
+        return light;
+    }
+
+    private FloorGridCell gridCell() {
+        FloorGridCell cell = FloorGridCell.create(floor, 0, 0, true, 0.1, 0.1);
+        ReflectionTestUtils.setField(cell, "id", UUID.randomUUID());
+        return cell;
+    }
+
+    private Cctv cctv(String code) {
+        MapNode customNode = node(code, NodeType.CUSTOM);
+        Cctv cctv = Cctv.create(code, code, customNode);
+        ReflectionTestUtils.setField(cctv, "id", UUID.randomUUID());
+        return cctv;
+    }
+
+    private CctvGridCell mapping(Cctv cctv, FloorGridCell cell) {
+        return CctvGridCell.create(cctv, cell);
+    }
+
+    private ObservationItem observation(String cctvCode, double avgHeadcount, long capturedAt) {
+        return ObservationItem.create(
+                UUID.randomUUID(), sessionId, null, cctvCode,
+                avgHeadcount, (int) avgHeadcount, 1, 1.0,
+                CongestionLevel.NORMAL, capturedAt - 5_000, capturedAt, capturedAt, null, 1L
+        );
+    }
+
+    private LightDirectionEventItem directionEvent(IoTLight light, IoTLightDirection direction, long changedAt) {
+        return LightDirectionEventItem.create(
+                sessionId, light.getId(), light.getCode(), direction,
+                light.getDecisionNode().getId(), light.getLeftEdge().getId(), light.getRightEdge().getId(), changedAt
+        );
+    }
+
+    @Test
+    @DisplayName("유도등이 안내한 방향과 다른 쪽 CCTV에서 인원이 탐지되면 이탈로 집계한다")
+    void calculate_success() {
+        // given
+        IoTLight light = lightWithGuidance();
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        FloorGridCell leftCell = gridCell();
+        FloorGridCell rightCell = gridCell();
+        Cctv leftCctv = cctv("CCTV_LEFT");
+        Cctv rightCctv = cctv("CCTV_RIGHT");
+
+        given(iotLightJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(lightId, SCHOOL_NAME))
+                .willReturn(Optional.of(light));
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(light.getLeftEdge().getId()))
+                .willReturn(List.of(MapEdgeGridCell.create(light.getLeftEdge(), leftCell)));
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(light.getRightEdge().getId()))
+                .willReturn(List.of(MapEdgeGridCell.create(light.getRightEdge(), rightCell)));
+        given(cctvGridCellRepository.findAllByGridCell_IdIn(List.of(leftCell.getId())))
+                .willReturn(List.of(mapping(leftCctv, leftCell)));
+        given(cctvGridCellRepository.findAllByGridCell_IdIn(List.of(rightCell.getId())))
+                .willReturn(List.of(mapping(rightCctv, rightCell)));
+
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+
+        given(observationRepository.findAllBySessionIdAndCctvCode(anyString(), anyString(), any(Integer.class)))
+                .willAnswer(invocation -> {
+                    String cctvCode = invocation.getArgument(1);
+                    if (cctvCode.equals("CCTV_LEFT")) {
+                        return List.of(observation("CCTV_LEFT", 3.0, 2_000L));
+                    }
+                    return List.of(observation("CCTV_RIGHT", 2.0, 3_000L));
+                });
+
+        // when
+        RouteDeviationResponse response = routeDeviationService.calculate(lightId, sessionId, EMAIL);
+
+        // then
+        assertThat(response.totalObservedWindows()).isEqualTo(2);
+        assertThat(response.deviatedWindows()).isEqualTo(1);
+        assertThat(response.deviationRate()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("경로 안내가 설정되지 않은 유도등이면 예외가 발생한다")
+    void calculate_guidanceNotConfigured_throws() {
+        MapNode customNode = node("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = IoTLight.create("LIGHT_001", "LIGHT_001", customNode);
+        ReflectionTestUtils.setField(light, "id", lightId);
+        TrainingSession session = mock(TrainingSession.class);
+
+        given(iotLightJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(lightId, SCHOOL_NAME))
+                .willReturn(Optional.of(light));
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> routeDeviationService.calculate(lightId, sessionId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.GUIDANCE_NOT_CONFIGURED.getMessage());
+    }
+
+    @Test
+    @DisplayName("좌/우를 감시하는 CCTV 매핑이 없으면 예외가 발생한다")
+    void calculate_noCctvMapping_throws() {
+        IoTLight light = lightWithGuidance();
+        TrainingSession session = mock(TrainingSession.class);
+
+        given(iotLightJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(lightId, SCHOOL_NAME))
+                .willReturn(Optional.of(light));
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(any())).willReturn(List.of());
+
+        assertThatThrownBy(() -> routeDeviationService.calculate(lightId, sessionId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(IoTLightErrorCode.DEVIATION_CCTV_MAPPING_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 훈련 세션이면 예외가 발생한다")
+    void calculate_sessionNotFound_throws() {
+        IoTLight light = lightWithGuidance();
+
+        given(iotLightJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(lightId, SCHOOL_NAME))
+                .willReturn(Optional.of(light));
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> routeDeviationService.calculate(lightId, sessionId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationServiceTest.java
@@ -189,6 +189,54 @@ class RouteDeviationServiceTest {
     }
 
     @Test
+    @DisplayName("같은 관측 구간에서 좌/우 CCTV가 모두 탐지되면 한 구간으로만 집계하고 이탈로 판정한다")
+    void calculate_bothSidesDetectedInSameWindow_countsOnce() {
+        // given
+        IoTLight light = lightWithGuidance();
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        FloorGridCell leftCell = gridCell();
+        FloorGridCell rightCell = gridCell();
+        Cctv leftCctv = cctv("CCTV_LEFT");
+        Cctv rightCctv = cctv("CCTV_RIGHT");
+
+        given(iotLightJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(lightId, SCHOOL_NAME))
+                .willReturn(Optional.of(light));
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(light.getLeftEdge().getId()))
+                .willReturn(List.of(MapEdgeGridCell.create(light.getLeftEdge(), leftCell)));
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(light.getRightEdge().getId()))
+                .willReturn(List.of(MapEdgeGridCell.create(light.getRightEdge(), rightCell)));
+        given(cctvGridCellRepository.findAllByGridCell_IdIn(List.of(leftCell.getId())))
+                .willReturn(List.of(mapping(leftCctv, leftCell)));
+        given(cctvGridCellRepository.findAllByGridCell_IdIn(List.of(rightCell.getId())))
+                .willReturn(List.of(mapping(rightCctv, rightCell)));
+
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+
+        // 두 CCTV 모두 같은 5초 구간(capturedAt=7000 -> windowStart=2000)에 인원을 탐지한다.
+        given(observationRepository.findAllBySessionIdAndCctvCode(anyString(), anyString(), any(Integer.class)))
+                .willAnswer(invocation -> {
+                    String cctvCode = invocation.getArgument(1);
+                    if (cctvCode.equals("CCTV_LEFT")) {
+                        return List.of(observation("CCTV_LEFT", 3.0, 7_000L));
+                    }
+                    return List.of(observation("CCTV_RIGHT", 2.0, 7_000L));
+                });
+
+        // when
+        RouteDeviationResponse response = routeDeviationService.calculate(lightId, sessionId, EMAIL);
+
+        // then: 두 레코드가 같은 구간이므로 total은 1로만 집계되고, 반대쪽(RIGHT)도 탐지됐으므로 이탈로 판정한다.
+        assertThat(response.totalObservedWindows()).isEqualTo(1);
+        assertThat(response.deviatedWindows()).isEqualTo(1);
+        assertThat(response.deviationRate()).isEqualTo(1.0);
+    }
+
+    @Test
     @DisplayName("경로 안내가 설정되지 않은 유도등이면 예외가 발생한다")
     void calculate_guidanceNotConfigured_throws() {
         MapNode customNode = node("LIGHT_001", NodeType.CUSTOM);

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/LightDirectionEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/LightDirectionEventRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.saferoute.domain.device.entity.IoTLightDirection;
+import com.saferoute.domain.telemetry.dynamo.entity.LightDirectionEventItem;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+
+@ExtendWith(MockitoExtension.class)
+class LightDirectionEventRepositoryTest {
+
+    private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final UUID LIGHT_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
+
+    @Mock
+    private DynamoDbEnhancedClient enhancedClient;
+    @Mock
+    private DynamoDbTable<LightDirectionEventItem> table;
+
+    private LightDirectionEventRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        when(enhancedClient.table(eq("saferoute-telemetry"), any(TableSchema.class))).thenReturn(table);
+        repository = new LightDirectionEventRepository(enhancedClient, "saferoute-telemetry");
+    }
+
+    @Test
+    void 방향_전환_이력을_저장한다() {
+        LightDirectionEventItem item = item(IoTLightDirection.LEFT, 1_000L);
+
+        repository.save(item);
+
+        verify(table).putItem(item);
+    }
+
+    @Test
+    void 세션과_유도등의_방향_전환_이력을_시간순으로_조회한다() {
+        LightDirectionEventItem first = item(IoTLightDirection.LEFT, 1_000L);
+        LightDirectionEventItem second = item(IoTLightDirection.RIGHT, 2_000L);
+        when(table.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(LightDirectionEventItem.class)
+                        .items(List.of(first, second)).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        List<LightDirectionEventItem> result =
+                repository.findAllBySessionIdAndLightCode(SESSION_ID.toString(), "LIGHT_001");
+
+        verify(table).query(captor.capture());
+        assertThat(captor.getValue().scanIndexForward()).isTrue();
+        assertThat(captor.getValue().queryConditional()
+                .expression(TableSchema.fromBean(LightDirectionEventItem.class),
+                        software.amazon.awssdk.enhanced.dynamodb.TableMetadata.primaryIndexName())
+                .expressionValues().values())
+                .extracting(value -> value.s())
+                .contains("LIGHT_DIRECTION#" + SESSION_ID + "#LIGHT_001");
+        assertThat(result).containsExactly(first, second);
+    }
+
+    private LightDirectionEventItem item(IoTLightDirection direction, long changedAt) {
+        return LightDirectionEventItem.create(
+                SESSION_ID, LIGHT_ID, "LIGHT_001", direction,
+                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), changedAt
+        );
+    }
+}

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/LightDirectionEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/LightDirectionEventRepositoryTest.java
@@ -52,6 +52,21 @@ class LightDirectionEventRepositoryTest {
     }
 
     @Test
+    void 같은_밀리초에_전환된_두_이벤트는_서로_다른_정렬키로_모두_저장된다() {
+        LightDirectionEventItem first = item(IoTLightDirection.LEFT, 1_000L);
+        LightDirectionEventItem second = item(IoTLightDirection.RIGHT, 1_000L);
+
+        assertThat(first.getSk()).isNotEqualTo(second.getSk());
+        assertThat(first.getPk()).isEqualTo(second.getPk());
+
+        repository.save(first);
+        repository.save(second);
+
+        verify(table).putItem(first);
+        verify(table).putItem(second);
+    }
+
+    @Test
     void 세션과_유도등의_방향_전환_이력을_시간순으로_조회한다() {
         LightDirectionEventItem first = item(IoTLightDirection.LEFT, 1_000L);
         LightDirectionEventItem second = item(IoTLightDirection.RIGHT, 2_000L);

--- a/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
@@ -103,6 +103,33 @@ class SecurityAuthorizationIntegrationTest {
     }
 
     @Test
+    @DisplayName("일반 사용자는 경로 이탈률 조회 엔드포인트에 접근할 수 없다")
+    void normalUserCannotReadRouteDeviation() throws Exception {
+        String token = signupAndLogin(UserRole.NORMAL);
+
+        mockMvc.perform(
+                        get("/api/v1/lights/{lightId}/deviation", UUID.randomUUID())
+                                .param("trainingSessionId", UUID.randomUUID().toString())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("관리자는 경로 이탈률 조회 엔드포인트에 접근할 수 있다")
+    void managerCanReadRouteDeviation() throws Exception {
+        String token = signupAndLogin(UserRole.MANAGER);
+
+        mockMvc.perform(
+                        get("/api/v1/lights/{lightId}/deviation", UUID.randomUUID())
+                                .param("trainingSessionId", UUID.randomUUID().toString())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
     @DisplayName("관리자는 건물을 등록할 수 있다")
     void managerCanWrite() throws Exception {
         String token =


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #121
- Branch: feat/#121

## 주요 내용

- 유도등의 방향 전환 이력을 DynamoDB에 시계열로 기록하는 LightDirectionEventItem/LightDirectionEventRepository 추가 (기존엔 서버 메모리에만 현재 방향을 들고 있어 이력 조회가 불가능했음)
- IoTLightService.changeDirection()에서 유도등이 속한 건물의 RUNNING 훈련 세션을 찾아 방향 전환 시점을 위 이력에 로깅 (세션이 없으면 스킵, 로깅 실패가 유도등 명령 자체를 막지 않도록 예외 흡수)
- CCTV 관측값(ObservationItem)과 유도등 방향 이력을 시간 축으로 조인해 경로 이탈률을 계산하는 RouteDeviationService 추가, GET /api/v1/lights/{lightId}/deviation API로 노출
  - 좌/우 통로(leftEdge/rightEdge)를 각각 감시하는 CCTV를 Edge → GridCell → CCTV 역방향 조회로 식별
  - 5초 관측 구간 중 인원이 탐지된 구간(avgHeadcount > 0)마다 그 시각에 유도등이 안내하던 방향과 실제 탐지된 CCTV 쪽을 비교해 불일치 비율 산출
  - 좌/우 CCTV 매핑이 없는 유도등을 위한 에러 코드(IOTLIGHT009) 추가

### CodeRabbit 리뷰 반영

- GET /api/v1/lights/{lightId}/deviation을 관리자 전용(hasRole("MANAGER"))으로 제한 (기존엔 일반 GET 허용 규칙에 걸려 NORMAL 사용자도 접근 가능했음), NORMAL 403 / MANAGER 통과 검증 테스트 추가
- 경로 이탈률 계산 시 같은 5초 관측 구간(windowStart)에 좌/우 CCTV가 각각 별도 레코드로 보고하는 경우를 구간 단위로 먼저 합산한 뒤 판정하도록 수정 (기존엔 레코드 단위로 순회해 한 구간을 두 번 집계할 수 있었음). 양쪽 모두에서 인원이 탐지된 구간은 이탈로 집계하되 구간 자체는 한 번만 카운트하고, 회귀 테스트 추가
- LightDirectionEventItem 정렬키(sk)에 UUID tie-breaker 추가 (changedAt만 쓰면 같은 밀리초에 발생한 두 전환이 같은 키를 가져 뒤의 저장이 앞의 이력을 덮어쓸 수 있었음), 회귀 테스트 추가

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 유도등과 훈련 세션별 경로 이탈 건수 및 이탈률을 조회할 수 있습니다.
  - CCTV 관측 결과와 유도등 방향 전환 이력을 바탕으로 이탈률을 분석합니다.
  - 훈련 중 발생한 유도등 방향 전환 이력을 저장하고 시간순으로 확인할 수 있습니다.

- **개선 사항**
  - 훈련 세션이 없을 때 불필요한 이력 저장을 건너뜁니다.
  - 이력 저장에 실패해도 유도등 제어 명령은 정상적으로 처리됩니다.
  - CCTV 매핑이 누락된 경우 명확한 오류를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->