### PR TITLE
[FEAT] #126: 세션/CCTV별 최신 모니터링 관측 조회 기능 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.telemetry.dynamo.entity;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import java.util.Locale;
 import java.util.UUID;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
@@ -14,6 +15,7 @@ public class ObservationItem {
 
     public static final String GSI1_NAME = "GSI1";
     public static final long TTL_SECONDS = 30L * 24 * 60 * 60;
+    private static final int GSI1_TIMESTAMP_WIDTH = 19;
 
     private String pk;
     private String sk;
@@ -97,7 +99,11 @@ public class ObservationItem {
     }
 
     public static String buildGsi1Sk(long capturedAt) {
-        return "TIME#" + capturedAt;
+        return "TIME#" + String.format(
+                Locale.ROOT,
+                "%0" + GSI1_TIMESTAMP_WIDTH + "d",
+                capturedAt
+        );
     }
 
     @DynamoDbPartitionKey

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
@@ -71,6 +71,23 @@ public class ObservationRepository {
         return Optional.ofNullable(table.getItem(request));
     }
 
+    public Optional<ObservationItem> findLatestBySessionIdAndCctvCode(
+            String trainingSessionId,
+            String cctvCode
+    ) {
+        QueryEnhancedRequest request = QueryEnhancedRequest.builder()
+                .queryConditional(QueryConditional.keyEqualTo(Key.builder()
+                        .partitionValue(ObservationItem.buildGsi1Pk(trainingSessionId, cctvCode))
+                        .build()))
+                .scanIndexForward(false)
+                .limit(1)
+                .build();
+
+        return gsi1.query(request).stream()
+                .flatMap(page -> page.items().stream())
+                .findFirst();
+    }
+
     public boolean claimProcessing(
             String eventId,
             String processingOwner,

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
@@ -38,7 +38,7 @@ class TelemetryItemTest {
         assertThat(item.getSk()).isEqualTo("META");
         assertThat(item.getEdgeId()).isEqualTo(EDGE_ID.toString());
         assertThat(item.getGsi1Pk()).isEqualTo("SESSION#" + SESSION_ID + "#CCTV#CCTV_001");
-        assertThat(item.getGsi1Sk()).isEqualTo("TIME#1786500005000");
+        assertThat(item.getGsi1Sk()).isEqualTo("TIME#0000001786500005000");
         assertThat(item.getEventStatus()).isEqualTo(EventProcessingStatus.RECEIVED);
         assertThat(item.getImageUploadStatus()).isEqualTo(ImageUploadStatus.PENDING);
     }
@@ -63,7 +63,17 @@ class TelemetryItemTest {
         assertThat(attributes.get("edgeId").s()).isEqualTo(EDGE_ID.toString());
         assertThat(attributes)
                 .containsEntry("GSI1_PK", AttributeValue.fromS("SESSION#" + SESSION_ID + "#CCTV#CCTV_001"))
-                .containsEntry("GSI1_SK", AttributeValue.fromS("TIME#1786500005000"));
+                .containsEntry("GSI1_SK", AttributeValue.fromS("TIME#0000001786500005000"));
+    }
+
+    @Test
+    void 관측값의_GSI_시간키는_자릿수_경계에서도_시간순으로_정렬된다() {
+        String beforeBoundary = ObservationItem.buildGsi1Sk(999L);
+        String afterBoundary = ObservationItem.buildGsi1Sk(1_000L);
+
+        assertThat(beforeBoundary).isEqualTo("TIME#0000000000000000999");
+        assertThat(afterBoundary).isEqualTo("TIME#0000000000000001000");
+        assertThat(afterBoundary).isGreaterThan(beforeBoundary);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepositoryTest.java
@@ -106,6 +106,46 @@ class ObservationRepositoryTest {
     }
 
     @Test
+    void 세션과_CCTV의_최신_관측값을_GSI에서_한_건_조회한다() {
+        ObservationItem latest = item("observation-latest", 2_000L);
+        ObservationItem older = item("observation-older", 1_000L);
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(ObservationItem.class)
+                        .items(List.of(latest, older)).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        var result = repository.findLatestBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001"
+        );
+
+        verify(gsi1).query(captor.capture());
+        QueryEnhancedRequest request = captor.getValue();
+        assertThat(request.scanIndexForward()).isFalse();
+        assertThat(request.limit()).isEqualTo(1);
+        assertThat(request.queryConditional()
+                .expression(TableSchema.fromBean(ObservationItem.class), ObservationItem.GSI1_NAME)
+                .expressionValues().values())
+                .extracting(value -> value.s())
+                .containsExactly("SESSION#" + SESSION_ID + "#CCTV#CCTV_001");
+        assertThat(result).contains(latest);
+    }
+
+    @Test
+    void 세션과_CCTV의_관측값이_없으면_empty를_반환한다() {
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(ObservationItem.class)
+                        .items(List.of()).build()).iterator())
+        );
+
+        var result = repository.findLatestBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001"
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
     void 조회_limit은_양수여야_한다() {
         assertThatThrownBy(() -> repository.findAllBySessionIdAndCctvCode(
                 SESSION_ID.toString(), "CCTV_001", 0


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #126
- Branch: `feat/#126`

## 주요 내용

- 훈련 세션과 CCTV 코드를 기준으로 최신 관측값 1건을 조회하는 Repository 메서드를 추가했습니다.
- `GSI1_PK`의 `SESSION#{trainingSessionId}#CCTV#{cctvCode}` 파티션을 사용합니다.
- `capturedAt` 기반 최신순 조회를 위해 `scanIndexForward(false)`를 적용했습니다.
- 최신 관측값 1건만 조회하도록 `limit(1)`을 적용했습니다.
- 조회 결과가 없으면 예외 대신 `Optional.empty()`를 반환합니다.
- 최신 관측 조회의 GSI 조건, 정렬 방향, 조회 개수 및 빈 결과 처리를 검증하는 테스트를 추가했습니다.
- 기존 다건 조회 메서드의 동작은 변경하지 않았습니다.

## ✅ Check List

- [x] 테스트 통과
- [x] `./gradlew build` 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 세션 ID와 CCTV 코드로 최신 관측값을 조회할 수 있습니다.
  * 조회 결과가 없을 경우 빈 결과를 반환합니다.

* **테스트**
  * 최신 관측값 조회 및 결과 없음 처리에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->