### PR TITLE
[FEAT] #132: 훈련 모니터링 목록 API 테스트 보강

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
       DB_URL: ${DB_URL:?DB_URL is required}
       DB_USERNAME: ${DB_USERNAME:?DB_USERNAME is required}
       DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
-      JPA_DDL_AUTO: ${JPA_DDL_AUTO:-create}
+      JPA_DDL_AUTO: ${JPA_DDL_AUTO:-update}
 
       AWS_REGION: ${AWS_REGION:-us-east-2}
       AWS_DEFAULT_REGION: ${AWS_REGION:-us-east-2}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     hibernate:
       # 기존 DB 호환을 위해 우선 update를 사용한다.
       # 추후 Flyway 등의 마이그레이션을 도입하면 validate로 변경한다.
-      ddl-auto: ${JPA_DDL_AUTO:create}
+      ddl-auto: ${JPA_DDL_AUTO:update}
     properties:
       hibernate:
         format_sql: false

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -140,9 +140,9 @@ class TrainingMonitoringControllerTest {
                 .andExpect(jsonPath("$.result.cameras[0].thumbnailUrl")
                         .value("https://example.com/frame.jpg"))
                 .andExpect(jsonPath("$.result.cameras[1].code").value("CCTV_002"))
-                .andExpect(jsonPath("$.result.cameras[1].thumbnailUrl").isEmpty())
-                .andExpect(jsonPath("$.result.cameras[1].capturedAt").isEmpty())
-                .andExpect(jsonPath("$.result.cameras[1].urlExpiresAt").isEmpty());
+                .andExpect(jsonPath("$.result.cameras[1].thumbnailUrl").value((Object) null))
+                .andExpect(jsonPath("$.result.cameras[1].capturedAt").value((Object) null))
+                .andExpect(jsonPath("$.result.cameras[1].urlExpiresAt").value((Object) null));
     }
 
     @Test
