### PR TITLE
[FEAT] #120: 리포트 조회 URL을 짧은 id로 노출 및 리포트 단건 조회 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/report/controller/ReportController.java
+++ b/src/main/java/com/saferoute/domain/report/controller/ReportController.java
@@ -1,0 +1,29 @@
+package com.saferoute.domain.report.controller;
+
+import com.saferoute.domain.report.dto.ReportResponse;
+import com.saferoute.domain.report.service.TrainingReportService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "훈련 리포트", description = "훈련 리포트 단건 조회 API")
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+  private final TrainingReportService trainingReportService;
+
+  // reportId는 TrainingReport.shortId (URL 노출용 짧은 id)
+  @GetMapping("/{reportId}")
+  public ResponseEntity<ReportResponse> getReport(
+      @PathVariable String reportId,
+      Authentication authentication) {
+    return ResponseEntity.ok(trainingReportService.getReport(reportId, authentication.getName()));
+  }
+}

--- a/src/main/java/com/saferoute/domain/report/dto/ReportResponse.java
+++ b/src/main/java/com/saferoute/domain/report/dto/ReportResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ReportResponse {
+  private String reportId;
   private Grade grade;
   private BigDecimal survivalRate;
   private Integer avgEvacuationSec;
@@ -19,6 +20,7 @@ public class ReportResponse {
 
   public static ReportResponse from(TrainingReport report) {
     return ReportResponse.builder()
+        .reportId(report.getShortId())
         .grade(report.getGrade())
         .survivalRate(report.getSurvivalRate())
         .avgEvacuationSec(report.getAvgEvacuationSec())

--- a/src/main/java/com/saferoute/domain/report/entity/TrainingReport.java
+++ b/src/main/java/com/saferoute/domain/report/entity/TrainingReport.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.training.entity.TrainingSession;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -21,9 +22,19 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TrainingReport {
 
+    // URL에 노출되는 짧은 id. 62^10 조합이라 무작위 생성만으로도 충돌 가능성이 무시할 만큼 낮고,
+    // 별도 채번 테이블(CctvCodeAllocation) 없이 컬럼의 UNIQUE 제약을 최종 방어선으로 둔다.
+    private static final String SHORT_ID_ALPHABET =
+            "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final int SHORT_ID_LENGTH = 10;
+    private static final SecureRandom SHORT_ID_RANDOM = new SecureRandom();
+
     @Id
     @GeneratedValue
     private UUID id;
+
+    @Column(name = "short_id", nullable = false, updatable = false, unique = true, length = SHORT_ID_LENGTH)
+    private String shortId;
 
     //훈련 상태 (A, B 등)
     @NotNull
@@ -64,6 +75,7 @@ public class TrainingReport {
     private TrainingReport(Grade grade, BigDecimal survivalRate, Integer avgEvacuationSec,
                            Integer participantCount, Double riskIndex, String aiRecommendations,
                            String pdfUrl, TrainingSession trainingSession) {
+        this.shortId = generateShortId();
         this.grade = grade;
         this.survivalRate = survivalRate;
         this.avgEvacuationSec = avgEvacuationSec;
@@ -79,5 +91,13 @@ public class TrainingReport {
                                         String pdfUrl, TrainingSession trainingSession) {
         return new TrainingReport(grade, survivalRate, avgEvacuationSec, participantCount,
                 riskIndex, aiRecommendations, pdfUrl, trainingSession);
+    }
+
+    private static String generateShortId() {
+        StringBuilder builder = new StringBuilder(SHORT_ID_LENGTH);
+        for (int i = 0; i < SHORT_ID_LENGTH; i++) {
+            builder.append(SHORT_ID_ALPHABET.charAt(SHORT_ID_RANDOM.nextInt(SHORT_ID_ALPHABET.length())));
+        }
+        return builder.toString();
     }
 }

--- a/src/main/java/com/saferoute/domain/report/repository/TrainingReportRepository.java
+++ b/src/main/java/com/saferoute/domain/report/repository/TrainingReportRepository.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.report.repository;
 import com.saferoute.domain.report.entity.TrainingReport;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,9 +13,9 @@ import org.springframework.data.repository.query.Param;
 public interface TrainingReportRepository extends JpaRepository<TrainingReport, UUID> {
 
   // 목록 조회에서 시나리오별 리포트 존재 여부/id를 N+1 없이 계산하기 위해,
-  // 시나리오당 세션이 1개뿐이라는 전제로 시나리오 id -> 리포트 id를 바로 매핑한다.
+  // 시나리오당 세션이 1개뿐이라는 전제로 시나리오 id -> 리포트 shortId를 바로 매핑한다.
   @Query("""
-      select tr.trainingSession.scenario.id as scenarioId, tr.id as reportId
+      select tr.trainingSession.scenario.id as scenarioId, tr.shortId as reportId
       from TrainingReport tr
       where tr.trainingSession.scenario.id in :scenarioIds
       """)
@@ -22,8 +23,12 @@ public interface TrainingReportRepository extends JpaRepository<TrainingReport, 
 
   interface ScenarioReportId {
     UUID getScenarioId();
-    UUID getReportId();
+    String getReportId();
   }
+
+  // 리포트 단건 조회 URL(shortId)로 조회하되, 기관 소속이 다른 리포트는 보이지 않도록 제한한다.
+  Optional<TrainingReport> findByShortIdAndTrainingSession_Scenario_Building_SchoolName(
+      String shortId, String schoolName);
 
   @Query("""
       select tr

--- a/src/main/java/com/saferoute/domain/report/service/TrainingReportService.java
+++ b/src/main/java/com/saferoute/domain/report/service/TrainingReportService.java
@@ -9,6 +9,8 @@ import com.saferoute.domain.report.repository.TrainingReportRepository;
 import com.saferoute.domain.report.dto.CreateReportRequest;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.ReportErrorCode;
+import com.saferoute.global.api.exception.ApiException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -37,6 +39,14 @@ public class TrainingReportService {
         request.getPdfUrl(),
         session);
     return ReportResponse.from(trainingReportRepository.save(report));
+  }
+
+  public ReportResponse getReport(String reportId, String email) {
+    String schoolName = schoolContextService.getSchoolName(email);
+    TrainingReport report = trainingReportRepository
+        .findByShortIdAndTrainingSession_Scenario_Building_SchoolName(reportId, schoolName)
+        .orElseThrow(() -> new ApiException(ReportErrorCode.REPORT_NOT_FOUND));
+    return ReportResponse.from(report);
   }
 
   public List<RecentTrainingReportResponse> getRecentTrainingReport(String email) {

--- a/src/main/java/com/saferoute/domain/training/dto/ScenarioResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/ScenarioResponse.java
@@ -23,8 +23,8 @@ public class ScenarioResponse {
     private ScenarioStatus status;
     // 훈련 세션이 하나도 없는 시나리오만 삭제 가능. 단건 조회에선 항상 null (목록 조회 전용 필드).
     private Boolean deletable;
-    // 이 시나리오의 훈련 리포트 id. 리포트가 아직 없으면 null (목록 조회 전용 필드).
-    private UUID reportId;
+    // 이 시나리오의 훈련 리포트 id(TrainingReport.shortId). 리포트가 아직 없으면 null (목록 조회 전용 필드).
+    private String reportId;
     private Instant createdAt;
     private Instant updatedAt;
 
@@ -32,7 +32,7 @@ public class ScenarioResponse {
         return from(scenario, null, null);
     }
 
-    public static ScenarioResponse from(TrainingScenario scenario, Boolean deletable, UUID reportId) {
+    public static ScenarioResponse from(TrainingScenario scenario, Boolean deletable, String reportId) {
         return ScenarioResponse.builder()
                 .id(scenario.getId())
                 .name(scenario.getName())

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -48,7 +48,7 @@ public class TrainingScenarioService {
 
         List<UUID> scenarioIds = scenarios.stream().map(TrainingScenario::getId).toList();
         Set<UUID> scenarioIdsWithSession = trainingSessionRepository.findScenarioIdsWithAnySession(scenarioIds);
-        Map<UUID, UUID> reportIdsByScenarioId = trainingReportRepository.findReportIdsByScenarioIds(scenarioIds)
+        Map<UUID, String> reportIdsByScenarioId = trainingReportRepository.findReportIdsByScenarioIds(scenarioIds)
                 .stream()
                 .collect(Collectors.toMap(
                         TrainingReportRepository.ScenarioReportId::getScenarioId,

--- a/src/main/java/com/saferoute/global/api/error/ReportErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/ReportErrorCode.java
@@ -1,0 +1,17 @@
+package com.saferoute.global.api.error;
+
+import com.saferoute.global.api.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportErrorCode implements BaseErrorCode {
+
+  REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT001", "훈련 리포트를 찾을 수 없습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}

--- a/src/test/java/com/saferoute/domain/report/service/TrainingReportServiceTest.java
+++ b/src/test/java/com/saferoute/domain/report/service/TrainingReportServiceTest.java
@@ -1,13 +1,20 @@
 package com.saferoute.domain.report.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.saferoute.domain.report.entity.TrainingReport;
 import com.saferoute.domain.report.repository.TrainingReportRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.ReportErrorCode;
+import com.saferoute.global.api.exception.ApiException;
 import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,6 +38,37 @@ class TrainingReportServiceTest {
 
     @Mock
     private SchoolContextService schoolContextService;
+
+    @Test
+    @DisplayName("shortId와 기관이 일치하는 리포트를 조회할 수 있다")
+    void getReport_matchingShortIdAndSchool_returnsReport() {
+        String reportId = "abc123XYZ0";
+        TrainingReport report = mock(TrainingReport.class);
+        given(report.getShortId()).willReturn(reportId);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(trainingReportRepository
+                .findByShortIdAndTrainingSession_Scenario_Building_SchoolName(reportId, SCHOOL_NAME))
+                .willReturn(Optional.of(report));
+
+        var response = trainingReportService.getReport(reportId, EMAIL);
+
+        assertThat(response.getReportId()).isEqualTo(reportId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않거나 다른 기관의 shortId로 조회하면 예외가 발생한다")
+    void getReport_notFound_throwsException() {
+        String reportId = "abc123XYZ0";
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(trainingReportRepository
+                .findByShortIdAndTrainingSession_Scenario_Building_SchoolName(reportId, SCHOOL_NAME))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> trainingReportService.getReport(reportId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(ReportErrorCode.REPORT_NOT_FOUND);
+    }
 
     @Test
     void calculatesDashboardStatsOnlyForAuthenticatedUsersSchool() {

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -117,7 +117,7 @@ class TrainingScenarioServiceTest {
     @DisplayName("리포트가 생성된 시나리오는 목록에서 reportId를 함께 응답한다")
     void getScenarios_scenarioWithReport_returnsReportId() {
         UUID scenarioId = UUID.randomUUID();
-        UUID reportId = UUID.randomUUID();
+        String reportId = "abc123XYZ0";
         TrainingScenario scenario = scenarioWithId(scenarioId);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
         given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
@@ -152,7 +152,7 @@ class TrainingScenarioServiceTest {
         assertThat(responses.get(0).getReportId()).isNull();
     }
 
-    private TrainingReportRepository.ScenarioReportId scenarioReportId(UUID scenarioId, UUID reportId) {
+    private TrainingReportRepository.ScenarioReportId scenarioReportId(UUID scenarioId, String reportId) {
         return new TrainingReportRepository.ScenarioReportId() {
             @Override
             public UUID getScenarioId() {
@@ -160,7 +160,7 @@ class TrainingScenarioServiceTest {
             }
 
             @Override
-            public UUID getReportId() {
+            public String getReportId() {
                 return reportId;
             }
         };


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #120
- Branch: feat/#120

## 배경

- 프론트에서 보고서 페이지 URL에 id를 노출해야 하는데, 현재 UUID(`3fa85f64-5717-4562-b3fc-2c963f66afa6` 형태)가 URL에 쓰기엔 너무 길다는 요청이 들어옴.
- 줄여야 할 대상은 시나리오가 아니라 `TrainingReport.id` — "보고서 페이지"라는 용도를 감안하면 자연스러운 리소스는 `/reports/{reportId}`.
- 리포트 단건 조회 GET API 추가


## 주요 내용

### 1. `TrainingReport`에 URL 노출용 shortId 컬럼 추가
- PK/FK는 그대로 UUID 유지 (PK를 바꾸면 `TrainingSession`과의 FK까지 건드려야 해서 대공사가 됨)
- 62자 알파벳(0-9A-Za-z) 10자리 무작위 생성, DB `UNIQUE` 제약을 최종 방어선으로 둠
- 별도 채번 테이블(`CctvCodeAllocation`류) 없이 무작위 생성만으로 충분 — 62^10 조합이라 충돌 확률이 무시할 만큼 낮음

### 2. 리포트 단건 조회 API 추가
- `ReportErrorCode.REPORT_NOT_FOUND` 추가
- `TrainingReportRepository`에 shortId + 기관 기준 조회 메서드 추가
- `TrainingReportService.getReport()` — 기관 소속 검증 포함
- `GET /api/v1/reports/{reportId}` 신규 엔드포인트 (`ReportController` — 기존 `TrainingReportController`는 `/api/v1/analysis/trainings` 하위라 원하는 경로가 안 나와서 별도 클래스로 분리)
- `ReportResponse`에 `reportId`(shortId) 필드 추가

### 3. 시나리오 목록 API의 reportId를 shortId 기준으로 전환
- `TrainingReportRepository.findReportIdsByScenarioIds`가 `tr.id` 대신 `tr.shortId`를 선택하도록 변경
- `ScenarioResponse.reportId` 타입을 `UUID` → `String`으로 변경
- 프론트가 목록에서 받은 `reportId`를 그대로 `GET /api/v1/reports/{reportId}` 호출에 쓸 수 있음

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 훈련 리포트를 전용 식별자로 단건 조회할 수 있습니다.
  - 조회 결과에 리포트 식별자가 표시됩니다.
  - 시나리오 목록에서 연결된 리포트를 일관된 식별자로 확인할 수 있습니다.
  - 리포트 식별자는 안전하게 생성되며 URL에 사용할 수 있습니다.

- **오류 처리**
  - 소속 범위에 맞는 리포트가 없을 경우 명확한 리포트 미존재 오류를 제공합니다.

- **테스트**
  - 리포트 조회 성공 및 미존재 상황에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->