### PR TITLE
[FEAT] #138: 실행 중인 훈련 조회 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -1,29 +1,137 @@
 package com.saferoute.domain.training.controller;
 
 import com.saferoute.domain.training.dto.CreateSessionRequest;
+import com.saferoute.domain.training.dto.TrainingSessionListApiResponse;
+import com.saferoute.domain.training.dto.TrainingSessionListResponse;
 import com.saferoute.domain.training.dto.TrainingSessionResponse;
+import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.service.TrainingSessionService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.TrainingSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "훈련 세션", description = "훈련 세션 생성/시작/종료 API")
+@Tag(name = "훈련 세션", description = "훈련 세션 생성/시작/종료/조회 API")
 @RestController
 @RequestMapping("/api/v1/sessions")
 @RequiredArgsConstructor
 public class TrainingSessionController {
 
   private final TrainingSessionService trainingSessionService;
+
+  @Operation(
+      summary = "상태별 훈련 세션 목록 조회",
+      description = """
+              요청자 학교 소속 훈련 세션을 상태로 필터링해 최신 시작 순으로 반환합니다.
+
+              모니터링 화면에 진입할 sessionId를 얻는 용도로 사용합니다.
+              예: GET /api/v1/sessions?status=RUNNING
+
+              해당 상태의 세션이 없으면 빈 배열을 반환합니다.
+              """
+  )
+  @ApiResponses({
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(
+          responseCode = "200",
+          description = "훈련 세션 목록 조회 성공",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @io.swagger.v3.oas.annotations.media.Schema(
+                  implementation = TrainingSessionListApiResponse.class
+              ),
+              examples = @ExampleObject(
+                  name = "실행 중인 세션 목록",
+                  value = """
+                          {
+                            "isSuccess": true,
+                            "code": "TRAINING_SUCCESS_008",
+                            "message": "훈련 세션 목록 조회에 성공했습니다.",
+                            "result": {
+                              "sessions": [
+                                {
+                                  "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                  "scenarioName": "3학년 A동 화재 대피 훈련",
+                                  "buildingId": "b5a6e5b0-1e3a-4b8a-9b8a-6a2b6b1f5a11",
+                                  "buildingName": "A동",
+                                  "status": "RUNNING",
+                                  "startedAt": "2026-08-26T05:26:00Z"
+                                }
+                              ]
+                            }
+                          }
+                          """
+              )
+          )
+      ),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(
+          responseCode = "400",
+          description = "status 값이 올바르지 않거나 누락됨",
+          content = @Content(
+              mediaType = "application/json",
+              examples = @ExampleObject(value = """
+                      {
+                        "isSuccess": false,
+                        "code": "COMMON400",
+                        "message": "입력값이 올바르지 않습니다."
+                      }
+                      """)
+          )
+      ),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(
+          responseCode = "401",
+          description = "JWT가 없거나 유효하지 않음",
+          content = @Content(
+              mediaType = "application/json",
+              examples = @ExampleObject(value = """
+                      {
+                        "isSuccess": false,
+                        "code": "COMMON401",
+                        "message": "인증이 필요합니다."
+                      }
+                      """)
+          )
+      ),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(
+          responseCode = "403",
+          description = "MANAGER 권한이 없음",
+          content = @Content(
+              mediaType = "application/json",
+              examples = @ExampleObject(value = """
+                      {
+                        "isSuccess": false,
+                        "code": "COMMON403",
+                        "message": "접근 권한이 없습니다."
+                      }
+                      """)
+          )
+      )
+  })
+  @GetMapping
+  public ResponseEntity<ApiResponse<TrainingSessionListResponse>> getSessions(
+      @Parameter(description = "조회할 세션 상태", required = true, example = "RUNNING")
+      @RequestParam TrainingStatus status,
+      Authentication authentication
+  ) {
+    TrainingSessionListResponse response =
+        trainingSessionService.getSessions(status, authentication.getName());
+    return ResponseEntity.ok(ApiResponse.success(TrainingSuccessCode.TRAINING_SESSION_LIST_FOUND, response));
+  }
 
   @PostMapping("/{scenarioId}")
   public ResponseEntity<TrainingSessionResponse> createTrainingSession(

--- a/src/main/java/com/saferoute/domain/training/dto/TrainingSessionListApiResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/TrainingSessionListApiResponse.java
@@ -1,0 +1,22 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "TrainingSessionListApiResponse",
+        description = "훈련 세션 목록의 공통 API 응답 스키마"
+)
+public record TrainingSessionListApiResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean isSuccess,
+
+        @Schema(description = "응답 코드", example = "TRAINING_SUCCESS_008")
+        String code,
+
+        @Schema(description = "응답 메시지", example = "훈련 세션 목록 조회에 성공했습니다.")
+        String message,
+
+        @Schema(description = "훈련 세션 목록")
+        TrainingSessionListResponse result
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/TrainingSessionListResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/TrainingSessionListResponse.java
@@ -1,0 +1,15 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "조건에 맞는 훈련 세션 목록")
+public record TrainingSessionListResponse(
+        @ArraySchema(
+                arraySchema = @Schema(description = "조회 조건에 맞는 세션 목록. 없으면 빈 배열"),
+                schema = @Schema(implementation = TrainingSessionSummaryResponse.class)
+        )
+        List<TrainingSessionSummaryResponse> sessions
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/TrainingSessionSummaryResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/TrainingSessionSummaryResponse.java
@@ -1,0 +1,40 @@
+package com.saferoute.domain.training.dto;
+
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(description = "훈련 세션 목록의 항목 하나")
+public record TrainingSessionSummaryResponse(
+        @Schema(description = "훈련 세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
+        UUID sessionId,
+
+        @Schema(description = "훈련 시나리오 이름", example = "3학년 A동 화재 대피 훈련")
+        String scenarioName,
+
+        @Schema(description = "훈련이 진행되는 건물 ID", example = "b5a6e5b0-1e3a-4b8a-9b8a-6a2b6b1f5a11")
+        UUID buildingId,
+
+        @Schema(description = "훈련이 진행되는 건물명", example = "A동")
+        String buildingName,
+
+        @Schema(description = "훈련 세션 상태", example = "RUNNING")
+        TrainingStatus status,
+
+        @Schema(description = "훈련 시작 시각", example = "2026-08-26T05:26:00Z")
+        Instant startedAt
+) {
+
+    public static TrainingSessionSummaryResponse from(TrainingSession session) {
+        return new TrainingSessionSummaryResponse(
+                session.getId(),
+                session.getScenario().getName(),
+                session.getScenario().getBuilding().getId(),
+                session.getScenario().getBuilding().getName(),
+                session.getStatus(),
+                session.getStartedAt()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +16,11 @@ import org.springframework.data.repository.query.Param;
 public interface TrainingSessionRepository extends JpaRepository<TrainingSession, UUID> {
 
   List<TrainingSession> findByStatusAndStartedAtBefore(TrainingStatus status, Instant threshold);
+
+  // 모니터링 화면 진입점: 요청자 학교 소속 세션 중 상태로 필터링해 최신 시작 순으로 반환한다.
+  @EntityGraph(attributePaths = {"scenario", "scenario.building"})
+  List<TrainingSession> findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(
+      TrainingStatus status, String schoolName);
 
   // Pi가 보낸 UUID 세션이 실행 중이고, 혼잡 엣지와 같은 건물에 속하는지 한 번에 검증한다.
   Optional<TrainingSession> findByIdAndStatusAndScenario_Building_Id(

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -4,7 +4,9 @@ import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
 import com.saferoute.domain.training.dto.RunningSessionResponse;
 import com.saferoute.domain.training.dto.ScheduledSessionResponse;
+import com.saferoute.domain.training.dto.TrainingSessionListResponse;
 import com.saferoute.domain.training.dto.TrainingSessionResponse;
+import com.saferoute.domain.training.dto.TrainingSessionSummaryResponse;
 import com.saferoute.domain.training.dto.TrainingStatusResponse;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
@@ -80,6 +82,18 @@ public class TrainingSessionService {
     } catch (DataIntegrityViolationException e) {
       throw new ApiException(TrainingErrorCode.SESSION_ALREADY_EXISTS);
     }
+  }
+
+  // 모니터링 화면 진입점: 프론트가 이 목록에서 sessionId를 얻어 모니터링 화면으로 이동한다.
+  @Transactional(readOnly = true)
+  public TrainingSessionListResponse getSessions(TrainingStatus status, String email) {
+    String schoolName = schoolContextService.getSchoolName(email);
+    List<TrainingSessionSummaryResponse> sessions = trainingSessionRepository
+        .findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(status, schoolName)
+        .stream()
+        .map(TrainingSessionSummaryResponse::from)
+        .toList();
+    return new TrainingSessionListResponse(sessions);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
@@ -23,6 +23,11 @@ public enum TrainingSuccessCode implements BaseCode {
             HttpStatus.OK,
             "TRAINING_SUCCESS_007",
             "카메라별 프레임 목록 조회에 성공했습니다."
+    ),
+    TRAINING_SESSION_LIST_FOUND(
+            HttpStatus.OK,
+            "TRAINING_SUCCESS_008",
+            "훈련 세션 목록 조회에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -134,6 +134,12 @@ public class SecurityConfig {
                                 "/api/v1/sessions/*/monitoring/cameras/**"
                         ).hasRole("MANAGER")
 
+                        // 세션 목록은 모니터링 화면 진입점으로 쓰이므로 카메라 조회와 동일하게 관리자 전용이다.
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/sessions"
+                        ).hasRole("MANAGER")
+
                         // 경로 이탈률은 훈련 결과 분석용 관리자 화면 전용이다.
                         .requestMatchers(
                                 HttpMethod.GET,

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
@@ -2,11 +2,14 @@ package com.saferoute.domain.training.controller;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.saferoute.domain.training.dto.TrainingSessionListResponse;
 import com.saferoute.domain.training.dto.TrainingSessionResponse;
+import com.saferoute.domain.training.dto.TrainingSessionSummaryResponse;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.service.TrainingSessionService;
 import com.saferoute.global.api.error.TrainingErrorCode;
@@ -14,6 +17,7 @@ import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.global.config.SecurityConfig;
 import com.saferoute.global.security.JwtAuthenticationFilter;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,6 +60,68 @@ class TrainingSessionControllerTest {
                 .adminName("박현지")
                 .scenarioName("정기 훈련")
                 .build();
+    }
+
+    // === getSessions ===
+
+    @Test
+    @DisplayName("GET /sessions?status=RUNNING - 세션 목록을 공통 응답으로 반환한다")
+    void getSessions_success() throws Exception {
+        UUID buildingId = UUID.randomUUID();
+        TrainingSessionSummaryResponse summary = new TrainingSessionSummaryResponse(
+                sessionId,
+                "3학년 A동 화재 대피 훈련",
+                buildingId,
+                "A동",
+                TrainingStatus.RUNNING,
+                Instant.parse("2026-08-26T05:26:00Z")
+        );
+        given(trainingSessionService.getSessions(TrainingStatus.RUNNING, EMAIL))
+                .willReturn(new TrainingSessionListResponse(List.of(summary)));
+
+        mockMvc.perform(get("/api/v1/sessions")
+                        .param("status", "RUNNING")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("TRAINING_SUCCESS_008"))
+                .andExpect(jsonPath("$.result.sessions[0].sessionId").value(sessionId.toString()))
+                .andExpect(jsonPath("$.result.sessions[0].scenarioName").value("3학년 A동 화재 대피 훈련"))
+                .andExpect(jsonPath("$.result.sessions[0].buildingId").value(buildingId.toString()))
+                .andExpect(jsonPath("$.result.sessions[0].buildingName").value("A동"))
+                .andExpect(jsonPath("$.result.sessions[0].status").value("RUNNING"));
+    }
+
+    @Test
+    @DisplayName("GET /sessions?status=RUNNING - 해당 상태의 세션이 없으면 빈 배열을 반환한다")
+    void getSessions_empty_returnsEmptyArray() throws Exception {
+        given(trainingSessionService.getSessions(TrainingStatus.RUNNING, EMAIL))
+                .willReturn(new TrainingSessionListResponse(List.of()));
+
+        mockMvc.perform(get("/api/v1/sessions")
+                        .param("status", "RUNNING")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.sessions").isEmpty());
+    }
+
+    @Test
+    @DisplayName("GET /sessions - status 파라미터가 없으면 400을 반환한다")
+    void getSessions_missingStatus_returnsBadRequest() throws Exception {
+        mockMvc.perform(get("/api/v1/sessions")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON400"));
+    }
+
+    @Test
+    @DisplayName("GET /sessions - status 값이 올바르지 않으면 400을 반환한다")
+    void getSessions_invalidStatus_returnsBadRequest() throws Exception {
+        mockMvc.perform(get("/api/v1/sessions")
+                        .param("status", "NOT_A_STATUS")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON400"));
     }
 
     // === start ===

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -9,8 +9,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
+import com.saferoute.domain.training.dto.TrainingSessionListResponse;
+import com.saferoute.domain.training.dto.TrainingSessionSummaryResponse;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.entity.TrainingScenario;
@@ -92,6 +95,52 @@ class TrainingSessionServiceTest {
                 .isInstanceOf(ApiException.class)
                 .extracting(exception -> ((ApiException) exception).getErrorCode())
                 .isEqualTo(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND);
+    }
+
+    // === getSessions ===
+
+    @Test
+    @DisplayName("요청자 학교의 상태별 세션 목록을 최신순으로 반환한다")
+    void getSessions_returnsSummariesForRequesterSchool() {
+        UUID buildingId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        given(building.getId()).willReturn(buildingId);
+        given(building.getName()).willReturn("A동");
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getName()).willReturn("3학년 A동 화재 대피 훈련");
+        given(scenario.getBuilding()).willReturn(building);
+        Instant startedAt = Instant.parse("2026-08-26T05:26:00Z");
+        TrainingSession session =
+                TrainingSession.create(TrainingStatus.RUNNING, startedAt, mock(User.class), scenario);
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        given(trainingSessionRepository
+                .findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(
+                        TrainingStatus.RUNNING, SCHOOL_NAME))
+                .willReturn(List.of(session));
+
+        TrainingSessionListResponse response = trainingSessionService.getSessions(TrainingStatus.RUNNING, EMAIL);
+
+        assertThat(response.sessions()).hasSize(1);
+        TrainingSessionSummaryResponse summary = response.sessions().get(0);
+        assertThat(summary.sessionId()).isEqualTo(sessionId);
+        assertThat(summary.scenarioName()).isEqualTo("3학년 A동 화재 대피 훈련");
+        assertThat(summary.buildingId()).isEqualTo(buildingId);
+        assertThat(summary.buildingName()).isEqualTo("A동");
+        assertThat(summary.status()).isEqualTo(TrainingStatus.RUNNING);
+        assertThat(summary.startedAt()).isEqualTo(startedAt);
+    }
+
+    @Test
+    @DisplayName("해당 상태의 세션이 없으면 빈 목록을 반환한다")
+    void getSessions_noMatchingSessions_returnsEmptyList() {
+        given(trainingSessionRepository
+                .findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(
+                        TrainingStatus.RUNNING, SCHOOL_NAME))
+                .willReturn(List.of());
+
+        TrainingSessionListResponse response = trainingSessionService.getSessions(TrainingStatus.RUNNING, EMAIL);
+
+        assertThat(response.sessions()).isEmpty();
     }
 
     // === create ===

--- a/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
@@ -184,6 +184,34 @@ class SecurityAuthorizationIntegrationTest {
     }
 
     @Test
+    @DisplayName("일반 사용자는 훈련 세션 목록을 조회할 수 없다")
+    void normalUserCannotReadTrainingSessions() throws Exception {
+        String token = signupAndLogin(UserRole.NORMAL);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions")
+                                .param("status", "RUNNING")
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("관리자는 훈련 세션 목록 엔드포인트에 접근할 수 있다")
+    void managerCanReadTrainingSessions() throws Exception {
+        String token = signupAndLogin(UserRole.MANAGER);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions")
+                                .param("status", "RUNNING")
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.sessions").isEmpty());
+    }
+
+    @Test
     @DisplayName("Swagger에 훈련 모니터링 카메라 API와 응답 예시가 노출된다")
     void trainingMonitoringApiIsDocumented() throws Exception {
         mockMvc.perform(get("/v3/api-docs"))


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #138
- Branch: feat/#138

## 주요 내용

- `GET /api/v1/sessions?status=RUNNING` API 추가
  - 요청자 학교 소속 훈련 세션만 상태로 필터링해 최신 시작 순으로 반환
  - 모니터링 화면 진입점: 프론트가 이 API로 sessionId를 얻어 `/monitoring/cameras`로 이동
  - 응답은 `sessionId, scenarioName, buildingId, buildingName, status, startedAt` 평탄한 구조 
  - 해당 상태의 세션이 없으면 빈 배열 반환
- `TrainingSessionRepository`에 `scenario`/`scenario.building`을 `@EntityGraph`로 한 번에 가져오는 조회 메서드 추가 (N+1 방지)
- 카메라 모니터링 API(`/monitoring/cameras`)와 동일하게 `SecurityConfig`에서 MANAGER 전용으로 제한 (NORMAL은 403)
- `status` 파라미터 누락/오입력은 기존 전역 예외 처리기가 `COMMON400`으로 처리

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 훈련 세션 목록 조회 API를 추가했습니다.
  - 상태별로 세션을 필터링하고, 소속 학교의 세션만 확인할 수 있습니다.
  - 세션 ID, 시나리오, 건물, 상태, 시작 시간을 목록으로 제공합니다.
  - 최신 시작 세션부터 정렬해 표시합니다.
  - 관리자 권한만 해당 목록을 조회할 수 있습니다.

- **문서화**
  - 요청 파라미터와 성공·오류 응답 정보를 API 문서에 추가했습니다.

- **테스트**
  - 정상 조회, 빈 목록, 잘못된 요청 및 권한 제한을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->