@@ -164,9 +164,9 @@ class TrainingMonitoringControllerTest {
         mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.cameras[0].thumbnailUrl").isEmpty())
-                .andExpect(jsonPath("$.result.cameras[0].capturedAt").isEmpty())
-                .andExpect(jsonPath("$.result.cameras[0].urlExpiresAt").isEmpty());
+                .andExpect(jsonPath("$.result.cameras[0].thumbnailUrl").value((Object) null))
+                .andExpect(jsonPath("$.result.cameras[0].capturedAt").value((Object) null))
+                .andExpect(jsonPath("$.result.cameras[0].urlExpiresAt").value((Object) null));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
 import com.saferoute.domain.training.service.TrainingMonitoringService;
+import com.saferoute.global.api.error.S3ErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.global.config.SecurityConfig;
@@ -38,6 +39,8 @@ class TrainingMonitoringControllerTest {
 
     private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
     private static final UUID CCTV_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID SECOND_CCTV_ID =
+            UUID.fromString("00000000-0000-0000-0000-000000000003");
     private static final String EMAIL = "manager@saferoute.com";
 
     @Autowired
@@ -48,7 +51,7 @@ class TrainingMonitoringControllerTest {
 
     @Test
     void 카메라별_최신_캡처_목록을_공통_응답으로_반환한다() throws Exception {
-        MonitoringCameraResponse camera = new MonitoringCameraResponse(
+        MonitoringCameraResponse firstCamera = new MonitoringCameraResponse(
                 CCTV_ID,
                 "CCTV_001",
                 "CAM-1",
@@ -59,8 +62,22 @@ class TrainingMonitoringControllerTest {
                 1_787_722_095_000L,
                 1_787_725_695_000L
         );
+        MonitoringCameraResponse secondCamera = new MonitoringCameraResponse(
+                SECOND_CCTV_ID,
+                "CCTV_002",
+                "CAM-2",
+                "A동",
+                "4층",
+                "A동 4층",
+                "https://example.com/second-frame.jpg",
+                1_787_722_096_000L,
+                1_787_725_696_000L
+        );
         given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
-                .willReturn(new MonitoringCameraListResponse(SESSION_ID, List.of(camera)));
+                .willReturn(new MonitoringCameraListResponse(
+                        SESSION_ID,
+                        List.of(firstCamera, secondCamera)
+                ));
 
         mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
@@ -76,7 +93,56 @@ class TrainingMonitoringControllerTest {
                 .andExpect(jsonPath("$.result.cameras[0].capturedAt")
                         .value(1_787_722_095_000L))
                 .andExpect(jsonPath("$.result.cameras[0].urlExpiresAt")
-                        .value(1_787_725_695_000L));
+                        .value(1_787_725_695_000L))
+                .andExpect(jsonPath("$.result.cameras[1].cctvId")
+                        .value(SECOND_CCTV_ID.toString()))
+                .andExpect(jsonPath("$.result.cameras[1].code").value("CCTV_002"))
+                .andExpect(jsonPath("$.result.cameras[1].thumbnailUrl")
+                        .value("https://example.com/second-frame.jpg"))
+                .andExpect(jsonPath("$.result.cameras[1].capturedAt")
+                        .value(1_787_722_096_000L));
+    }
+
+    @Test
+    void 일부_CCTV에만_캡처가_있어도_전체_목록과_null_이미지_필드를_반환한다() throws Exception {
+        MonitoringCameraResponse capturedCamera = new MonitoringCameraResponse(
+                CCTV_ID,
+                "CCTV_001",
+                "CAM-1",
+                "A동",
+                "1층",
+                "A동 1층",
+                "https://example.com/frame.jpg",
+                1_787_722_095_000L,
+                1_787_725_695_000L
+        );
+        MonitoringCameraResponse pendingCamera = new MonitoringCameraResponse(
+                SECOND_CCTV_ID,
+                "CCTV_002",
+                "CAM-2",
+                "A동",
+                "2층",
+                "A동 2층",
+                null,
+                null,
+                null
+        );
+        given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
+                .willReturn(new MonitoringCameraListResponse(
+                        SESSION_ID,
+                        List.of(capturedCamera, pendingCamera)
+                ));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.cameras.length()").value(2))
+                .andExpect(jsonPath("$.result.cameras[0].thumbnailUrl")
+                        .value("https://example.com/frame.jpg"))
+                .andExpect(jsonPath("$.result.cameras[1].code").value("CCTV_002"))
+                .andExpect(jsonPath("$.result.cameras[1].thumbnailUrl").isEmpty())
+                .andExpect(jsonPath("$.result.cameras[1].capturedAt").isEmpty())
+                .andExpect(jsonPath("$.result.cameras[1].urlExpiresAt").isEmpty());
     }
 
     @Test
@@ -115,6 +181,19 @@ class TrainingMonitoringControllerTest {
     }
 
     @Test
+    void 다른_학교의_세션이면_존재_여부를_노출하지_않고_404를_반환한다() throws Exception {
+        given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("TRAINING001"))
+                .andExpect(jsonPath("$.message").value("훈련 세션을 찾을 수 없습니다."));
+    }
+
+    @Test
     void 실행_중인_세션이_아니면_409를_반환한다() throws Exception {
         given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
                 .willThrow(new ApiException(TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND));
@@ -123,5 +202,19 @@ class TrainingMonitoringControllerTest {
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("TRAINING006"));
+    }
+
+    @Test
+    void S3_조회_URL_발급에_실패하면_500과_정의된_오류_응답을_반환한다() throws Exception {
+        given(trainingMonitoringService.getCameras(SESSION_ID, EMAIL))
+                .willThrow(new ApiException(S3ErrorCode.PRESIGNED_GET_URL_GENERATION_FAILED));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("S3_ERROR_005"))
+                .andExpect(jsonPath("$.message")
+                        .value("S3 이미지 조회 URL 발급에 실패했습니다."));
     }
 }

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -20,6 +20,7 @@ import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.S3ErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
@@ -195,6 +196,122 @@ class TrainingMonitoringServiceTest {
     }
 
     @Test
+    void 일부_CCTV에만_캡처가_있어도_모든_활성_CCTV를_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv capturedCctv = cctv(
+                CCTV_ID,
+                "CCTV_001",
+                "CAM-1",
+                1
+        );
+        Cctv pendingCctv = cctv(
+                UUID.fromString("00000000-0000-0000-0000-000000000004"),
+                "CCTV_002",
+                "CAM-2",
+                2
+        );
+        LatestMonitoringCaptureItem capture = LatestMonitoringCaptureItem.create(
+                SESSION_ID,
+                "CCTV_001",
+                1_000L,
+                "monitoring/first.jpg"
+        );
+        Instant expiresAt = Instant.parse("2026-08-27T01:00:00Z");
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(capturedCctv, pendingCctv));
+        given(latestMonitoringCaptureRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(capture));
+        given(s3PresignedUrlService.createGetUrl("monitoring/first.jpg"))
+                .willReturn(new PresignedGetUrl("https://example.com/first.jpg", expiresAt));
+
+        MonitoringCameraListResponse response = service.getCameras(SESSION_ID, EMAIL);
+
+        assertThat(response.cameras()).hasSize(2);
+        assertThat(response.cameras().get(0))
+                .extracting(
+                        MonitoringCameraResponse::code,
+                        MonitoringCameraResponse::thumbnailUrl,
+                        MonitoringCameraResponse::capturedAt,
+                        MonitoringCameraResponse::urlExpiresAt
+                )
+                .containsExactly(
+                        "CCTV_001",
+                        "https://example.com/first.jpg",
+                        1_000L,
+                        expiresAt.toEpochMilli()
+                );
+        assertThat(response.cameras().get(1))
+                .extracting(
+                        MonitoringCameraResponse::code,
+                        MonitoringCameraResponse::thumbnailUrl,
+                        MonitoringCameraResponse::capturedAt,
+                        MonitoringCameraResponse::urlExpiresAt
+                )
+                .containsExactly("CCTV_002", null, null, null);
+        verify(s3PresignedUrlService).createGetUrl("monitoring/first.jpg");
+    }
+
+    @Test
+    void 동일_CCTV는_최신_캡처_포인터의_프레임_한_장만_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(1);
+        LatestMonitoringCaptureItem latestCapture = LatestMonitoringCaptureItem.create(
+                SESSION_ID,
+                "CCTV_001",
+                2_000L,
+                "monitoring/latest.jpg"
+        );
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(latestMonitoringCaptureRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(latestCapture));
+        given(s3PresignedUrlService.createGetUrl("monitoring/latest.jpg"))
+                .willReturn(new PresignedGetUrl(
+                        "https://example.com/latest.jpg",
+                        Instant.parse("2026-08-27T01:00:00Z")
+                ));
+
+        MonitoringCameraListResponse response = service.getCameras(SESSION_ID, EMAIL);
+
+        assertThat(response.cameras()).singleElement().satisfies(camera -> {
+            assertThat(camera.code()).isEqualTo("CCTV_001");
+            assertThat(camera.thumbnailUrl()).isEqualTo("https://example.com/latest.jpg");
+            assertThat(camera.capturedAt()).isEqualTo(2_000L);
+        });
+        verify(s3PresignedUrlService, never()).createGetUrl("monitoring/old.jpg");
+    }
+
+    @Test
+    void 최신_관측의_이미지_키가_null이면_placeholder_응답을_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(1);
+        LatestMonitoringCaptureItem capture = LatestMonitoringCaptureItem.create(
+                SESSION_ID,
+                "CCTV_001",
+                1_000L,
+                null
+        );
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(latestMonitoringCaptureRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(capture));
+
+        MonitoringCameraResponse camera = service.getCameras(SESSION_ID, EMAIL)
+                .cameras().get(0);
+
+        assertThat(camera.thumbnailUrl()).isNull();
+        assertThat(camera.capturedAt()).isNull();
+        assertThat(camera.urlExpiresAt()).isNull();
+        verify(s3PresignedUrlService, never()).createGetUrl(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
     void 활성_CCTV가_없으면_빈_목록을_반환한다() {
         stubSession(TrainingStatus.RUNNING);
         given(cctvJpaRepository
@@ -210,7 +327,7 @@ class TrainingMonitoringServiceTest {
     }
 
     @Test
-    void 다른_학교이거나_없는_세션은_조회할_수_없다() {
+    void 존재하지_않는_세션은_조회할_수_없다() {
         given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(
                 SESSION_ID, SCHOOL_NAME)).willReturn(Optional.empty());
 
@@ -219,6 +336,59 @@ class TrainingMonitoringServiceTest {
                 .hasFieldOrPropertyWithValue(
                         "errorCode",
                         TrainingErrorCode.TRAINING_SESSION_NOT_FOUND
+                );
+        verify(cctvJpaRepository, never())
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        org.mockito.ArgumentMatchers.any());
+        verify(latestMonitoringCaptureRepository, never())
+                .findAllBySessionId(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 다른_학교의_세션은_존재_여부를_노출하지_않고_조회할_수_없다() {
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(
+                SESSION_ID, SCHOOL_NAME)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getCameras(SESSION_ID, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        TrainingErrorCode.TRAINING_SESSION_NOT_FOUND
+                );
+        verify(trainingSessionRepository)
+                .findByIdAndScenario_Building_SchoolName(SESSION_ID, SCHOOL_NAME);
+        verify(cctvJpaRepository, never())
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        org.mockito.ArgumentMatchers.any());
+        verify(latestMonitoringCaptureRepository, never())
+                .findAllBySessionId(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void S3_조회_URL_발급에_실패하면_정의된_예외를_전파한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
+        given(cctv.getCode()).willReturn("CCTV_001");
+        LatestMonitoringCaptureItem capture = LatestMonitoringCaptureItem.create(
+                SESSION_ID,
+                "CCTV_001",
+                1_000L,
+                "monitoring/frame.jpg"
+        );
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(latestMonitoringCaptureRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(capture));
+        given(s3PresignedUrlService.createGetUrl("monitoring/frame.jpg"))
+                .willThrow(new ApiException(S3ErrorCode.PRESIGNED_GET_URL_GENERATION_FAILED));
+
+        assertThatThrownBy(() -> service.getCameras(SESSION_ID, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        S3ErrorCode.PRESIGNED_GET_URL_GENERATION_FAILED
                 );
     }
 


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #132
- Branch: `feat/#132`

## 주요 내용

- 훈련 모니터링 목록 Service 단위 테스트를 보강했습니다.
  - 모든 CCTV에 캡처가 있는 경우
  - 일부 CCTV에만 캡처가 있는 경우
  - 등록 직후 캡처가 없는 경우
  - 동일 CCTV의 최신 캡처 1장 반환
  - `monitoringImageKey`가 `null` 또는 공백인 경우
  - 세션이 존재하지 않는 경우
  - 다른 학교 사용자가 접근하는 경우
  - S3 presigned GET URL 발급에 실패하는 경우
- 캡처가 없는 CCTV의 `thumbnailUrl`, `capturedAt`, `urlExpiresAt`이 모두 `null`로 반환되는지 검증했습니다.
- 다른 학교의 세션은 존재 여부를 노출하지 않고 `TRAINING001`로 처리되는지 검증했습니다.
- S3 URL 발급 실패 시 HTTP 500과 `S3_ERROR_005` 공통 오류 응답이 반환되는지 검증했습니다.
- Controller 테스트에서 전체 캡처 및 부분 캡처 목록의 JSON 응답을 검증했습니다.
- 전체 Gradle 테스트를 실행해 기존 기능의 회귀 여부를 확인했습니다.

## ✅ Check List

- [x] 테스트 통과
- [x] `./gradlew build` 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 프로덕션 환경에서 기존 데이터베이스 구조를 유지하면서 변경 사항을 반영하도록 설정이 개선되었습니다.
  * 모니터링 화면에서 모든 활성 CCTV가 표시되며, 캡처가 없는 카메라는 이미지 정보가 비어 있는 상태로 표시됩니다.
  * 각 CCTV의 최신 캡처 이미지만 사용해 잘못된 이미지가 표시되는 문제가 개선되었습니다.
  * 권한이 없는 세션 접근 및 이미지 URL 발급 실패 시 보다 명확한 오류 응답을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->