### PR TITLE
[FEAT] #134: 모니터링 이미지 키 검증 강화

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -80,7 +80,8 @@ public class CongestionObservationService {
             throw new ApiException(CongestionErrorCode.MONITORED_AREA_NOT_AVAILABLE);
         }
 
-        validateMonitoringImageKey(session.getId(), cctv.getCode(), request.capturedAt(), request.monitoringImageKey());
+        String monitoringImageKey = validateMonitoringImageKey(
+                session.getId(), cctv.getCode(), request.capturedAt(), request.monitoringImageKey());
 
         double density = request.avgHeadcount() / monitoredAreaM2;
         CongestionLevel level = config.classify(density);
@@ -98,13 +99,13 @@ public class CongestionObservationService {
                 request.windowStart(),
                 request.windowEnd(),
                 request.capturedAt(),
-                request.monitoringImageKey(),
+                monitoringImageKey,
                 request.configVersion()
         );
 
         IdempotentSaveResult<ObservationItem> saveResult = observationRepository.saveIfAbsent(item);
         validateEventIdentity(saveResult.item(), request, session.getId());
-        updateLatestMonitoringCapture(session.getId(), cctv.getCode(), request);
+        updateLatestMonitoringCapture(session.getId(), cctv.getCode(), request.capturedAt(), monitoringImageKey);
 
         String processingOwner = UUID.randomUUID().toString();
         long processingStartedAt = Instant.now().toEpochMilli();
