### PR TITLE
[FEAT] #136: 카메라별 프레임 목록 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvJpaRepository.java
@@ -29,6 +29,10 @@ public interface CctvJpaRepository extends JpaRepository<Cctv, UUID> {
     List<Cctv> findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
             UUID buildingId);
 
+    // 훈련 세션이 속한 건물의 CCTV인지 검증하기 위한 조회 (다른 건물의 CCTV ID 접근 차단)
+    @EntityGraph(attributePaths = {"customNode", "customNode.floor", "customNode.floor.building"})
+    Optional<Cctv> findByIdAndCustomNode_Floor_Building_Id(UUID id, UUID buildingId);
+
     @EntityGraph(attributePaths = {"customNode", "customNode.floor"})
     @Query("select cctv from Cctv cctv where cctv.id = :cctvId")
     Optional<Cctv> findByIdWithLocation(@Param("cctvId") UUID cctvId);

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
@@ -86,7 +86,7 @@ public class ObservationItem {
         item.pk = buildPk(item.eventId);
         item.sk = "META";
         item.gsi1Pk = buildGsi1Pk(item.trainingSessionId, cctvCode);
-        item.gsi1Sk = buildGsi1Sk(capturedAt);
+        item.gsi1Sk = buildGsi1Sk(capturedAt, item.eventId);
         return item;
     }
 
@@ -98,12 +98,15 @@ public class ObservationItem {
         return "SESSION#" + trainingSessionId + "#CCTV#" + cctvCode;
     }
 
