### PR TITLE
fix(dashboard): 대시보드 API 공통 응답 포맷 적용 - #124

### DIFF
--- a/src/main/java/com/saferoute/domain/dashboard/DashboardController.java
+++ b/src/main/java/com/saferoute/domain/dashboard/DashboardController.java
@@ -5,11 +5,11 @@ import com.saferoute.domain.report.dto.RecentTrainingReportResponse;
 import com.saferoute.domain.training.dto.TrainingStatusResponse;
 import com.saferoute.domain.report.service.TrainingReportService;
 import com.saferoute.domain.training.service.TrainingSessionService;
+import com.saferoute.global.api.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,27 +27,29 @@ public class DashboardController {
   private final TrainingSessionService trainingSessionService;
 
   @GetMapping("/trainings")
-  public ResponseEntity<List<RecentTrainingReportResponse>> getRecentReports(
+  public ResponseEntity<ApiResponse<List<RecentTrainingReportResponse>>> getRecentReports(
       Authentication authentication
   ) {
     List<RecentTrainingReportResponse> response =
         trainingReportService.getRecentTrainingReport(authentication.getName());
-    return ResponseEntity.status(HttpStatus.OK).body(response);
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 
   @GetMapping("/stats")
-  public ResponseEntity<DashboardStatsResponse> getStats(
+  public ResponseEntity<ApiResponse<DashboardStatsResponse>> getStats(
       Authentication authentication
   ) {
     DashboardStatsResponse response = trainingReportService.getStats(authentication.getName());
-    return ResponseEntity.status(HttpStatus.OK).body(response);
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 
   @GetMapping("/training-status/{sessionId}")
-  public ResponseEntity<TrainingStatusResponse> getTrainingStatus(
+  public ResponseEntity<ApiResponse<TrainingStatusResponse>> getTrainingStatus(
       @PathVariable UUID sessionId,
       Authentication authentication) {
-    return ResponseEntity.ok(trainingSessionService.getTrainingStatus(sessionId, authentication.getName()));
+    TrainingStatusResponse response =
+        trainingSessionService.getTrainingStatus(sessionId, authentication.getName());
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #124 
- Branch: bug/#124

## 주요 내용

DashboardController의 세 엔드포인트가 다른 API와 달리 ApiResponse로
감싸지지 않고 응답을 그대로 반환하고 있어 공통 포맷에 맞춰 통일

- GET /api/dashboard/trainings
- GET /api/dashboard/stats
- GET /api/dashboard/training-status/{sessionId}

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?