@@ -180,13 +181,14 @@ public class CongestionObservationService {
     private void updateLatestMonitoringCapture(
             UUID sessionId,
             String cctvCode,
-            ReportObservationRequest request
+            long capturedAt,
+            String monitoringImageKey
     ) {
         LatestMonitoringCaptureItem capture = LatestMonitoringCaptureItem.create(
                 sessionId,
                 cctvCode,
-                request.capturedAt(),
-                request.monitoringImageKey()
+                capturedAt,
+                monitoringImageKey
         );
         if (!latestMonitoringCaptureRepository.updateIfLatest(capture)) {
             log.debug("더 최신 캡처가 있어 모니터링 포인터 갱신을 건너뜀: cctvCode={}", cctvCode);
@@ -195,11 +197,12 @@ public class CongestionObservationService {
 
     // monitoringImageKey는 Pi가 임의로 채워 보내는 문자열이라, canonical 경로 형식과 요청 신원(세션/CCTV/캡처시각)이
     // 일치하는지 검증한 뒤에만 저장한다. 다른 세션/CCTV의 S3 객체를 가리키는 변조된 key가 저장되는 것을 막기 위함.
-    private void validateMonitoringImageKey(
+    // 빈 문자열은 이미지 없음을 뜻하는 null로 정규화해서 반환한다 - CongestionImageUrlService는 null만 이미지 없음으로 취급한다.
+    private String validateMonitoringImageKey(
             UUID sessionId, String cctvCode, long capturedAt, String monitoringImageKey
     ) {
         if (monitoringImageKey == null || monitoringImageKey.isBlank()) {
-            return;
+            return null;
         }
 
         String[] segments = monitoringImageKey.split("/", -1);
@@ -220,6 +223,7 @@ public class CongestionObservationService {
         if (!sameIdentity) {
             throw new ApiException(CongestionErrorCode.MONITORING_IMAGE_IDENTITY_MISMATCH);
         }
+        return monitoringImageKey;
     }
 
     private UUID parseCanonicalUuid(String value) {
@@ -235,11 +239,18 @@ public class CongestionObservationService {
     }
 
     private long parseCapturedAt(String value) {
+        long parsed;
         try {
-            return Long.parseLong(value);
+            parsed = Long.parseLong(value);
         } catch (NumberFormatException exception) {
             throw new ApiException(CongestionErrorCode.MONITORING_IMAGE_KEY_INVALID, exception);
         }
+        // Long.parseLong은 "+2000", "02000" 같은 비canonical 표기도 허용하므로,
+        // 다시 문자열로 되돌렸을 때 원본과 같은지 확인해 canonical decimal만 통과시킨다.
+        if (!Long.toString(parsed).equals(value)) {
+            throw new ApiException(CongestionErrorCode.MONITORING_IMAGE_KEY_INVALID);
+        }
+        return parsed;
     }
 
     private void validateEventIdentity(ObservationItem item, ReportObservationRequest request, UUID sessionId) {

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -49,6 +49,10 @@ public class CongestionObservationService {
 
     static final Duration PROCESSING_LEASE = Duration.ofMinutes(1);
 
+    private static final String TRAINING_PREFIX = "training";
+    private static final String MONITORING_DIRECTORY = "monitoring";
+    private static final String JPEG_SUFFIX = ".jpg";
+
     private final ObservationRepository observationRepository;
     private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final CurrentCctvStateRepository currentCctvStateRepository;
@@ -75,6 +79,8 @@ public class CongestionObservationService {
         if (monitoredAreaM2 == null || monitoredAreaM2 <= 0) {
             throw new ApiException(CongestionErrorCode.MONITORED_AREA_NOT_AVAILABLE);
         }
+
+        validateMonitoringImageKey(session.getId(), cctv.getCode(), request.capturedAt(), request.monitoringImageKey());
 
         double density = request.avgHeadcount() / monitoredAreaM2;
         CongestionLevel level = config.classify(density);
@@ -184,6 +190,55 @@ public class CongestionObservationService {
         );
         if (!latestMonitoringCaptureRepository.updateIfLatest(capture)) {
             log.debug("더 최신 캡처가 있어 모니터링 포인터 갱신을 건너뜀: cctvCode={}", cctvCode);
+        }
+    }
+
+    // monitoringImageKey는 Pi가 임의로 채워 보내는 문자열이라, canonical 경로 형식과 요청 신원(세션/CCTV/캡처시각)이
+    // 일치하는지 검증한 뒤에만 저장한다. 다른 세션/CCTV의 S3 객체를 가리키는 변조된 key가 저장되는 것을 막기 위함.
+    private void validateMonitoringImageKey(
+            UUID sessionId, String cctvCode, long capturedAt, String monitoringImageKey
+    ) {
+        if (monitoringImageKey == null || monitoringImageKey.isBlank()) {
+            return;
+        }
+
+        String[] segments = monitoringImageKey.split("/", -1);
+        if (segments.length != 5
+                || !TRAINING_PREFIX.equals(segments[0])
+                || !MONITORING_DIRECTORY.equals(segments[2])
+                || !segments[4].endsWith(JPEG_SUFFIX)) {
+            throw new ApiException(CongestionErrorCode.MONITORING_IMAGE_KEY_INVALID);
+        }
+
+        UUID keySessionId = parseCanonicalUuid(segments[1]);
+        String capturedAtSegment = segments[4].substring(0, segments[4].length() - JPEG_SUFFIX.length());
+        long keyCapturedAt = parseCapturedAt(capturedAtSegment);
+
+        boolean sameIdentity = sessionId.equals(keySessionId)
+                && Objects.equals(cctvCode, segments[3])
+                && capturedAt == keyCapturedAt;
+        if (!sameIdentity) {
+            throw new ApiException(CongestionErrorCode.MONITORING_IMAGE_IDENTITY_MISMATCH);
+        }
+    }
+
+    private UUID parseCanonicalUuid(String value) {
+        try {
+            UUID uuid = UUID.fromString(value);
+            if (!uuid.toString().equals(value)) {
+                throw new IllegalArgumentException("non-canonical UUID");
+            }
+            return uuid;
+        } catch (IllegalArgumentException exception) {
+            throw new ApiException(CongestionErrorCode.MONITORING_IMAGE_KEY_INVALID, exception);
+        }
+    }
+
+    private long parseCapturedAt(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException exception) {
+            throw new ApiException(CongestionErrorCode.MONITORING_IMAGE_KEY_INVALID, exception);
         }
     }
 

--- a/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/CongestionErrorCode.java
@@ -53,6 +53,16 @@ public enum CongestionErrorCode implements BaseErrorCode {
             HttpStatus.CONFLICT,
             "CONGESTION009",
             "CCTV의 감시 면적을 계산할 수 없습니다. 감시 영역이 설정되지 않았습니다."
+    ),
+    MONITORING_IMAGE_KEY_INVALID(
+            HttpStatus.BAD_REQUEST,
+            "CONGESTION010",
+            "모니터링 이미지 경로 형식이 올바르지 않습니다."
+    ),
+    MONITORING_IMAGE_IDENTITY_MISMATCH(
+            HttpStatus.CONFLICT,
+            "CONGESTION011",
+            "모니터링 이미지 경로의 세션, CCTV 또는 캡처 시각이 요청과 일치하지 않습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -318,6 +318,44 @@ class CongestionObservationServiceTest {
     }
 
     @Test
+    @DisplayName("빈 monitoringImageKey는 검증을 통과시키되 null로 정규화해서 저장한다")
+    void reportObservation_normalizesBlankMonitoringImageKeyToNull() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+
+        service.reportObservation(cctv, request(5.0, ""));
+
+        verify(observationRepository).saveIfAbsent(argThat(item ->
+                item.getMonitoringImageKey() == null));
+        verify(latestMonitoringCaptureRepository).updateIfLatest(argThat(capture ->
+                capture.getMonitoringImageKey() == null));
+    }
+
+    @Test
+    @DisplayName("monitoringImageKey의 capturedAt 세그먼트가 canonical decimal이 아니면 CONGESTION010을 반환한다")
+    void reportObservation_rejectsNonCanonicalCapturedAtSegment() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> service.reportObservation(
+                cctv, request(5.0, "training/" + sessionId + "/monitoring/CCTV_001/+2000.jpg")))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORING_IMAGE_KEY_INVALID);
+        assertThatThrownBy(() -> service.reportObservation(
+                cctv, request(5.0, "training/" + sessionId + "/monitoring/CCTV_001/02000.jpg")))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORING_IMAGE_KEY_INVALID);
+
+        verify(observationRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
     @DisplayName("monitoringImageKey 형식이 canonical 경로가 아니면 CONGESTION010을 반환한다")
     void reportObservation_rejectsMalformedMonitoringImageKey() {
         TrainingSession session = mock(TrainingSession.class);

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -112,9 +112,13 @@ class CongestionObservationServiceTest {
     }
 
     private ReportObservationRequest request(double avgHeadcount) {
+        return request(avgHeadcount, null);
+    }
+
+    private ReportObservationRequest request(double avgHeadcount, String monitoringImageKey) {
         return new ReportObservationRequest(
                 UUID.randomUUID(), sessionId, "CCTV_001", avgHeadcount, 8, 25,
-                1_000L, 2_000L, 2_000L, 1L, null
+                1_000L, 2_000L, 2_000L, 1L, monitoringImageKey
         );
     }
 
@@ -294,5 +298,87 @@ class CongestionObservationServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.EVENT_IDENTITY_MISMATCH);
 
         verify(observationRepository, never()).claimProcessing(anyString(), anyString(), anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("monitoringImageKey가 canonical 형식(training/{sessionId}/monitoring/{cctvCode}/{capturedAt}.jpg)이면 저장된다")
+    void reportObservation_acceptsValidMonitoringImageKey() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+        String key = "training/" + sessionId + "/monitoring/CCTV_001/2000.jpg";
+
+        service.reportObservation(cctv, request(5.0, key));
+
+        verify(observationRepository).saveIfAbsent(argThat(item ->
+                key.equals(item.getMonitoringImageKey())));
+    }
+
+    @Test
+    @DisplayName("monitoringImageKey 형식이 canonical 경로가 아니면 CONGESTION010을 반환한다")
+    void reportObservation_rejectsMalformedMonitoringImageKey() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> service.reportObservation(
+                cctv, request(5.0, "training/" + sessionId + "/monitoring/CCTV_001/2000.png")))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORING_IMAGE_KEY_INVALID);
+
+        verify(observationRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("monitoringImageKey의 세션 ID가 요청 세션과 다르면 CONGESTION011을 반환한다")
+    void reportObservation_rejectsMonitoringImageKeyWithDifferentSession() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        String otherSessionId = UUID.randomUUID().toString();
+
+        assertThatThrownBy(() -> service.reportObservation(
+                cctv, request(5.0, "training/" + otherSessionId + "/monitoring/CCTV_001/2000.jpg")))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORING_IMAGE_IDENTITY_MISMATCH);
+
+        verify(observationRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("monitoringImageKey의 CCTV 코드가 요청 CCTV와 다르면 CONGESTION011을 반환한다")
+    void reportObservation_rejectsMonitoringImageKeyWithDifferentCctvCode() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> service.reportObservation(
+                cctv, request(5.0, "training/" + sessionId + "/monitoring/CCTV_999/2000.jpg")))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORING_IMAGE_IDENTITY_MISMATCH);
+
+        verify(observationRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("monitoringImageKey의 capturedAt이 요청 capturedAt과 다르면 CONGESTION011을 반환한다")
+    void reportObservation_rejectsMonitoringImageKeyWithDifferentCapturedAt() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> service.reportObservation(
+                cctv, request(5.0, "training/" + sessionId + "/monitoring/CCTV_001/9999.jpg")))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORING_IMAGE_IDENTITY_MISMATCH);
+
+        verify(observationRepository, never()).saveIfAbsent(any());
     }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #134
- Branch: feat/#134

## 주요 내용

- 훈련 관측(Observation) 저장 시 `monitoringImageKey`를 검증 없이 그대로 신뢰하던 문제를 수정
- 허용 경로 형식(`training/{sessionId}/monitoring/{cctvCode}/{capturedAt}.jpg`)과 요청의 세션 ID·CCTV 코드·capturedAt 일치 여부를 검증한 뒤에만 저장하도록 변경
- 형식 오류(`CONGESTION010`), 신원 불일치(`CONGESTION011`) 전용 에러 코드 추가
- S3 객체 존재(HeadObject) 확인은 5초 주기 수신 경로의 지연/비용을 고려해 제외

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 모니터링 이미지 키의 경로 형식과 세션, CCTV, 캡처 시각 일치 여부를 저장 전에 검증합니다.
  * 잘못된 이미지 확장자나 식별 정보가 포함된 요청에 명확한 오류를 반환합니다.
  * 유효한 이미지 키는 정상적으로 저장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->