-    public static String buildGsi1Sk(long capturedAt) {
+    // capturedAt만으로는 같은 캡처 시각을 가진 프레임이 같은 정렬 키를 갖게 되어
+    // 페이지 경계에서 sortLessThan 커서 조회 시 프레임이 누락될 수 있다.
+    // eventId를 tie-breaker로 덧붙여 정렬 키를 항상 고유하게 만든다.
+    public static String buildGsi1Sk(long capturedAt, String eventId) {
         return "TIME#" + String.format(
                 Locale.ROOT,
                 "%0" + GSI1_TIMESTAMP_WIDTH + "d",
                 capturedAt
-        );
+        ) + "#" + eventId;
     }
 
     @DynamoDbPartitionKey

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
@@ -183,7 +183,8 @@ public class ObservationRepository {
             String trainingSessionId,
             String cctvCode,
             int limit,
-            Long beforeCapturedAt
+            Long beforeCapturedAt,
+            String beforeEventId
     ) {
         validateLimit(limit);
         QueryConditional queryConditional = beforeCapturedAt == null
@@ -192,7 +193,7 @@ public class ObservationRepository {
                         .build())
                 : QueryConditional.sortLessThan(Key.builder()
                         .partitionValue(ObservationItem.buildGsi1Pk(trainingSessionId, cctvCode))
-                        .sortValue(ObservationItem.buildGsi1Sk(beforeCapturedAt))
+                        .sortValue(ObservationItem.buildGsi1Sk(beforeCapturedAt, beforeEventId))
                         .build());
         QueryEnhancedRequest request = QueryEnhancedRequest.builder()
                 .queryConditional(queryConditional)

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationRepository.java
@@ -179,6 +179,33 @@ public class ObservationRepository {
                 .toList();
     }
 
+    public List<ObservationItem> findPageBySessionIdAndCctvCode(
+            String trainingSessionId,
+            String cctvCode,
+            int limit,
+            Long beforeCapturedAt
+    ) {
+        validateLimit(limit);
+        QueryConditional queryConditional = beforeCapturedAt == null
+                ? QueryConditional.keyEqualTo(Key.builder()
+                        .partitionValue(ObservationItem.buildGsi1Pk(trainingSessionId, cctvCode))
+                        .build())
+                : QueryConditional.sortLessThan(Key.builder()
+                        .partitionValue(ObservationItem.buildGsi1Pk(trainingSessionId, cctvCode))
+                        .sortValue(ObservationItem.buildGsi1Sk(beforeCapturedAt))
+                        .build());
+        QueryEnhancedRequest request = QueryEnhancedRequest.builder()
+                .queryConditional(queryConditional)
+                .scanIndexForward(false)
+                .limit(limit)
+                .build();
+
+        return gsi1.query(request).stream()
+                .flatMap(page -> page.items().stream())
+                .limit(limit)
+                .toList();
+    }
+
     private void validateLimit(int limit) {
         if (limit <= 0) {
             throw new IllegalArgumentException("limit은 0보다 커야합니다.");

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -2,6 +2,8 @@ package com.saferoute.domain.training.controller;
 
 import com.saferoute.domain.training.dto.MonitoringCameraListApiResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.dto.MonitoringFrameListApiResponse;
+import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
 import com.saferoute.domain.training.service.TrainingMonitoringService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.TrainingSuccessCode;
@@ -11,13 +13,17 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(
@@ -27,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/sessions/{sessionId}/monitoring")
 @RequiredArgsConstructor
+@Validated
 public class TrainingMonitoringController {
 
     private final TrainingMonitoringService trainingMonitoringService;
@@ -200,6 +207,190 @@ public class TrainingMonitoringController {
                 trainingMonitoringService.getCameras(sessionId, authentication.getName());
         return ResponseEntity.ok(ApiResponse.success(
                 TrainingSuccessCode.MONITORING_CAMERA_LIST_FOUND,
+                response
+        ));
+    }
+
+    @Operation(
+            summary = "카메라별 프레임 목록 조회",
+            description = """
+                    특정 CCTV에서 캡처된 프레임을 최신순으로 페이지네이션 조회합니다.
+                    상세 모니터링 화면의 큰 이미지와 하단 프레임 탐색 UI에 사용됩니다.
+
+                    cursor를 생략하면 가장 최신 프레임부터 반환합니다. 다음 페이지가 있으면
+                    응답의 nextCursor를 다음 요청의 cursor로 그대로 전달하면 되며, hasNext가
+                    false이면 더 이상 조회할 프레임이 없다는 뜻입니다.
+
+                    각 프레임의 imageUrl은 S3 presigned GET URL이며 영구 URL이 아닙니다.
+                    이미지 업로드가 아직 끝나지 않은 프레임은 imageUrl, urlExpiresAt이 null로
+                    반환됩니다. capturedAt은 Unix epoch milliseconds 단위입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "카메라별 프레임 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    implementation = MonitoringFrameListApiResponse.class
+                            ),
+                            examples = @ExampleObject(
+                                    name = "프레임 목록",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "TRAINING_SUCCESS_007",
+                                              "message": "카메라별 프레임 목록 조회에 성공했습니다.",
+                                              "result": {
+                                                "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                                "cctvId": "67b86e33-7874-494c-855f-e591e7847c09",
+                                                "frames": [
+                                                  {
+                                                    "frameId": "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11",
+                                                    "capturedAt": 1787722095000,
+                                                    "imageUrl": "https://example-bucket.s3.amazonaws.com/training/session/monitoring/CCTV_001/frame.jpg",
+                                                    "urlExpiresAt": 1787725695000,
+                                                    "headcount": 12,
+                                                    "density": 0.42,
+                                                    "congestionLevel": "CROWDED"
+                                                  }
+                                                ],
+                                                "nextCursor": "MTc4NzcyMjA5NTAwMA",
+                                                "hasNext": true
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "cursor 형식이 올바르지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON400",
+                                      "message": "입력값이 올바르지 않습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "JWT가 없거나 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "MANAGER 권한이 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON403",
+                                      "message": "접근 권한이 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "세션이 없거나, 요청자와 다른 학교의 세션이거나, 세션이 속한 건물의 CCTV가 아님",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "세션을 찾을 수 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "TRAINING001",
+                                                      "message": "훈련 세션을 찾을 수 없습니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "CCTV를 찾을 수 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "CCTV001",
+                                                      "message": "CCTV를 찾을 수 없습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "훈련 세션이 RUNNING 상태가 아님",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING006",
+                                      "message": "진행 중인 훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "S3 presigned GET URL 발급 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "S3_ERROR_005",
+                                      "message": "S3 이미지 조회 URL 발급에 실패했습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    @GetMapping("/cameras/{cctvId}/frames")
+    public ResponseEntity<ApiResponse<MonitoringFrameListResponse>> getFrames(
+            @Parameter(
+                    description = "조회할 RUNNING 훈련 세션의 UUID",
+                    required = true,
+                    example = "d669294e-55e1-4c00-bf67-229d89b76948"
+            )
+            @PathVariable UUID sessionId,
+            @Parameter(
+                    description = "프레임을 조회할 CCTV의 UUID",
+                    required = true,
+                    example = "67b86e33-7874-494c-855f-e591e7847c09"
+            )
+            @PathVariable UUID cctvId,
+            @Parameter(description = "한 페이지에 조회할 프레임 개수", example = "20")
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int limit,
+            @Parameter(
+                    description = "이전 응답의 nextCursor. 생략하면 최신 프레임부터 조회",
+                    example = "MTc4NzcyMjA5NTAwMA"
+            )
+            @RequestParam(required = false) String cursor,
+            Authentication authentication
+    ) {
+        MonitoringFrameListResponse response = trainingMonitoringService.getFrames(
+                sessionId, cctvId, limit, cursor, authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success(
+                TrainingSuccessCode.MONITORING_FRAME_LIST_FOUND,
                 response
         ));
     }

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameListApiResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameListApiResponse.java
@@ -1,0 +1,22 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "MonitoringFrameListApiResponse",
+        description = "카메라별 프레임 목록의 공통 API 응답 스키마"
+)
+public record MonitoringFrameListApiResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean isSuccess,
+
+        @Schema(description = "응답 코드", example = "TRAINING_SUCCESS_007")
+        String code,
+
+        @Schema(description = "응답 메시지", example = "카메라별 프레임 목록 조회에 성공했습니다.")
+        String message,
+
+        @Schema(description = "카메라별 프레임 목록")
+        MonitoringFrameListResponse result
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameListResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameListResponse.java
@@ -1,0 +1,32 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "카메라별 프레임 목록 (최신순 커서 페이지네이션)")
+public record MonitoringFrameListResponse(
+        @Schema(description = "조회한 훈련 세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
+        UUID sessionId,
+
+        @Schema(description = "조회한 CCTV ID", example = "67b86e33-7874-494c-855f-e591e7847c09")
+        UUID cctvId,
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "최신 캡처순으로 정렬된 프레임 목록"),
+                schema = @Schema(implementation = MonitoringFrameResponse.class)
+        )
+        List<MonitoringFrameResponse> frames,
+
+        @Schema(
+                description = "다음 페이지 조회에 사용할 커서. 다음 페이지가 없으면 null",
+                example = "MTc4NzcyMjA5NTAwMA",
+                nullable = true
+        )
+        String nextCursor,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameResponse.java
@@ -1,0 +1,63 @@
+package com.saferoute.domain.training.dto;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상세 모니터링 화면의 프레임 한 장")
+public record MonitoringFrameResponse(
+        @Schema(description = "프레임(Observation) ID", example = "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11")
+        String frameId,
+
+        @Schema(description = "프레임 캡처 시각(Unix epoch milliseconds)", example = "1787722095000")
+        long capturedAt,
+
+        @Schema(
+                description = "프레임 이미지의 S3 presigned GET URL. 이미지 업로드가 아직 끝나지 않았으면 null",
+                example = "https://example-bucket.s3.amazonaws.com/training/session/monitoring/CCTV_001/frame.jpg",
+                nullable = true
+        )
+        String imageUrl,
+
+        @Schema(
+                description = "imageUrl 만료 시각(Unix epoch milliseconds). imageUrl이 없으면 null",
+                example = "1787725695000",
+                nullable = true
+        )
+        Long urlExpiresAt,
+
+        @Schema(description = "프레임 시점의 최대 인원수", example = "12", nullable = true)
+        Integer headcount,
+
+        @Schema(description = "프레임 시점의 밀집도", example = "0.42", nullable = true)
+        Double density,
+
+        @Schema(description = "프레임 시점의 혼잡 단계", example = "CROWDED", nullable = true)
+        CongestionLevel congestionLevel
+) {
+
+    public static MonitoringFrameResponse withoutImage(ObservationItem item) {
+        return new MonitoringFrameResponse(
+                item.getEventId(),
+                item.getCapturedAt(),
+                null,
+                null,
+                item.getPeakHeadcount(),
+                item.getDensity(),
+                item.getCongestionLevel()
+        );
+    }
+
+    public static MonitoringFrameResponse withImage(ObservationItem item, PresignedGetUrl presignedGetUrl) {
+        return new MonitoringFrameResponse(
+                item.getEventId(),
+                item.getCapturedAt(),
+                presignedGetUrl.viewUrl(),
+                presignedGetUrl.expiresAt().toEpochMilli(),
+                item.getPeakHeadcount(),
+                item.getDensity(),
+                item.getCongestionLevel()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/FrameCursor.java
+++ b/src/main/java/com/saferoute/domain/training/service/FrameCursor.java
@@ -1,0 +1,30 @@
+package com.saferoute.domain.training.service;
+
+import com.saferoute.global.api.code.ErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+// 프레임 목록의 nextCursor를 만들고 해석한다. 클라이언트에는 불투명한 문자열로만 노출된다.
+final class FrameCursor {
+
+    private FrameCursor() {
+    }
+
+    static String encode(long capturedAt) {
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(Long.toString(capturedAt).getBytes(StandardCharsets.UTF_8));
+    }
+
+    static Long decode(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        try {
+            String decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+            return Long.parseLong(decoded);
+        } catch (IllegalArgumentException exception) {
+            throw new ApiException(ErrorCode.INVALID_INPUT, exception);
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/FrameCursor.java
+++ b/src/main/java/com/saferoute/domain/training/service/FrameCursor.java
@@ -6,23 +6,37 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 // 프레임 목록의 nextCursor를 만들고 해석한다. 클라이언트에는 불투명한 문자열로만 노출된다.
+// capturedAt이 같은 프레임이 페이지 경계에 있어도 eventId를 함께 인코딩해 페이지 재개 지점을
+// 정확히 가리키도록 한다 (ObservationItem.buildGsi1Sk 참고).
 final class FrameCursor {
+
+    private static final String SEPARATOR = "|";
 
     private FrameCursor() {
     }
 
-    static String encode(long capturedAt) {
-        return Base64.getUrlEncoder().withoutPadding()
-                .encodeToString(Long.toString(capturedAt).getBytes(StandardCharsets.UTF_8));
+    record Position(long capturedAt, String eventId) {
     }
 
-    static Long decode(String cursor) {
+    static String encode(long capturedAt, String eventId) {
+        String raw = capturedAt + SEPARATOR + eventId;
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    static Position decode(String cursor) {
         if (cursor == null || cursor.isBlank()) {
             return null;
         }
         try {
             String decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
-            return Long.parseLong(decoded);
+            int separatorIndex = decoded.indexOf(SEPARATOR);
+            if (separatorIndex < 0 || separatorIndex == decoded.length() - 1) {
+                throw new IllegalArgumentException("cursor 형식이 올바르지 않습니다.");
+            }
+            long capturedAt = Long.parseLong(decoded.substring(0, separatorIndex));
+            String eventId = decoded.substring(separatorIndex + 1);
+            return new Position(capturedAt, eventId);
         } catch (IllegalArgumentException exception) {
             throw new ApiException(ErrorCode.INVALID_INPUT, exception);
         }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -71,11 +71,13 @@ public class TrainingMonitoringService {
     ) {
         TrainingSession session = findRunningSessionForSchool(sessionId, email);
         Cctv cctv = findCctvInSessionBuilding(cctvId, session);
-        Long beforeCapturedAt = FrameCursor.decode(cursor);
+        FrameCursor.Position position = FrameCursor.decode(cursor);
+        Long beforeCapturedAt = position != null ? position.capturedAt() : null;
+        String beforeEventId = position != null ? position.eventId() : null;
 
         // hasNext 판단을 위해 요청한 개수보다 하나 더 조회한다.
         List<ObservationItem> page = observationRepository.findPageBySessionIdAndCctvCode(
-                sessionId.toString(), cctv.getCode(), limit + 1, beforeCapturedAt);
+                sessionId.toString(), cctv.getCode(), limit + 1, beforeCapturedAt, beforeEventId);
 
         boolean hasNext = page.size() > limit;
         List<ObservationItem> items = hasNext ? page.subList(0, limit) : page;
@@ -83,7 +85,11 @@ public class TrainingMonitoringService {
         List<MonitoringFrameResponse> frames = items.stream()
                 .map(this::toFrameResponse)
                 .toList();
-        String nextCursor = hasNext ? FrameCursor.encode(items.get(items.size() - 1).getCapturedAt()) : null;
+        String nextCursor = hasNext
+                ? FrameCursor.encode(
+                        items.get(items.size() - 1).getCapturedAt(),
+                        items.get(items.size() - 1).getEventId())
+                : null;
 
         return new MonitoringFrameListResponse(sessionId, cctvId, frames, nextCursor, hasNext);
     }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -3,13 +3,18 @@ package com.saferoute.domain.training.service;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
 import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
+import com.saferoute.domain.training.dto.MonitoringFrameResponse;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.CctvErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
@@ -31,6 +36,7 @@ public class TrainingMonitoringService {
     private final TrainingSessionRepository trainingSessionRepository;
     private final CctvJpaRepository cctvJpaRepository;
     private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
+    private final ObservationRepository observationRepository;
     private final S3PresignedUrlService s3PresignedUrlService;
     private final SchoolContextService schoolContextService;
 
@@ -54,6 +60,46 @@ public class TrainingMonitoringService {
                 .map(cctv -> toResponse(cctv, capturesByCctvCode.get(cctv.getCode())))
                 .toList();
         return new MonitoringCameraListResponse(sessionId, cameras);
+    }
+
+    public MonitoringFrameListResponse getFrames(
+            UUID sessionId,
+            UUID cctvId,
+            int limit,
+            String cursor,
+            String email
+    ) {
+        TrainingSession session = findRunningSessionForSchool(sessionId, email);
+        Cctv cctv = findCctvInSessionBuilding(cctvId, session);
+        Long beforeCapturedAt = FrameCursor.decode(cursor);
+
+        // hasNext 판단을 위해 요청한 개수보다 하나 더 조회한다.
+        List<ObservationItem> page = observationRepository.findPageBySessionIdAndCctvCode(
+                sessionId.toString(), cctv.getCode(), limit + 1, beforeCapturedAt);
+
+        boolean hasNext = page.size() > limit;
+        List<ObservationItem> items = hasNext ? page.subList(0, limit) : page;
+
+        List<MonitoringFrameResponse> frames = items.stream()
+                .map(this::toFrameResponse)
+                .toList();
+        String nextCursor = hasNext ? FrameCursor.encode(items.get(items.size() - 1).getCapturedAt()) : null;
+
+        return new MonitoringFrameListResponse(sessionId, cctvId, frames, nextCursor, hasNext);
+    }
+
+    private Cctv findCctvInSessionBuilding(UUID cctvId, TrainingSession session) {
+        UUID buildingId = session.getScenario().getBuilding().getId();
+        return cctvJpaRepository.findByIdAndCustomNode_Floor_Building_Id(cctvId, buildingId)
+                .orElseThrow(() -> new ApiException(CctvErrorCode.CCTV_NOT_FOUND));
+    }
+
+    private MonitoringFrameResponse toFrameResponse(ObservationItem item) {
+        if (item.getMonitoringImageKey() == null || item.getMonitoringImageKey().isBlank()) {
+            return MonitoringFrameResponse.withoutImage(item);
+        }
+        PresignedGetUrl presignedGetUrl = s3PresignedUrlService.createGetUrl(item.getMonitoringImageKey());
+        return MonitoringFrameResponse.withImage(item, presignedGetUrl);
     }
 
     private TrainingSession findRunningSessionForSchool(UUID sessionId, String email) {

--- a/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
@@ -18,6 +18,11 @@ public enum TrainingSuccessCode implements BaseCode {
             HttpStatus.OK,
             "TRAINING_SUCCESS_006",
             "모니터링 카메라 목록 조회에 성공했습니다."
+    ),
+    MONITORING_FRAME_LIST_FOUND(
+            HttpStatus.OK,
+            "TRAINING_SUCCESS_007",
+            "카메라별 프레임 목록 조회에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -127,9 +127,11 @@ public class SecurityConfig {
                         ).hasRole("MANAGER")
 
                         // 훈련 모니터링 카메라와 캡처 이미지는 관리자 화면에서만 조회한다.
+                        // 카메라 카드 목록(/cameras)과 프레임 목록(/cameras/{cctvId}/frames)을 모두 포함해야 한다.
                         .requestMatchers(
                                 HttpMethod.GET,
-                                "/api/v1/sessions/*/monitoring/cameras"
+                                "/api/v1/sessions/*/monitoring/cameras",
+                                "/api/v1/sessions/*/monitoring/cameras/**"
                         ).hasRole("MANAGER")
 
                         // 경로 이탈률은 훈련 결과 분석용 관리자 화면 전용이다.

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
@@ -38,7 +38,7 @@ class TelemetryItemTest {
         assertThat(item.getSk()).isEqualTo("META");
         assertThat(item.getEdgeId()).isEqualTo(EDGE_ID.toString());
         assertThat(item.getGsi1Pk()).isEqualTo("SESSION#" + SESSION_ID + "#CCTV#CCTV_001");
-        assertThat(item.getGsi1Sk()).isEqualTo("TIME#0000001786500005000");
+        assertThat(item.getGsi1Sk()).isEqualTo("TIME#0000001786500005000#" + OBSERVATION_ID);
         assertThat(item.getEventStatus()).isEqualTo(EventProcessingStatus.RECEIVED);
         assertThat(item.getImageUploadStatus()).isEqualTo(ImageUploadStatus.PENDING);
     }
@@ -63,17 +63,25 @@ class TelemetryItemTest {
         assertThat(attributes.get("edgeId").s()).isEqualTo(EDGE_ID.toString());
         assertThat(attributes)
                 .containsEntry("GSI1_PK", AttributeValue.fromS("SESSION#" + SESSION_ID + "#CCTV#CCTV_001"))
-                .containsEntry("GSI1_SK", AttributeValue.fromS("TIME#0000001786500005000"));
+                .containsEntry("GSI1_SK", AttributeValue.fromS("TIME#0000001786500005000#" + OBSERVATION_ID));
     }
 
     @Test
     void 관측값의_GSI_시간키는_자릿수_경계에서도_시간순으로_정렬된다() {
-        String beforeBoundary = ObservationItem.buildGsi1Sk(999L);
-        String afterBoundary = ObservationItem.buildGsi1Sk(1_000L);
+        String beforeBoundary = ObservationItem.buildGsi1Sk(999L, OBSERVATION_ID.toString());
+        String afterBoundary = ObservationItem.buildGsi1Sk(1_000L, OBSERVATION_ID.toString());
 
-        assertThat(beforeBoundary).isEqualTo("TIME#0000000000000000999");
-        assertThat(afterBoundary).isEqualTo("TIME#0000000000000001000");
+        assertThat(beforeBoundary).isEqualTo("TIME#0000000000000000999#" + OBSERVATION_ID);
+        assertThat(afterBoundary).isEqualTo("TIME#0000000000000001000#" + OBSERVATION_ID);
         assertThat(afterBoundary).isGreaterThan(beforeBoundary);
+    }
+
+    @Test
+    void 캡처_시각이_같아도_eventId로_정렬키가_서로_달라진다() {
+        String first = ObservationItem.buildGsi1Sk(1_000L, EVENT_ID.toString());
+        String second = ObservationItem.buildGsi1Sk(1_000L, OBSERVATION_ID.toString());
+
+        assertThat(first).isNotEqualTo(second);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -5,9 +5,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
+import com.saferoute.domain.training.dto.MonitoringFrameResponse;
 import com.saferoute.domain.training.service.TrainingMonitoringService;
+import com.saferoute.global.api.code.ErrorCode;
+import com.saferoute.global.api.error.CctvErrorCode;
 import com.saferoute.global.api.error.S3ErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
@@ -216,5 +221,91 @@ class TrainingMonitoringControllerTest {
                 .andExpect(jsonPath("$.code").value("S3_ERROR_005"))
                 .andExpect(jsonPath("$.message")
                         .value("S3 이미지 조회 URL 발급에 실패했습니다."));
+    }
+
+    @Test
+    void 카메라별_프레임_목록을_공통_응답으로_반환한다() throws Exception {
+        MonitoringFrameResponse frame = new MonitoringFrameResponse(
+                "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11",
+                1_787_722_095_000L,
+                "https://example.com/frame.jpg",
+                1_787_725_695_000L,
+                12,
+                0.42,
+                CongestionLevel.CROWDED
+        );
+        given(trainingMonitoringService.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL))
+                .willReturn(new MonitoringFrameListResponse(
+                        SESSION_ID, CCTV_ID, List.of(frame), "next-cursor", true
+                ));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
+                        SESSION_ID, CCTV_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("TRAINING_SUCCESS_007"))
+                .andExpect(jsonPath("$.result.sessionId").value(SESSION_ID.toString()))
+                .andExpect(jsonPath("$.result.cctvId").value(CCTV_ID.toString()))
+                .andExpect(jsonPath("$.result.frames[0].frameId")
+                        .value("3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11"))
+                .andExpect(jsonPath("$.result.frames[0].capturedAt").value(1_787_722_095_000L))
+                .andExpect(jsonPath("$.result.frames[0].imageUrl")
+                        .value("https://example.com/frame.jpg"))
+                .andExpect(jsonPath("$.result.frames[0].urlExpiresAt").value(1_787_725_695_000L))
+                .andExpect(jsonPath("$.result.frames[0].headcount").value(12))
+                .andExpect(jsonPath("$.result.frames[0].density").value(0.42))
+                .andExpect(jsonPath("$.result.frames[0].congestionLevel").value("CROWDED"))
+                .andExpect(jsonPath("$.result.nextCursor").value("next-cursor"))
+                .andExpect(jsonPath("$.result.hasNext").value(true));
+    }
+
+    @Test
+    void limit과_cursor_쿼리파라미터를_서비스에_그대로_전달한다() throws Exception {
+        given(trainingMonitoringService.getFrames(SESSION_ID, CCTV_ID, 5, "prev-cursor", EMAIL))
+                .willReturn(new MonitoringFrameListResponse(SESSION_ID, CCTV_ID, List.of(), null, false));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
+                        SESSION_ID, CCTV_ID)
+                        .param("limit", "5")
+                        .param("cursor", "prev-cursor")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.frames").isEmpty())
+                .andExpect(jsonPath("$.result.hasNext").value(false));
+    }
+
+    @Test
+    void limit이_범위를_벗어나면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
+                        SESSION_ID, CCTV_ID)
+                        .param("limit", "0")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 세션이_속한_건물의_CCTV가_아니면_404를_반환한다() throws Exception {
+        given(trainingMonitoringService.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL))
+                .willThrow(new ApiException(CctvErrorCode.CCTV_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
+                        SESSION_ID, CCTV_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CCTV001"));
+    }
+
+    @Test
+    void cursor_형식이_올바르지_않으면_400을_반환한다() throws Exception {
+        given(trainingMonitoringService.getFrames(SESSION_ID, CCTV_ID, 20, "invalid-cursor", EMAIL))
+                .willThrow(new ApiException(ErrorCode.INVALID_INPUT));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
+                        SESSION_ID, CCTV_ID)
+                        .param("cursor", "invalid-cursor")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON400"));
     }
 }

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -11,15 +11,22 @@ import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
+import com.saferoute.domain.training.dto.MonitoringFrameResponse;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.code.ErrorCode;
+import com.saferoute.global.api.error.CctvErrorCode;
 import com.saferoute.global.api.error.S3ErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
@@ -51,6 +58,8 @@ class TrainingMonitoringServiceTest {
     @Mock
     private LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     @Mock
+    private ObservationRepository observationRepository;
+    @Mock
     private S3PresignedUrlService s3PresignedUrlService;
     @Mock
     private SchoolContextService schoolContextService;
@@ -63,6 +72,7 @@ class TrainingMonitoringServiceTest {
                 trainingSessionRepository,
                 cctvJpaRepository,
                 latestMonitoringCaptureRepository,
+                observationRepository,
                 s3PresignedUrlService,
                 schoolContextService
         );
@@ -405,6 +415,141 @@ class TrainingMonitoringServiceTest {
         verify(cctvJpaRepository, never())
                 .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
                         org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void 프레임_목록을_최신순으로_반환하고_다음_페이지가_있으면_커서를_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = frameCctv();
+        ObservationItem newest = observation(3_000L, "monitoring/frame-3.jpg");
+        ObservationItem middle = observation(2_000L, "monitoring/frame-2.jpg");
+        ObservationItem oldest = observation(1_000L, "monitoring/frame-1.jpg");
+        given(observationRepository.findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 3, null))
+                .willReturn(List.of(newest, middle, oldest));
+        given(s3PresignedUrlService.createGetUrl(org.mockito.ArgumentMatchers.anyString()))
+                .willReturn(new PresignedGetUrl(
+                        "https://example.com/frame.jpg",
+                        Instant.parse("2026-08-27T01:00:00Z")
+                ));
+
+        MonitoringFrameListResponse response = service.getFrames(SESSION_ID, CCTV_ID, 2, null, EMAIL);
+
+        assertThat(response.sessionId()).isEqualTo(SESSION_ID);
+        assertThat(response.cctvId()).isEqualTo(CCTV_ID);
+        assertThat(response.frames())
+                .extracting(MonitoringFrameResponse::capturedAt)
+                .containsExactly(3_000L, 2_000L);
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.nextCursor()).isEqualTo(FrameCursor.encode(2_000L));
+    }
+
+    @Test
+    void 마지막_페이지면_nextCursor가_없다() {
+        stubSession(TrainingStatus.RUNNING);
+        frameCctv();
+        ObservationItem only = observation(1_000L, "monitoring/frame-1.jpg");
+        given(observationRepository.findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 21, null))
+                .willReturn(List.of(only));
+        given(s3PresignedUrlService.createGetUrl("monitoring/frame-1.jpg"))
+                .willReturn(new PresignedGetUrl(
+                        "https://example.com/frame-1.jpg",
+                        Instant.parse("2026-08-27T01:00:00Z")
+                ));
+
+        MonitoringFrameListResponse response = service.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL);
+
+        assertThat(response.frames()).hasSize(1);
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    void cursor를_전달하면_해당_시점_이전_프레임을_조회한다() {
+        stubSession(TrainingStatus.RUNNING);
+        frameCctv();
+        given(observationRepository.findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 21, 1_000L))
+                .willReturn(List.of());
+
+        service.getFrames(SESSION_ID, CCTV_ID, 20, FrameCursor.encode(1_000L), EMAIL);
+
+        verify(observationRepository)
+                .findPageBySessionIdAndCctvCode(SESSION_ID.toString(), "CCTV_001", 21, 1_000L);
+    }
+
+    @Test
+    void 이미지_키가_없는_프레임은_imageUrl이_null이다() {
+        stubSession(TrainingStatus.RUNNING);
+        frameCctv();
+        ObservationItem withoutImage = observation(1_000L, null);
+        given(observationRepository.findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 21, null))
+                .willReturn(List.of(withoutImage));
+
+        MonitoringFrameResponse frame = service.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL)
+                .frames().get(0);
+
+        assertThat(frame.imageUrl()).isNull();
+        assertThat(frame.urlExpiresAt()).isNull();
+        verify(s3PresignedUrlService, never()).createGetUrl(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 세션이_속한_건물의_CCTV가_아니면_조회할_수_없다() {
+        stubSession(TrainingStatus.RUNNING);
+        given(cctvJpaRepository.findByIdAndCustomNode_Floor_Building_Id(CCTV_ID, BUILDING_ID))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CctvErrorCode.CCTV_NOT_FOUND);
+        verify(observationRepository, never())
+                .findPageBySessionIdAndCctvCode(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyInt(),
+                        org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void cursor_형식이_올바르지_않으면_400을_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
+        given(cctvJpaRepository.findByIdAndCustomNode_Floor_Building_Id(CCTV_ID, BUILDING_ID))
+                .willReturn(Optional.of(cctv));
+
+        assertThatThrownBy(() -> service.getFrames(SESSION_ID, CCTV_ID, 20, "not-a-valid-cursor!!", EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+    }
+
+    private Cctv frameCctv() {
+        Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
+        given(cctv.getCode()).willReturn("CCTV_001");
+        given(cctvJpaRepository.findByIdAndCustomNode_Floor_Building_Id(CCTV_ID, BUILDING_ID))
+                .willReturn(Optional.of(cctv));
+        return cctv;
+    }
+
+    private ObservationItem observation(long capturedAt, String monitoringImageKey) {
+        return ObservationItem.create(
+                UUID.randomUUID(),
+                SESSION_ID,
+                null,
+                "CCTV_001",
+                4.0,
+                5,
+                10,
+                0.42,
+                CongestionLevel.CROWDED,
+                capturedAt - 500,
+                capturedAt,
+                capturedAt,
+                monitoringImageKey,
+                1L
+        );
     }
 
     private void stubSession(TrainingStatus status) {

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -421,11 +421,14 @@ class TrainingMonitoringServiceTest {
     void 프레임_목록을_최신순으로_반환하고_다음_페이지가_있으면_커서를_반환한다() {
         stubSession(TrainingStatus.RUNNING);
         Cctv cctv = frameCctv();
-        ObservationItem newest = observation(3_000L, "monitoring/frame-3.jpg");
-        ObservationItem middle = observation(2_000L, "monitoring/frame-2.jpg");
-        ObservationItem oldest = observation(1_000L, "monitoring/frame-1.jpg");
+        UUID newestEventId = UUID.randomUUID();
+        UUID middleEventId = UUID.randomUUID();
+        UUID oldestEventId = UUID.randomUUID();
+        ObservationItem newest = observation(newestEventId, 3_000L, "monitoring/frame-3.jpg");
+        ObservationItem middle = observation(middleEventId, 2_000L, "monitoring/frame-2.jpg");
+        ObservationItem oldest = observation(oldestEventId, 1_000L, "monitoring/frame-1.jpg");
         given(observationRepository.findPageBySessionIdAndCctvCode(
-                SESSION_ID.toString(), "CCTV_001", 3, null))
+                SESSION_ID.toString(), "CCTV_001", 3, null, null))
                 .willReturn(List.of(newest, middle, oldest));
         given(s3PresignedUrlService.createGetUrl(org.mockito.ArgumentMatchers.anyString()))
                 .willReturn(new PresignedGetUrl(
@@ -441,16 +444,17 @@ class TrainingMonitoringServiceTest {
                 .extracting(MonitoringFrameResponse::capturedAt)
                 .containsExactly(3_000L, 2_000L);
         assertThat(response.hasNext()).isTrue();
-        assertThat(response.nextCursor()).isEqualTo(FrameCursor.encode(2_000L));
+        assertThat(response.nextCursor())
+                .isEqualTo(FrameCursor.encode(2_000L, middleEventId.toString()));
     }
 
     @Test
     void 마지막_페이지면_nextCursor가_없다() {
         stubSession(TrainingStatus.RUNNING);
         frameCctv();
-        ObservationItem only = observation(1_000L, "monitoring/frame-1.jpg");
+        ObservationItem only = observation(UUID.randomUUID(), 1_000L, "monitoring/frame-1.jpg");
         given(observationRepository.findPageBySessionIdAndCctvCode(
-                SESSION_ID.toString(), "CCTV_001", 21, null))
+                SESSION_ID.toString(), "CCTV_001", 21, null, null))
                 .willReturn(List.of(only));
         given(s3PresignedUrlService.createGetUrl("monitoring/frame-1.jpg"))
                 .willReturn(new PresignedGetUrl(
@@ -469,23 +473,55 @@ class TrainingMonitoringServiceTest {
     void cursor를_전달하면_해당_시점_이전_프레임을_조회한다() {
         stubSession(TrainingStatus.RUNNING);
         frameCctv();
+        UUID cursorEventId = UUID.randomUUID();
         given(observationRepository.findPageBySessionIdAndCctvCode(
-                SESSION_ID.toString(), "CCTV_001", 21, 1_000L))
+                SESSION_ID.toString(), "CCTV_001", 21, 1_000L, cursorEventId.toString()))
                 .willReturn(List.of());
 
-        service.getFrames(SESSION_ID, CCTV_ID, 20, FrameCursor.encode(1_000L), EMAIL);
+        service.getFrames(
+                SESSION_ID, CCTV_ID, 20, FrameCursor.encode(1_000L, cursorEventId.toString()), EMAIL);
 
-        verify(observationRepository)
-                .findPageBySessionIdAndCctvCode(SESSION_ID.toString(), "CCTV_001", 21, 1_000L);
+        verify(observationRepository).findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 21, 1_000L, cursorEventId.toString());
+    }
+
+    @Test
+    void 캡처_시각이_같은_프레임이_페이지_경계에_있어도_누락되지_않는다() {
+        stubSession(TrainingStatus.RUNNING);
+        frameCctv();
+        UUID firstEventId = UUID.randomUUID();
+        UUID secondEventId = UUID.randomUUID();
+        ObservationItem first = observation(firstEventId, 1_000L, "monitoring/first.jpg");
+        ObservationItem second = observation(secondEventId, 1_000L, "monitoring/second.jpg");
+        given(observationRepository.findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 2, null, null))
+                .willReturn(List.of(first, second));
+        given(observationRepository.findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 2, 1_000L, firstEventId.toString()))
+                .willReturn(List.of(second));
+        given(s3PresignedUrlService.createGetUrl(org.mockito.ArgumentMatchers.anyString()))
+                .willReturn(new PresignedGetUrl(
+                        "https://example.com/frame.jpg",
+                        Instant.parse("2026-08-27T01:00:00Z")
+                ));
+
+        MonitoringFrameListResponse firstPage = service.getFrames(SESSION_ID, CCTV_ID, 1, null, EMAIL);
+        MonitoringFrameListResponse secondPage = service.getFrames(
+                SESSION_ID, CCTV_ID, 1, firstPage.nextCursor(), EMAIL);
+
+        assertThat(firstPage.frames()).extracting(MonitoringFrameResponse::frameId)
+                .containsExactly(firstEventId.toString());
+        assertThat(secondPage.frames()).extracting(MonitoringFrameResponse::frameId)
+                .containsExactly(secondEventId.toString());
     }
 
     @Test
     void 이미지_키가_없는_프레임은_imageUrl이_null이다() {
         stubSession(TrainingStatus.RUNNING);
         frameCctv();
-        ObservationItem withoutImage = observation(1_000L, null);
+        ObservationItem withoutImage = observation(UUID.randomUUID(), 1_000L, null);
         given(observationRepository.findPageBySessionIdAndCctvCode(
-                SESSION_ID.toString(), "CCTV_001", 21, null))
+                SESSION_ID.toString(), "CCTV_001", 21, null, null))
                 .willReturn(List.of(withoutImage));
 
         MonitoringFrameResponse frame = service.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL)
@@ -510,6 +546,7 @@ class TrainingMonitoringServiceTest {
                         org.mockito.ArgumentMatchers.anyString(),
                         org.mockito.ArgumentMatchers.anyString(),
                         org.mockito.ArgumentMatchers.anyInt(),
+                        org.mockito.ArgumentMatchers.any(),
                         org.mockito.ArgumentMatchers.any());
     }
 
@@ -533,9 +570,9 @@ class TrainingMonitoringServiceTest {
         return cctv;
     }
 
-    private ObservationItem observation(long capturedAt, String monitoringImageKey) {
+    private ObservationItem observation(UUID eventId, long capturedAt, String monitoringImageKey) {
         return ObservationItem.create(
-                UUID.randomUUID(),
+                eventId,
                 SESSION_ID,
                 null,
                 "CCTV_001",

--- a/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
@@ -156,6 +156,34 @@ class SecurityAuthorizationIntegrationTest {
     }
 
     @Test
+    @DisplayName("일반 사용자는 훈련 모니터링 프레임 목록을 조회할 수 없다")
+    void normalUserCannotReadTrainingMonitoringFrames() throws Exception {
+        String token = signupAndLogin(UserRole.NORMAL);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
+                                UUID.randomUUID(), UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("관리자는 훈련 모니터링 프레임 목록 엔드포인트에 접근할 수 있다")
+    void managerCanReadTrainingMonitoringFrames() throws Exception {
+        String token = signupAndLogin(UserRole.MANAGER);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
+                                UUID.randomUUID(), UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
     @DisplayName("Swagger에 훈련 모니터링 카메라 API와 응답 예시가 노출된다")
     void trainingMonitoringApiIsDocumented() throws Exception {
         mockMvc.perform(get("/v3/api-docs"))


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #136
- Branch: feat/#136

## 주요 내용

- `GET /api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames` API 추가
  - `limit`(1~100, 기본 20), `cursor` 쿼리 파라미터로 최신 프레임부터 커서 페이지네이션 조회
  - 프레임별로 인원수(headcount), 밀도(density), 혼잡 단계(congestionLevel)와 S3 presigned GET URL(imageUrl) 포함
  - 응답에 `nextCursor`, `hasNext` 포함 — 프론트는 `nextCursor`를 다음 요청의 `cursor`로 그대로 넘기면 됨
  - 세션이 요청자 학교 소속인지, CCTV가 해당 세션이 속한 건물 소속인지 검증 (다른 학교/건물의 CCTV ID 접근 차단)
- ObservationRepository에 `gsi1Sk` 기준 `sortLessThan` 커서 조회 메서드 추가 (기존에는 offset 방식 페이지네이션만 존재)
- CctvJpaRepository에 세션이 속한 건물 소속 CCTV인지 확인하는 조회 메서드 추가
- 프레임 목록 응답 DTO(MonitoringFrameResponse/ListResponse) 및 커서 인코딩/디코딩용 FrameCursor 추가
- 기존 `/cameras` 엔드포인트와 동일한 스타일로 Swagger 문서화 (한글 설명 + 응답 예시)

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 세션과 CCTV별 모니터링 프레임 목록을 조회할 수 있습니다.
  - 최신 프레임부터 이미지 URL, 캡처 시각, 인원 수, 밀집도, 혼잡 단계 정보를 제공합니다.
  - `limit`과 커서를 사용한 페이지 단위 조회를 지원하며, 다음 페이지 존재 여부와 커서를 안내합니다.
  - 이미지가 없는 프레임도 조회할 수 있으며, 제공되는 이미지는 안전한 임시 URL로 확인할 수 있습니다.

- **오류 처리**
  - 잘못된 조회 조건, 커서, 접근 권한 및 CCTV 소속 오류를 명확한 응답으로 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->