### PR TITLE
[FEAT] #128: 훈련 세션별 카메라 최신 캡처 목록 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -14,9 +14,11 @@ import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTrigger
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
+import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
+import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -48,6 +50,7 @@ public class CongestionObservationService {
     static final Duration PROCESSING_LEASE = Duration.ofMinutes(1);
 
     private final ObservationRepository observationRepository;
+    private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final CurrentCctvStateRepository currentCctvStateRepository;
     private final TrainingSessionRepository trainingSessionRepository;
     private final CctvGridCellRepository cctvGridCellRepository;
@@ -95,6 +98,7 @@ public class CongestionObservationService {
 
         IdempotentSaveResult<ObservationItem> saveResult = observationRepository.saveIfAbsent(item);
         validateEventIdentity(saveResult.item(), request, session.getId());
+        updateLatestMonitoringCapture(session.getId(), cctv.getCode(), request);
 
         String processingOwner = UUID.randomUUID().toString();
         long processingStartedAt = Instant.now().toEpochMilli();
@@ -164,6 +168,22 @@ public class CongestionObservationService {
         // 오래된 관측값이 최신 상태를 덮어쓰지 않도록 조건부 갱신 (lastDetectedAt 기준). 실패해도 관측값 저장 자체는 유지한다.
         if (!currentCctvStateRepository.updateIfLatest(stateItem)) {
             log.debug("더 최신 상태가 있어 CCTV 현재 상태 갱신을 건너뜀: cctvCode={}", cctvCode);
+        }
+    }
+
+    private void updateLatestMonitoringCapture(
+            UUID sessionId,
+            String cctvCode,
+            ReportObservationRequest request
+    ) {
+        LatestMonitoringCaptureItem capture = LatestMonitoringCaptureItem.create(
+                sessionId,
+                cctvCode,
+                request.capturedAt(),
+                request.monitoringImageKey()
+        );
+        if (!latestMonitoringCaptureRepository.updateIfLatest(capture)) {
+            log.debug("더 최신 캡처가 있어 모니터링 포인터 갱신을 건너뜀: cctvCode={}", cctvCode);
         }
     }
 

--- a/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
@@ -25,6 +25,10 @@ public interface CctvJpaRepository extends JpaRepository<Cctv, UUID> {
     List<Cctv> findAllByCustomNode_Floor_IdAndCustomNode_Floor_Building_SchoolName(
             UUID floorId, String schoolName);
 
+    @EntityGraph(attributePaths = {"customNode", "customNode.floor", "customNode.floor.building"})
+    List<Cctv> findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+            UUID buildingId);
+
     @EntityGraph(attributePaths = {"customNode", "customNode.floor"})
     @Query("select cctv from Cctv cctv where cctv.id = :cctvId")
     Optional<Cctv> findByIdWithLocation(@Param("cctvId") UUID cctvId);

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/LatestMonitoringCaptureItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/LatestMonitoringCaptureItem.java
@@ -1,0 +1,104 @@
+package com.saferoute.domain.telemetry.dynamo.entity;
+
+import java.util.UUID;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+@DynamoDbBean
+public class LatestMonitoringCaptureItem {
+
+    private String pk;
+    private String sk;
+    private String trainingSessionId;
+    private String cctvCode;
+    private Long capturedAt;
+    private String monitoringImageKey;
+    private Long expiresAt;
+
+    public LatestMonitoringCaptureItem() {
+    }
+
+    public static LatestMonitoringCaptureItem create(
+            UUID trainingSessionId,
+            String cctvCode,
+            long capturedAt,
+            String monitoringImageKey
+    ) {
+        LatestMonitoringCaptureItem item = new LatestMonitoringCaptureItem();
+        item.trainingSessionId = trainingSessionId.toString();
+        item.cctvCode = cctvCode;
+        item.capturedAt = capturedAt;
+        item.monitoringImageKey = monitoringImageKey;
+        item.expiresAt = Math.floorDiv(capturedAt, 1_000L) + ObservationItem.TTL_SECONDS;
+        item.pk = buildPk(item.trainingSessionId);
+        item.sk = buildSk(cctvCode);
+        return item;
+    }
+
+    public static String buildPk(String trainingSessionId) {
+        return "LATEST_MONITORING#" + trainingSessionId;
+    }
+
+    public static String buildSk(String cctvCode) {
+        return "CCTV#" + cctvCode;
+    }
+
+    @DynamoDbPartitionKey
+    public String getPk() {
+        return pk;
+    }
+
+    public void setPk(String pk) {
+        this.pk = pk;
+    }
+
+    @DynamoDbSortKey
+    public String getSk() {
+        return sk;
+    }
+
+    public void setSk(String sk) {
+        this.sk = sk;
+    }
+
+    public String getTrainingSessionId() {
+        return trainingSessionId;
+    }
+
+    public void setTrainingSessionId(String trainingSessionId) {
+        this.trainingSessionId = trainingSessionId;
+    }
+
+    public String getCctvCode() {
+        return cctvCode;
+    }
+
+    public void setCctvCode(String cctvCode) {
+        this.cctvCode = cctvCode;
+    }
+
+    public Long getCapturedAt() {
+        return capturedAt;
+    }
+
+    public void setCapturedAt(Long capturedAt) {
+        this.capturedAt = capturedAt;
+    }
+
+    public String getMonitoringImageKey() {
+        return monitoringImageKey;
+    }
+
+    public void setMonitoringImageKey(String monitoringImageKey) {
+        this.monitoringImageKey = monitoringImageKey;
+    }
+
+    public Long getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Long expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/LatestMonitoringCaptureRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/LatestMonitoringCaptureRepository.java
@@ -1,0 +1,65 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+
+@Repository
+public class LatestMonitoringCaptureRepository {
+
+    private final DynamoDbTable<LatestMonitoringCaptureItem> table;
+
+    public LatestMonitoringCaptureRepository(
+            DynamoDbEnhancedClient enhancedClient,
+            @Value("${aws.dynamodb.table-name}") String tableName
+    ) {
+        this.table = enhancedClient.table(
+                tableName,
+                TableSchema.fromBean(LatestMonitoringCaptureItem.class)
+        );
+    }
+
+    public boolean updateIfLatest(LatestMonitoringCaptureItem incoming) {
+        Expression condition = Expression.builder()
+                .expression("attribute_not_exists(#capturedAt) OR :incomingCapturedAt >= #capturedAt")
+                .putExpressionName("#capturedAt", "capturedAt")
+                .putExpressionValue(
+                        ":incomingCapturedAt",
+                        AttributeValue.fromN(Long.toString(incoming.getCapturedAt()))
+                )
+                .build();
+        PutItemEnhancedRequest<LatestMonitoringCaptureItem> request =
+                PutItemEnhancedRequest.builder(LatestMonitoringCaptureItem.class)
+                        .item(incoming)
+                        .conditionExpression(condition)
+                        .build();
+
+        try {
+            table.putItem(request);
+            return true;
+        } catch (ConditionalCheckFailedException exception) {
+            return false;
+        }
+    }
+
+    public List<LatestMonitoringCaptureItem> findAllBySessionId(String trainingSessionId) {
+        QueryEnhancedRequest request = QueryEnhancedRequest.builder()
+                .queryConditional(QueryConditional.keyEqualTo(Key.builder()
+                        .partitionValue(LatestMonitoringCaptureItem.buildPk(trainingSessionId))
+                        .build()))
+                .scanIndexForward(true)
+                .build();
+        return table.query(request).items().stream().toList();
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -1,5 +1,6 @@
 package com.saferoute.domain.training.controller;
 
+import com.saferoute.domain.training.dto.MonitoringCameraListApiResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.service.TrainingMonitoringService;
 import com.saferoute.global.api.response.ApiResponse;
@@ -55,6 +56,9 @@ public class TrainingMonitoringController {
                     description = "모니터링 카메라 목록 조회 성공",
                     content = @Content(
                             mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    implementation = MonitoringCameraListApiResponse.class
+                            ),
                             examples = {
                                     @ExampleObject(
                                             name = "최신 캡처가 있는 카메라",

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -179,8 +179,8 @@ public class TrainingMonitoringController {
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": false,
-                                      "code": "S3_ERROR_003",
-                                      "message": "S3 업로드 URL 발급에 실패했습니다."
+                                      "code": "S3_ERROR_005",
+                                      "message": "S3 이미지 조회 URL 발급에 실패했습니다."
                                     }
                                     """)
                     )

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -1,0 +1,202 @@
+package com.saferoute.domain.training.controller;
+
+import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.service.TrainingMonitoringService;
+import com.saferoute.global.api.response.ApiResponse;
+import com.saferoute.global.api.response.TrainingSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "훈련 모니터링",
+        description = "실행 중인 훈련의 카메라별 최신 주기 캡처 조회 API"
+)
+@RestController
+@RequestMapping("/api/v1/sessions/{sessionId}/monitoring")
+@RequiredArgsConstructor
+public class TrainingMonitoringController {
+
+    private final TrainingMonitoringService trainingMonitoringService;
+
+    @Operation(
+            summary = "카메라별 최신 캡처 목록 조회",
+            description = """
+                    실행 중인 훈련 세션의 건물에 설치된 활성 CCTV 카드 목록을 반환합니다.
+
+                    각 카메라의 thumbnailUrl은 최신 Observation의 monitoringImageKey로 발급한
+                    S3 presigned GET URL이며 영구 URL이 아닙니다. capturedAt과 urlExpiresAt은 모두
+                    Unix epoch milliseconds 단위입니다.
+
+                    아직 캡처가 없는 카메라도 목록에 포함되며 thumbnailUrl, capturedAt,
+                    urlExpiresAt이 모두 null로 반환됩니다. 클라이언트는 이 경우 placeholder를
+                    표시해야 합니다. 'n초 전 캡처'와 같은 상대 시간은 capturedAt을 기준으로
+                    클라이언트에서 계산합니다.
+
+                    목록은 층 번호 오름차순, 같은 층에서는 CCTV 코드 오름차순으로 정렬됩니다.
+                    비활성 CCTV는 반환하지 않습니다. 최신 상태가 필요하면 화면에서 주기적으로
+                    이 API를 다시 호출해 주세요.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "모니터링 카메라 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "최신 캡처가 있는 카메라",
+                                            value = """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "TRAINING_SUCCESS_006",
+                                                      "message": "모니터링 카메라 목록 조회에 성공했습니다.",
+                                                      "result": {
+                                                        "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                                        "cameras": [
+                                                          {
+                                                            "cctvId": "67b86e33-7874-494c-855f-e591e7847c09",
+                                                            "code": "CCTV_001",
+                                                            "name": "CAM-1",
+                                                            "buildingName": "A동",
+                                                            "floorName": "3층",
+                                                            "location": "A동 3층",
+                                                            "thumbnailUrl": "https://example-bucket.s3.amazonaws.com/training/session/monitoring/CCTV_001/frame.jpg",
+                                                            "capturedAt": 1787722095000,
+                                                            "urlExpiresAt": 1787725695000
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "캡처가 없는 카메라",
+                                            value = """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "TRAINING_SUCCESS_006",
+                                                      "message": "모니터링 카메라 목록 조회에 성공했습니다.",
+                                                      "result": {
+                                                        "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                                        "cameras": [
+                                                          {
+                                                            "cctvId": "8b767966-b423-4d1b-bc2a-4107de97ad72",
+                                                            "code": "CCTV_002",
+                                                            "name": "CAM-2",
+                                                            "buildingName": "A동",
+                                                            "floorName": "1층",
+                                                            "location": "A동 1층",
+                                                            "thumbnailUrl": null,
+                                                            "capturedAt": null,
+                                                            "urlExpiresAt": null
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "JWT가 없거나 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "MANAGER 권한이 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON403",
+                                      "message": "접근 권한이 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "세션이 없거나 요청자와 다른 학교의 세션",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING001",
+                                      "message": "훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "훈련 세션이 RUNNING 상태가 아님",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING006",
+                                      "message": "진행 중인 훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "S3 presigned GET URL 발급 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "S3_ERROR_003",
+                                      "message": "S3 업로드 URL 발급에 실패했습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    @GetMapping("/cameras")
+    public ResponseEntity<ApiResponse<MonitoringCameraListResponse>> getCameras(
+            @Parameter(
+                    description = "조회할 RUNNING 훈련 세션의 UUID",
+                    required = true,
+                    example = "d669294e-55e1-4c00-bf67-229d89b76948"
+            )
+            @PathVariable UUID sessionId,
+            Authentication authentication
+    ) {
+        MonitoringCameraListResponse response =
+                trainingMonitoringService.getCameras(sessionId, authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success(
+                TrainingSuccessCode.MONITORING_CAMERA_LIST_FOUND,
+                response
+        ));
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringCameraListApiResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringCameraListApiResponse.java
@@ -1,0 +1,22 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "MonitoringCameraListApiResponse",
+        description = "카메라별 최신 캡처 목록의 공통 API 응답 스키마"
+)
+public record MonitoringCameraListApiResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean isSuccess,
+
+        @Schema(description = "응답 코드", example = "TRAINING_SUCCESS_006")
+        String code,
+
+        @Schema(description = "응답 메시지", example = "모니터링 카메라 목록 조회에 성공했습니다.")
+        String message,
+
+        @Schema(description = "카메라별 최신 캡처 목록")
+        MonitoringCameraListResponse result
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringCameraListResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringCameraListResponse.java
@@ -1,0 +1,19 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "훈련 세션의 모니터링 카메라 목록")
+public record MonitoringCameraListResponse(
+        @Schema(description = "조회한 훈련 세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
+        UUID sessionId,
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "활성 CCTV 카드 목록. CCTV가 없으면 빈 배열"),
+                schema = @Schema(implementation = MonitoringCameraResponse.class)
+        )
+        List<MonitoringCameraResponse> cameras
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringCameraResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringCameraResponse.java
@@ -1,0 +1,101 @@
+package com.saferoute.domain.training.dto;
+
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "훈련 모니터링 화면의 카메라 카드")
+public record MonitoringCameraResponse(
+        @Schema(description = "CCTV ID", example = "67b86e33-7874-494c-855f-e591e7847c09")
+        UUID cctvId,
+
+        @Schema(description = "CCTV 고유 코드", example = "CCTV_001")
+        String code,
+
+        @Schema(description = "관리자가 지정한 CCTV 이름", example = "CAM-1")
+        String name,
+
+        @Schema(description = "CCTV가 설치된 건물명", example = "A동")
+        String buildingName,
+
+        @Schema(description = "화면 표시용 층 이름", example = "3층")
+        String floorName,
+
+        @Schema(description = "건물명과 층 이름을 조합한 표시 위치", example = "A동 3층")
+        String location,
+
+        @Schema(
+                description = "최신 캡처 이미지의 S3 presigned GET URL. 캡처가 없으면 null",
+                example = "https://example-bucket.s3.amazonaws.com/training/session/monitoring/CCTV_001/frame.jpg",
+                nullable = true
+        )
+        String thumbnailUrl,
+
+        @Schema(
+                description = "최신 프레임 캡처 시각(Unix epoch milliseconds). 캡처가 없으면 null",
+                example = "1787722095000",
+                nullable = true
+        )
+        Long capturedAt,
+
+        @Schema(
+                description = "thumbnailUrl 만료 시각(Unix epoch milliseconds). 캡처가 없으면 null",
+                example = "1787725695000",
+                nullable = true
+        )
+        Long urlExpiresAt
+) {
+
+    public static MonitoringCameraResponse withoutCapture(Cctv cctv) {
+        Location location = Location.from(cctv);
+        return new MonitoringCameraResponse(
+                cctv.getId(),
+                cctv.getCode(),
+                cctv.getName(),
+                location.buildingName(),
+                location.floorName(),
+                location.displayName(),
+                null,
+                null,
+                null
+        );
+    }
+
+    public static MonitoringCameraResponse withCapture(
+            Cctv cctv,
+            long capturedAt,
+            PresignedGetUrl presignedGetUrl
+    ) {
+        Location location = Location.from(cctv);
+        return new MonitoringCameraResponse(
+                cctv.getId(),
+                cctv.getCode(),
+                cctv.getName(),
+                location.buildingName(),
+                location.floorName(),
+                location.displayName(),
+                presignedGetUrl.viewUrl(),
+                capturedAt,
+                presignedGetUrl.expiresAt().toEpochMilli()
+        );
+    }
+
+    private record Location(String buildingName, String floorName, String displayName) {
+
+        private static Location from(Cctv cctv) {
+            Floor floor = cctv.getCustomNode().getFloor();
+            String buildingName = floor.getBuilding().getName();
+            String floorName = formatFloorName(floor.getFloorNum());
+            return new Location(buildingName, floorName, buildingName + " " + floorName);
+        }
+
+        private static String formatFloorName(int floorNum) {
+            if (floorNum < 0) {
+                return "지하 " + Math.abs((long) floorNum) + "층";
+            }
+            return floorNum + "층";
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -1,0 +1,80 @@
+package com.saferoute.domain.training.service;
+
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TrainingMonitoringService {
+
+    private final TrainingSessionRepository trainingSessionRepository;
+    private final CctvJpaRepository cctvJpaRepository;
+    private final ObservationRepository observationRepository;
+    private final S3PresignedUrlService s3PresignedUrlService;
+    private final SchoolContextService schoolContextService;
+
+    public MonitoringCameraListResponse getCameras(UUID sessionId, String email) {
+        TrainingSession session = findRunningSessionForSchool(sessionId, email);
+        UUID buildingId = session.getScenario().getBuilding().getId();
+        List<Cctv> cctvs = cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        buildingId);
+
+        List<MonitoringCameraResponse> cameras = cctvs.stream()
+                .map(cctv -> toResponse(sessionId, cctv))
+                .toList();
+        return new MonitoringCameraListResponse(sessionId, cameras);
+    }
+
+    private TrainingSession findRunningSessionForSchool(UUID sessionId, String email) {
+        String schoolName = schoolContextService.getSchoolName(email);
+        TrainingSession session = trainingSessionRepository
+                .findByIdAndScenario_Building_SchoolName(sessionId, schoolName)
+                .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+        if (session.getStatus() != TrainingStatus.RUNNING) {
+            throw new ApiException(TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND);
+        }
+        return session;
+    }
+
+    private MonitoringCameraResponse toResponse(UUID sessionId, Cctv cctv) {
+        return observationRepository
+                .findLatestBySessionIdAndCctvCode(sessionId.toString(), cctv.getCode())
+                .filter(this::hasMonitoringImage)
+                .map(observation -> withCapture(cctv, observation))
+                .orElseGet(() -> MonitoringCameraResponse.withoutCapture(cctv));
+    }
+
+    private boolean hasMonitoringImage(ObservationItem observation) {
+        return observation.getMonitoringImageKey() != null
+                && !observation.getMonitoringImageKey().isBlank();
+    }
+
+    private MonitoringCameraResponse withCapture(Cctv cctv, ObservationItem observation) {
+        PresignedGetUrl presignedGetUrl =
+                s3PresignedUrlService.createGetUrl(observation.getMonitoringImageKey());
+        return MonitoringCameraResponse.withCapture(
+                cctv,
+                observation.getCapturedAt(),
+                presignedGetUrl
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -2,8 +2,8 @@ package com.saferoute.domain.training.service;
 
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
-import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
-import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
+import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
 import com.saferoute.domain.training.entity.TrainingSession;
@@ -15,7 +15,10 @@ import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
 import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +30,7 @@ public class TrainingMonitoringService {
 
     private final TrainingSessionRepository trainingSessionRepository;
     private final CctvJpaRepository cctvJpaRepository;
-    private final ObservationRepository observationRepository;
+    private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final S3PresignedUrlService s3PresignedUrlService;
     private final SchoolContextService schoolContextService;
 
@@ -37,9 +40,18 @@ public class TrainingMonitoringService {
         List<Cctv> cctvs = cctvJpaRepository
                 .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
                         buildingId);
+        if (cctvs.isEmpty()) {
+            return new MonitoringCameraListResponse(sessionId, List.of());
+        }
+        Map<String, LatestMonitoringCaptureItem> capturesByCctvCode =
+                latestMonitoringCaptureRepository.findAllBySessionId(sessionId.toString()).stream()
+                        .collect(Collectors.toMap(
+                                LatestMonitoringCaptureItem::getCctvCode,
+                                Function.identity()
+                        ));
 
         List<MonitoringCameraResponse> cameras = cctvs.stream()
-                .map(cctv -> toResponse(sessionId, cctv))
+                .map(cctv -> toResponse(cctv, capturesByCctvCode.get(cctv.getCode())))
                 .toList();
         return new MonitoringCameraListResponse(sessionId, cameras);
     }
@@ -55,25 +67,28 @@ public class TrainingMonitoringService {
         return session;
     }
 
-    private MonitoringCameraResponse toResponse(UUID sessionId, Cctv cctv) {
-        return observationRepository
-                .findLatestBySessionIdAndCctvCode(sessionId.toString(), cctv.getCode())
-                .filter(this::hasMonitoringImage)
-                .map(observation -> withCapture(cctv, observation))
-                .orElseGet(() -> MonitoringCameraResponse.withoutCapture(cctv));
+    private MonitoringCameraResponse toResponse(
+            Cctv cctv,
+            LatestMonitoringCaptureItem capture
+    ) {
+        if (!hasMonitoringImage(capture)) {
+            return MonitoringCameraResponse.withoutCapture(cctv);
+        }
+        return withCapture(cctv, capture);
     }
 
-    private boolean hasMonitoringImage(ObservationItem observation) {
-        return observation.getMonitoringImageKey() != null
-                && !observation.getMonitoringImageKey().isBlank();
+    private boolean hasMonitoringImage(LatestMonitoringCaptureItem capture) {
+        return capture != null
+                && capture.getMonitoringImageKey() != null
+                && !capture.getMonitoringImageKey().isBlank();
     }
 
-    private MonitoringCameraResponse withCapture(Cctv cctv, ObservationItem observation) {
+    private MonitoringCameraResponse withCapture(Cctv cctv, LatestMonitoringCaptureItem capture) {
         PresignedGetUrl presignedGetUrl =
-                s3PresignedUrlService.createGetUrl(observation.getMonitoringImageKey());
+                s3PresignedUrlService.createGetUrl(capture.getMonitoringImageKey());
         return MonitoringCameraResponse.withCapture(
                 cctv,
-                observation.getCapturedAt(),
+                capture.getCapturedAt(),
                 presignedGetUrl
         );
     }

--- a/src/main/java/com/saferoute/global/api/error/S3ErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/S3ErrorCode.java
@@ -20,6 +20,11 @@ public enum S3ErrorCode implements BaseErrorCode {
             HttpStatus.SERVICE_UNAVAILABLE,
             "S3_ERROR_004",
             "S3 객체 확인에 실패했습니다. 잠시 후 다시 시도해 주세요."
+    ),
+    PRESIGNED_GET_URL_GENERATION_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "S3_ERROR_005",
+            "S3 이미지 조회 URL 발급에 실패했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
@@ -13,7 +13,12 @@ public enum TrainingSuccessCode implements BaseCode {
     TRAINING_STATUS_FOUND(HttpStatus.OK, "TRAINING_SUCCESS_002", "훈련 상태 조회에 성공했습니다."),
     TRAINING_STARTED(HttpStatus.OK, "TRAINING_SUCCESS_003", "훈련이 시작되었습니다."),
     TRAINING_ENDED(HttpStatus.OK, "TRAINING_SUCCESS_004", "훈련이 정상 종료되었습니다."),
-    TRAINING_FORCE_ENDED(HttpStatus.OK, "TRAINING_SUCCESS_005", "훈련이 강제 종료되었습니다.");
+    TRAINING_FORCE_ENDED(HttpStatus.OK, "TRAINING_SUCCESS_005", "훈련이 강제 종료되었습니다."),
+    MONITORING_CAMERA_LIST_FOUND(
+            HttpStatus.OK,
+            "TRAINING_SUCCESS_006",
+            "모니터링 카메라 목록 조회에 성공했습니다."
+    );
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -126,6 +126,12 @@ public class SecurityConfig {
                                 "/api/v1/congestion-observations/*/image-url"
                         ).hasRole("MANAGER")
 
+                        // 훈련 모니터링 카메라와 캡처 이미지는 관리자 화면에서만 조회한다.
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/sessions/*/monitoring/cameras"
+                        ).hasRole("MANAGER")
+
                         // 경로 이탈률은 훈련 결과 분석용 관리자 화면 전용이다.
                         .requestMatchers(
                                 HttpMethod.GET,

--- a/src/main/java/com/saferoute/infrastructure/s3/service/S3PresignedUrlService.java
+++ b/src/main/java/com/saferoute/infrastructure/s3/service/S3PresignedUrlService.java
@@ -67,7 +67,7 @@ public class S3PresignedUrlService {
                     presignedRequest.expiration()
             );
         } catch (SdkException exception) {
-            throw new ApiException(S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED, exception);
+            throw new ApiException(S3ErrorCode.PRESIGNED_GET_URL_GENERATION_FAILED, exception);
         }
     }
 }

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -33,6 +33,7 @@ import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
+import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -60,6 +61,9 @@ class CongestionObservationServiceTest {
 
     @Mock
     private ObservationRepository observationRepository;
+
+    @Mock
+    private LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
 
     @Mock
     private CurrentCctvStateRepository currentCctvStateRepository;
@@ -206,6 +210,12 @@ class CongestionObservationServiceTest {
         service.reportObservation(cctv, request(5.0));
 
         verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
+        verify(latestMonitoringCaptureRepository).updateIfLatest(argThat(capture ->
+                capture.getTrainingSessionId().equals(sessionId.toString())
+                        && capture.getCctvCode().equals("CCTV_001")
+                        && capture.getCapturedAt().equals(2_000L)
+                        && capture.getMonitoringImageKey() == null
+        ));
         verify(currentCctvStateRepository).updateIfLatest(any());
     }
 

--- a/src/test/java/com/saferoute/domain/device/repository/CctvJpaRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/device/repository/CctvJpaRepositoryTest.java
@@ -13,6 +13,7 @@ import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.config.JpaAuditingConfig;
+import java.util.List;
 import org.hibernate.Hibernate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,5 +72,59 @@ class CctvJpaRepositoryTest {
         entityManager.clear();
         assertThatCode(() -> found.getCustomNode().getFloor().getBuilding().getId())
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("건물의 활성 CCTV만 층과 코드 순으로 위치 정보와 함께 조회한다")
+    void findMonitoringCctvs_filtersAndOrdersWithLocationGraph() {
+        Building targetBuilding = buildingRepository.save(Building.create(
+                "A동",
+                "서울특별시 안전구 모니터링로 123",
+                BuildingType.CLASSROOM,
+                "SafeRoute School"
+        ));
+        Building otherBuilding = buildingRepository.save(Building.create(
+                "B동",
+                "서울특별시 안전구 모니터링로 456",
+                BuildingType.CLASSROOM,
+                "SafeRoute School"
+        ));
+        Floor firstFloor = floorRepository.save(Floor.create(targetBuilding, 1));
+        Floor secondFloor = floorRepository.save(Floor.create(targetBuilding, 2));
+        Floor otherFloor = floorRepository.save(Floor.create(otherBuilding, 1));
+
+        saveCctv(secondFloor, "CCTV_001");
+        saveCctv(firstFloor, "CCTV_003");
+        saveCctv(firstFloor, "CCTV_002");
+        Cctv disabled = saveCctv(firstFloor, "CCTV_004");
+        disabled.disable();
+        saveCctv(otherFloor, "CCTV_005");
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Cctv> found = cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        targetBuilding.getId());
+
+        assertThat(found)
+                .extracting(Cctv::getCode)
+                .containsExactly("CCTV_002", "CCTV_003", "CCTV_001");
+        assertThat(found).allSatisfy(cctv -> {
+            assertThat(Hibernate.isInitialized(cctv.getCustomNode())).isTrue();
+            assertThat(Hibernate.isInitialized(cctv.getCustomNode().getFloor())).isTrue();
+            assertThat(Hibernate.isInitialized(cctv.getCustomNode().getFloor().getBuilding())).isTrue();
+        });
+    }
+
+    private Cctv saveCctv(Floor floor, String code) {
+        MapNode customNode = mapNodeJpaRepository.save(MapNode.createCustom(
+                floor,
+                code,
+                code + " 카메라",
+                0.5,
+                0.5,
+                CustomDeviceType.CCTV
+        ));
+        return cctvJpaRepository.save(Cctv.create(code, code + " 카메라", customNode));
     }
 }

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
@@ -103,6 +103,23 @@ class TelemetryItemTest {
                 .doesNotContainKey("expiresAt");
     }
 
+    @Test
+    void 최신_모니터링_캡처는_세션_파티션과_CCTV_정렬키를_사용한다() {
+        long capturedAt = 1_786_500_005_000L;
+        LatestMonitoringCaptureItem item = LatestMonitoringCaptureItem.create(
+                SESSION_ID,
+                "CCTV_001",
+                capturedAt,
+                "training/session/monitoring/CCTV_001/frame.jpg"
+        );
+
+        assertThat(item.getPk()).isEqualTo("LATEST_MONITORING#" + SESSION_ID);
+        assertThat(item.getSk()).isEqualTo("CCTV#CCTV_001");
+        assertThat(item.getCapturedAt()).isEqualTo(capturedAt);
+        assertThat(item.getExpiresAt())
+                .isEqualTo(Math.floorDiv(capturedAt, 1_000L) + ObservationItem.TTL_SECONDS);
+    }
+
     private ObservationItem observation() {
         return ObservationItem.create(
                 OBSERVATION_ID, SESSION_ID, EDGE_ID, "CCTV_001", 5.0, 8, 25,

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/LatestMonitoringCaptureRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/LatestMonitoringCaptureRepositoryTest.java
@@ -1,0 +1,110 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+
+@ExtendWith(MockitoExtension.class)
+class LatestMonitoringCaptureRepositoryTest {
+
+    private static final UUID SESSION_ID =
+            UUID.fromString("00000000-0000-0000-0000-000000000003");
+
+    @Mock
+    private DynamoDbEnhancedClient enhancedClient;
+    @Mock
+    private DynamoDbTable<LatestMonitoringCaptureItem> table;
+
+    private LatestMonitoringCaptureRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        when(enhancedClient.table(eq("saferoute-telemetry"), any(TableSchema.class)))
+                .thenReturn(table);
+        repository = new LatestMonitoringCaptureRepository(enhancedClient, "saferoute-telemetry");
+    }
+
+    @Test
+    void 최신_캡처면_조건부_갱신한다() {
+        LatestMonitoringCaptureItem incoming = item("CCTV_001", 2_000L);
+        ArgumentCaptor<PutItemEnhancedRequest<LatestMonitoringCaptureItem>> captor = putCaptor();
+
+        assertThat(repository.updateIfLatest(incoming)).isTrue();
+
+        verify(table).putItem(captor.capture());
+        assertThat(captor.getValue().conditionExpression().expression())
+                .isEqualTo("attribute_not_exists(#capturedAt) OR :incomingCapturedAt >= #capturedAt");
+        assertThat(captor.getValue().conditionExpression().expressionValues()
+                .get(":incomingCapturedAt").n()).isEqualTo("2000");
+    }
+
+    @Test
+    void 과거_캡처는_최신_포인터를_덮어쓸_수_없다() {
+        doThrow(ConditionalCheckFailedException.builder().message("stale").build())
+                .when(table).putItem(any(PutItemEnhancedRequest.class));
+
+        assertThat(repository.updateIfLatest(item("CCTV_001", 1_000L))).isFalse();
+    }
+
+    @Test
+    void 세션의_CCTV별_최신_캡처를_한번의_Query로_조회한다() {
+        LatestMonitoringCaptureItem first = item("CCTV_001", 1_000L);
+        LatestMonitoringCaptureItem second = item("CCTV_002", 2_000L);
+        when(table.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(LatestMonitoringCaptureItem.class)
+                        .items(List.of(first, second)).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor =
+                ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        List<LatestMonitoringCaptureItem> result =
+                repository.findAllBySessionId(SESSION_ID.toString());
+
+        verify(table).query(captor.capture());
+        assertThat(captor.getValue().queryConditional()
+                .expression(
+                        TableSchema.fromBean(LatestMonitoringCaptureItem.class),
+                        TableMetadata.primaryIndexName()
+                )
+                .expressionValues().values())
+                .extracting(value -> value.s())
+                .contains("LATEST_MONITORING#" + SESSION_ID);
+        assertThat(result).containsExactly(first, second);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ArgumentCaptor<PutItemEnhancedRequest<LatestMonitoringCaptureItem>> putCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(PutItemEnhancedRequest.class);
+    }
+
+    private LatestMonitoringCaptureItem item(String cctvCode, long capturedAt) {
+        return LatestMonitoringCaptureItem.create(
+                SESSION_ID,
+                cctvCode,
+                capturedAt,
+                "training/session/monitoring/" + cctvCode + "/frame.jpg"
+        );
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -1,0 +1,127 @@
+package com.saferoute.domain.training.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.service.TrainingMonitoringService;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.config.SecurityConfig;
+import com.saferoute.global.security.JwtAuthenticationFilter;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = TrainingMonitoringController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {JwtAuthenticationFilter.class, SecurityConfig.class}
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+@WithMockUser(username = "manager@saferoute.com")
+class TrainingMonitoringControllerTest {
+
+    private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID CCTV_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final String EMAIL = "manager@saferoute.com";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TrainingMonitoringService trainingMonitoringService;
+
+    @Test
+    void 카메라별_최신_캡처_목록을_공통_응답으로_반환한다() throws Exception {
+        MonitoringCameraResponse camera = new MonitoringCameraResponse(
+                CCTV_ID,
+                "CCTV_001",
+                "CAM-1",
+                "A동",
+                "3층",
+                "A동 3층",
+                "https://example.com/frame.jpg",
+                1_787_722_095_000L,
+                1_787_725_695_000L
+        );
+        given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
+                .willReturn(new MonitoringCameraListResponse(SESSION_ID, List.of(camera)));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("TRAINING_SUCCESS_006"))
+                .andExpect(jsonPath("$.result.sessionId").value(SESSION_ID.toString()))
+                .andExpect(jsonPath("$.result.cameras[0].cctvId").value(CCTV_ID.toString()))
+                .andExpect(jsonPath("$.result.cameras[0].code").value("CCTV_001"))
+                .andExpect(jsonPath("$.result.cameras[0].floorName").value("3층"))
+                .andExpect(jsonPath("$.result.cameras[0].thumbnailUrl")
+                        .value("https://example.com/frame.jpg"))
+                .andExpect(jsonPath("$.result.cameras[0].capturedAt")
+                        .value(1_787_722_095_000L))
+                .andExpect(jsonPath("$.result.cameras[0].urlExpiresAt")
+                        .value(1_787_725_695_000L));
+    }
+
+    @Test
+    void 캡처가_없는_카메라는_이미지_필드를_null로_반환한다() throws Exception {
+        MonitoringCameraResponse camera = new MonitoringCameraResponse(
+                CCTV_ID,
+                "CCTV_001",
+                "CAM-1",
+                "A동",
+                "1층",
+                "A동 1층",
+                null,
+                null,
+                null
+        );
+        given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
+                .willReturn(new MonitoringCameraListResponse(SESSION_ID, List.of(camera)));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.cameras[0].thumbnailUrl").isEmpty())
+                .andExpect(jsonPath("$.result.cameras[0].capturedAt").isEmpty())
+                .andExpect(jsonPath("$.result.cameras[0].urlExpiresAt").isEmpty());
+    }
+
+    @Test
+    void 세션을_찾을_수_없으면_404를_반환한다() throws Exception {
+        given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
+    void 실행_중인_세션이_아니면_409를_반환한다() throws Exception {
+        given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("TRAINING006"));
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -1,0 +1,228 @@
+package com.saferoute.domain.training.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.entity.TrainingScenario;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TrainingMonitoringServiceTest {
+
+    private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID BUILDING_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID CCTV_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final String EMAIL = "manager@saferoute.com";
+    private static final String SCHOOL_NAME = "SafeRoute School";
+
+    @Mock
+    private TrainingSessionRepository trainingSessionRepository;
+    @Mock
+    private CctvJpaRepository cctvJpaRepository;
+    @Mock
+    private ObservationRepository observationRepository;
+    @Mock
+    private S3PresignedUrlService s3PresignedUrlService;
+    @Mock
+    private SchoolContextService schoolContextService;
+
+    private TrainingMonitoringService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TrainingMonitoringService(
+                trainingSessionRepository,
+                cctvJpaRepository,
+                observationRepository,
+                s3PresignedUrlService,
+                schoolContextService
+        );
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+    }
+
+    @Test
+    void 활성_CCTV의_최신_캡처와_presigned_URL을_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(3);
+        ObservationItem observation = org.mockito.Mockito.mock(ObservationItem.class);
+        Instant expiresAt = Instant.parse("2026-08-27T01:00:00Z");
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(observationRepository.findLatestBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001"))
+                .willReturn(Optional.of(observation));
+        given(observation.getMonitoringImageKey())
+                .willReturn("training/session/monitoring/CCTV_001/1787722095000.jpg");
+        given(observation.getCapturedAt()).willReturn(1_787_722_095_000L);
+        given(s3PresignedUrlService.createGetUrl(
+                "training/session/monitoring/CCTV_001/1787722095000.jpg"))
+                .willReturn(new PresignedGetUrl("https://example.com/frame.jpg", expiresAt));
+
+        MonitoringCameraListResponse response = service.getCameras(SESSION_ID, EMAIL);
+
+        assertThat(response.sessionId()).isEqualTo(SESSION_ID);
+        assertThat(response.cameras()).hasSize(1);
+        MonitoringCameraResponse camera = response.cameras().get(0);
+        assertThat(camera.cctvId()).isEqualTo(CCTV_ID);
+        assertThat(camera.code()).isEqualTo("CCTV_001");
+        assertThat(camera.name()).isEqualTo("CAM-1");
+        assertThat(camera.buildingName()).isEqualTo("A동");
+        assertThat(camera.floorName()).isEqualTo("3층");
+        assertThat(camera.location()).isEqualTo("A동 3층");
+        assertThat(camera.thumbnailUrl()).isEqualTo("https://example.com/frame.jpg");
+        assertThat(camera.capturedAt()).isEqualTo(1_787_722_095_000L);
+        assertThat(camera.urlExpiresAt()).isEqualTo(expiresAt.toEpochMilli());
+    }
+
+    @Test
+    void 캡처가_없는_활성_CCTV도_null_이미지_필드로_포함한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(-1);
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(observationRepository.findLatestBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001"))
+                .willReturn(Optional.empty());
+
+        MonitoringCameraResponse camera = service.getCameras(SESSION_ID, EMAIL)
+                .cameras().get(0);
+
+        assertThat(camera.floorName()).isEqualTo("지하 1층");
+        assertThat(camera.location()).isEqualTo("A동 지하 1층");
+        assertThat(camera.thumbnailUrl()).isNull();
+        assertThat(camera.capturedAt()).isNull();
+        assertThat(camera.urlExpiresAt()).isNull();
+        verify(s3PresignedUrlService, never()).createGetUrl(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 최신_관측의_이미지_키가_공백이면_placeholder_응답을_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(1);
+        ObservationItem observation = org.mockito.Mockito.mock(ObservationItem.class);
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(observationRepository.findLatestBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001"))
+                .willReturn(Optional.of(observation));
+        given(observation.getMonitoringImageKey()).willReturn(" ");
+
+        MonitoringCameraResponse camera = service.getCameras(SESSION_ID, EMAIL)
+                .cameras().get(0);
+
+        assertThat(camera.thumbnailUrl()).isNull();
+        assertThat(camera.capturedAt()).isNull();
+        assertThat(camera.urlExpiresAt()).isNull();
+        verify(s3PresignedUrlService, never()).createGetUrl(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 활성_CCTV가_없으면_빈_목록을_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of());
+
+        MonitoringCameraListResponse response = service.getCameras(SESSION_ID, EMAIL);
+
+        assertThat(response.cameras()).isEmpty();
+        verify(observationRepository, never())
+                .findLatestBySessionIdAndCctvCode(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()
+                );
+    }
+
+    @Test
+    void 다른_학교이거나_없는_세션은_조회할_수_없다() {
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(
+                SESSION_ID, SCHOOL_NAME)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getCameras(SESSION_ID, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        TrainingErrorCode.TRAINING_SESSION_NOT_FOUND
+                );
+    }
+
+    @Test
+    void 실행_중이_아닌_세션은_조회할_수_없다() {
+        stubSession(TrainingStatus.COMPLETED);
+
+        assertThatThrownBy(() -> service.getCameras(SESSION_ID, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND
+                );
+        verify(cctvJpaRepository, never())
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        org.mockito.ArgumentMatchers.any());
+    }
+
+    private void stubSession(TrainingStatus status) {
+        TrainingSession session = org.mockito.Mockito.mock(TrainingSession.class);
+        TrainingScenario scenario = org.mockito.Mockito.mock(TrainingScenario.class);
+        Building building = org.mockito.Mockito.mock(Building.class);
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(
+                SESSION_ID, SCHOOL_NAME)).willReturn(Optional.of(session));
+        given(session.getStatus()).willReturn(status);
+        if (status == TrainingStatus.RUNNING) {
+            given(session.getScenario()).willReturn(scenario);
+            given(scenario.getBuilding()).willReturn(building);
+            given(building.getId()).willReturn(BUILDING_ID);
+        }
+    }
+
+    private Cctv cctv(int floorNum) {
+        Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
+        MapNode node = org.mockito.Mockito.mock(MapNode.class);
+        Floor floor = org.mockito.Mockito.mock(Floor.class);
+        Building building = org.mockito.Mockito.mock(Building.class);
+        given(cctv.getId()).willReturn(CCTV_ID);
+        given(cctv.getCode()).willReturn("CCTV_001");
+        given(cctv.getName()).willReturn("CAM-1");
+        given(cctv.getCustomNode()).willReturn(node);
+        given(node.getFloor()).willReturn(floor);
+        given(floor.getFloorNum()).willReturn(floorNum);
+        given(floor.getBuilding()).willReturn(building);
+        given(building.getName()).willReturn("A동");
+        return cctv;
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -11,8 +11,8 @@ import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.floor.entity.Floor;
-import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
-import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
+import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
 import com.saferoute.domain.training.entity.TrainingScenario;
@@ -48,7 +48,7 @@ class TrainingMonitoringServiceTest {
     @Mock
     private CctvJpaRepository cctvJpaRepository;
     @Mock
-    private ObservationRepository observationRepository;
+    private LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     @Mock
     private S3PresignedUrlService s3PresignedUrlService;
     @Mock
@@ -61,7 +61,7 @@ class TrainingMonitoringServiceTest {
         service = new TrainingMonitoringService(
                 trainingSessionRepository,
                 cctvJpaRepository,
-                observationRepository,
+                latestMonitoringCaptureRepository,
                 s3PresignedUrlService,
                 schoolContextService
         );
@@ -72,18 +72,18 @@ class TrainingMonitoringServiceTest {
     void 활성_CCTV의_최신_캡처와_presigned_URL을_반환한다() {
         stubSession(TrainingStatus.RUNNING);
         Cctv cctv = cctv(3);
-        ObservationItem observation = org.mockito.Mockito.mock(ObservationItem.class);
+        LatestMonitoringCaptureItem capture = org.mockito.Mockito.mock(LatestMonitoringCaptureItem.class);
         Instant expiresAt = Instant.parse("2026-08-27T01:00:00Z");
         given(cctvJpaRepository
                 .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
                         BUILDING_ID))
                 .willReturn(List.of(cctv));
-        given(observationRepository.findLatestBySessionIdAndCctvCode(
-                SESSION_ID.toString(), "CCTV_001"))
-                .willReturn(Optional.of(observation));
-        given(observation.getMonitoringImageKey())
+        given(latestMonitoringCaptureRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(capture));
+        given(capture.getCctvCode()).willReturn("CCTV_001");
+        given(capture.getMonitoringImageKey())
                 .willReturn("training/session/monitoring/CCTV_001/1787722095000.jpg");
-        given(observation.getCapturedAt()).willReturn(1_787_722_095_000L);
+        given(capture.getCapturedAt()).willReturn(1_787_722_095_000L);
         given(s3PresignedUrlService.createGetUrl(
                 "training/session/monitoring/CCTV_001/1787722095000.jpg"))
                 .willReturn(new PresignedGetUrl("https://example.com/frame.jpg", expiresAt));
@@ -112,9 +112,8 @@ class TrainingMonitoringServiceTest {
                 .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
                         BUILDING_ID))
                 .willReturn(List.of(cctv));
-        given(observationRepository.findLatestBySessionIdAndCctvCode(
-                SESSION_ID.toString(), "CCTV_001"))
-                .willReturn(Optional.empty());
+        given(latestMonitoringCaptureRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of());
 
         MonitoringCameraResponse camera = service.getCameras(SESSION_ID, EMAIL)
                 .cameras().get(0);
@@ -131,15 +130,15 @@ class TrainingMonitoringServiceTest {
     void 최신_관측의_이미지_키가_공백이면_placeholder_응답을_반환한다() {
         stubSession(TrainingStatus.RUNNING);
         Cctv cctv = cctv(1);
-        ObservationItem observation = org.mockito.Mockito.mock(ObservationItem.class);
+        LatestMonitoringCaptureItem capture = org.mockito.Mockito.mock(LatestMonitoringCaptureItem.class);
         given(cctvJpaRepository
                 .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
                         BUILDING_ID))
                 .willReturn(List.of(cctv));
-        given(observationRepository.findLatestBySessionIdAndCctvCode(
-                SESSION_ID.toString(), "CCTV_001"))
-                .willReturn(Optional.of(observation));
-        given(observation.getMonitoringImageKey()).willReturn(" ");
+        given(latestMonitoringCaptureRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(capture));
+        given(capture.getCctvCode()).willReturn("CCTV_001");
+        given(capture.getMonitoringImageKey()).willReturn(" ");
 
         MonitoringCameraResponse camera = service.getCameras(SESSION_ID, EMAIL)
                 .cameras().get(0);
@@ -148,6 +147,51 @@ class TrainingMonitoringServiceTest {
         assertThat(camera.capturedAt()).isNull();
         assertThat(camera.urlExpiresAt()).isNull();
         verify(s3PresignedUrlService, never()).createGetUrl(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 여러_CCTV의_최신_캡처를_세션_Query_한번으로_매핑한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv firstCctv = cctv(
+                CCTV_ID,
+                "CCTV_001",
+                "CAM-1",
+                1
+        );
+        Cctv secondCctv = cctv(
+                UUID.fromString("00000000-0000-0000-0000-000000000004"),
+                "CCTV_002",
+                "CAM-2",
+                2
+        );
+        LatestMonitoringCaptureItem firstCapture = LatestMonitoringCaptureItem.create(
+                SESSION_ID, "CCTV_001", 1_000L, "monitoring/first.jpg"
+        );
+        LatestMonitoringCaptureItem secondCapture = LatestMonitoringCaptureItem.create(
+                SESSION_ID, "CCTV_002", 2_000L, "monitoring/second.jpg"
+        );
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(firstCctv, secondCctv));
+        given(latestMonitoringCaptureRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(firstCapture, secondCapture));
+        given(s3PresignedUrlService.createGetUrl(org.mockito.ArgumentMatchers.anyString()))
+                .willReturn(new PresignedGetUrl(
+                        "https://example.com/frame.jpg",
+                        Instant.parse("2026-08-27T01:00:00Z")
+                ));
+
+        MonitoringCameraListResponse response = service.getCameras(SESSION_ID, EMAIL);
+
+        assertThat(response.cameras())
+                .extracting(MonitoringCameraResponse::code, MonitoringCameraResponse::capturedAt)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("CCTV_001", 1_000L),
+                        org.assertj.core.groups.Tuple.tuple("CCTV_002", 2_000L)
+                );
+        verify(latestMonitoringCaptureRepository)
+                .findAllBySessionId(SESSION_ID.toString());
     }
 
     @Test
@@ -161,11 +205,8 @@ class TrainingMonitoringServiceTest {
         MonitoringCameraListResponse response = service.getCameras(SESSION_ID, EMAIL);
 
         assertThat(response.cameras()).isEmpty();
-        verify(observationRepository, never())
-                .findLatestBySessionIdAndCctvCode(
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString()
-                );
+        verify(latestMonitoringCaptureRepository, never())
+                .findAllBySessionId(org.mockito.ArgumentMatchers.anyString());
     }
 
     @Test
@@ -211,13 +252,17 @@ class TrainingMonitoringServiceTest {
     }
 
     private Cctv cctv(int floorNum) {
+        return cctv(CCTV_ID, "CCTV_001", "CAM-1", floorNum);
+    }
+
+    private Cctv cctv(UUID cctvId, String code, String name, int floorNum) {
         Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
         MapNode node = org.mockito.Mockito.mock(MapNode.class);
         Floor floor = org.mockito.Mockito.mock(Floor.class);
         Building building = org.mockito.Mockito.mock(Building.class);
-        given(cctv.getId()).willReturn(CCTV_ID);
-        given(cctv.getCode()).willReturn("CCTV_001");
-        given(cctv.getName()).willReturn("CAM-1");
+        given(cctv.getId()).willReturn(cctvId);
+        given(cctv.getCode()).willReturn(code);
+        given(cctv.getName()).willReturn(name);
         given(cctv.getCustomNode()).willReturn(node);
         given(node.getFloor()).willReturn(floor);
         given(floor.getFloorNum()).willReturn(floorNum);

--- a/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
@@ -130,6 +130,53 @@ class SecurityAuthorizationIntegrationTest {
     }
 
     @Test
+    @DisplayName("일반 사용자는 훈련 모니터링 카메라 목록을 조회할 수 없다")
+    void normalUserCannotReadTrainingMonitoringCameras() throws Exception {
+        String token = signupAndLogin(UserRole.NORMAL);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/cameras", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("관리자는 훈련 모니터링 카메라 목록 엔드포인트에 접근할 수 있다")
+    void managerCanReadTrainingMonitoringCameras() throws Exception {
+        String token = signupAndLogin(UserRole.MANAGER);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/cameras", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
+    @DisplayName("Swagger에 훈련 모니터링 카메라 API와 응답 예시가 노출된다")
+    void trainingMonitoringApiIsDocumented() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/sessions/{sessionId}/monitoring/cameras'].get.summary"
+                ).value("카메라별 최신 캡처 목록 조회"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/sessions/{sessionId}/monitoring/cameras']"
+                                + ".get.responses['200'].content['application/json'].examples"
+                                + ".['최신 캡처가 있는 카메라'].value.result.cameras[0].capturedAt"
+                ).value(1_787_722_095_000L))
+                .andExpect(jsonPath(
+                        "$.components.schemas.MonitoringCameraResponse.properties.thumbnailUrl.description"
+                ).value(org.hamcrest.Matchers.containsString("presigned GET URL")))
+                .andExpect(jsonPath(
+                        "$.components.schemas.MonitoringCameraResponse.properties.capturedAt.description"
+                ).value(org.hamcrest.Matchers.containsString("epoch milliseconds")));
+    }
+
+    @Test
     @DisplayName("관리자는 건물을 등록할 수 있다")
     void managerCanWrite() throws Exception {
         String token =

--- a/src/test/java/com/saferoute/infrastructure/s3/S3PresignedUrlServiceTest.java
+++ b/src/test/java/com/saferoute/infrastructure/s3/S3PresignedUrlServiceTest.java
@@ -124,7 +124,7 @@ class S3PresignedUrlServiceTest {
                 .isInstanceOf(ApiException.class)
                 .hasFieldOrPropertyWithValue(
                         "errorCode",
-                        S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED
+                        S3ErrorCode.PRESIGNED_GET_URL_GENERATION_FAILED
                 );
     }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #128
- Branch: feat/#128

## 주요 내용

- 훈련 모니터링 화면에서 사용할 카메라별 최신 캡처 목록 API를 추가했습니다.
  - GET `/api/v1/sessions/{sessionId}/monitoring/cameras`
  - MANAGER 권한을 가진 사용자만 호출할 수 있습니다.
  - 로그인한 사용자의 학교에 소속된 세션만 조회할 수 있습니다.
  - 현재 `RUNNING` 상태인 훈련 세션만 조회할 수 있습니다.

- 세션 건물에 설치된 활성 CCTV 목록을 조회하도록 구현했습니다.
  - 비활성 CCTV는 응답에서 제외합니다.
  - 층 번호 오름차순, 같은 층에서는 CCTV 코드 오름차순으로 정렬합니다.
  - 지하층은 `지하 1층` 형식으로 반환합니다.
  - CCTV가 없는 경우 빈 배열을 반환합니다.

- CCTV별 최신 캡처 정보를 응답하도록 구현했습니다.
  - CCTV별 최신 Observation을 조회합니다.
  - `monitoringImageKey`를 S3 Presigned GET URL로 변환합니다.
  - `capturedAt`과 `urlExpiresAt`은 Unix epoch milliseconds 단위로 반환합니다.
  - 아직 Observation이 없거나 `monitoringImageKey`가 비어 있으면 `thumbnailUrl`, `capturedAt`, `urlExpiresAt`을 모두 `null`로 반환합니다.
  - 캡처가 없는 CCTV도 목록에서 제외하지 않으며, 프론트에서 placeholder를 표시할 수 있도록 응답합니다.

- 프론트 연동을 위한 Swagger 문서를 추가했습니다.
  - 각 요청·응답 필드의 의미와 nullable 조건을 작성했습니다.
  - Presigned URL의 만료 특성과 `capturedAt` 기준 상대 시간 표시 방법을 설명했습니다.
  - 최신 화면 갱신을 위해 주기적으로 API를 재호출해야 한다는 내용을 명시했습니다.
  - 캡처가 있는 경우와 없는 경우의 성공 응답 예시를 각각 추가했습니다.
  - 401, 403, 404, 409, 500 오류 응답 예시를 추가했습니다.
  - 공통 응답 래퍼와 카메라 응답 DTO가 Swagger Schema에 표시되도록 구성했습니다.

- S3 Bucket을 공개로 변경하거나 새로운 애플리케이션 설정을 추가하지 않았습니다.
  - 기존 S3 Presigned GET URL 설정을 사용합니다.
  - 프론트에서는 `thumbnailUrl`을 `<img src>`에 직접 바인딩하면 됩니다.
  - 기존 모니터링 이미지 7일 Lifecycle 정책을 그대로 사용할 수 있습니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 실행 중인 훈련 세션의 활성 CCTV 목록을 조회할 수 있습니다.
  * 카메라 위치, 최신 캡처 이미지, 촬영 시각 및 URL 만료 시각을 제공합니다.
  * 캡처가 없는 카메라도 목록에 표시됩니다.
  * 해당 기능은 관리자 권한으로 이용할 수 있습니다.

* **문서**
  * 모니터링 카메라 조회 API의 응답 형식과 오류 사례를 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->