### PR TITLE
[FEAT] #140: FireZone 로직 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/UserZoneController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/UserZoneController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.UUID;
 
 @Tag(name = "유저 구역", description = "유저구역 등록/조회/수정/삭제 API")

--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/UserZoneController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/UserZoneController.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.evacuation.grid.dto.response.UserZoneCellsResponse;
 import com.saferoute.domain.evacuation.grid.dto.response.UserZoneResponse;
 import com.saferoute.domain.evacuation.grid.service.UserZoneService;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Tag(name = "유저 구역", description = "유저구역 등록/조회/수정/삭제 API")
 @RestController
 @RequestMapping("/api/v1/floors/{floorId}/user-zones")
 @RequiredArgsConstructor

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/FloorGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/FloorGridCellRepository.java
@@ -35,4 +35,19 @@ public interface FloorGridCellRepository extends JpaRepository<FloorGridCell, UU
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from FloorGridCell c where c.floor.id = :floorId")
     int deleteAllByFloorId(@Param("floorId") UUID floorId);
+
+    // 4방향(상하좌우) 인접 셀. 대각선까지 필요하면 조건 추가.
+    @Query("""
+        SELECT c FROM FloorGridCell c
+        WHERE c.floor.id = :floorId
+          AND (
+            (c.rowIndex = :row - 1 AND c.columnIndex = :column) OR
+            (c.rowIndex = :row + 1 AND c.columnIndex = :column) OR
+            (c.rowIndex = :row AND c.columnIndex = :column - 1) OR
+            (c.rowIndex = :row AND c.columnIndex = :column + 1)
+          )
+        """)
+    List<FloorGridCell> findAdjacent(@Param("floorId") UUID floorId,
+                                     @Param("row") int row,
+                                     @Param("column") int column);
 }

--- a/src/main/java/com/saferoute/domain/training/controller/FireZoneController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/FireZoneController.java
@@ -1,0 +1,35 @@
+package com.saferoute.domain.training.controller;
+
+import com.saferoute.domain.training.dto.CreateFireZoneRequest;
+import com.saferoute.domain.training.dto.FireZoneResponse;
+import com.saferoute.domain.training.service.FireZoneService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "화재구역", description = "훈련 시나리오 발화점 지정 API")
+@RestController
+@RequestMapping("/api/v1/scenarios/{scenarioId}/fire-zones")
+@RequiredArgsConstructor
+public class FireZoneController {
+
+    private final FireZoneService fireZoneService;
+
+    @PostMapping
+    public ResponseEntity<FireZoneResponse> designateOrigin(
+            @PathVariable UUID scenarioId,
+            @Valid @RequestBody CreateFireZoneRequest request,
+            Authentication authentication) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(fireZoneService.designateOrigin(scenarioId, request, authentication.getName()));
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/dto/CreateFireZoneRequest.java
+++ b/src/main/java/com/saferoute/domain/training/dto/CreateFireZoneRequest.java
@@ -1,0 +1,9 @@
+package com.saferoute.domain.training.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record CreateFireZoneRequest(
+        @NotNull UUID gridCellId
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/FireZoneResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/FireZoneResponse.java
@@ -1,0 +1,28 @@
+package com.saferoute.domain.training.dto;
+
+import com.saferoute.domain.training.entity.FireZone;
+import java.time.Instant;
+import java.util.UUID;
+
+public record FireZoneResponse(
+        UUID id,
+        UUID scenarioId,
+        UUID floorId,
+        UUID gridCellId,
+        boolean isManualAdd,
+        int spreadGeneration,
+        Instant addedAt
+) {
+
+    public static FireZoneResponse from(FireZone fireZone) {
+        return new FireZoneResponse(
+                fireZone.getId(),
+                fireZone.getScenarioId(),
+                fireZone.getFloorId(),
+                fireZone.getGridCellId(),
+                fireZone.getIsManualAdd(),
+                fireZone.getSpreadGeneration(),
+                fireZone.getAddedAt()
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/entity/FireZone.java
+++ b/src/main/java/com/saferoute/domain/training/entity/FireZone.java
@@ -64,11 +64,6 @@ public class FireZone {
         this.spreadGeneration = spreadGeneration;
     }
 
-    // 화재구역 등록용 정적 팩토리 메서드
-    public static FireZone create(TrainingScenario scenario, Floor floor, FloorGridCell gridCell, Boolean isManualAdd,  Integer spreadGeneration) {
-        return new FireZone(scenario, floor, gridCell, isManualAdd, spreadGeneration);
-    }
-
     // 관리자가 지정한 최초 발화점 등록용
     public static FireZone createOrigin(TrainingScenario scenario, Floor floor, FloorGridCell gridCell) {
         return new FireZone(scenario, floor, gridCell, true, 0);

--- a/src/main/java/com/saferoute/domain/training/entity/FireZone.java
+++ b/src/main/java/com/saferoute/domain/training/entity/FireZone.java
@@ -47,20 +47,36 @@ public class FireZone {
     @Column(name = "is_manual_add", nullable = false)
     private Boolean isManualAdd = false;
 
+    @NotNull
+    @Column(name = "spread_generation", nullable = false)
+    private Integer spreadGeneration;
+
     @CreatedDate
     @Column(name = "added_at", nullable = false, updatable = false)
     private Instant addedAt;
 
-    private FireZone(TrainingScenario scenario, Floor floor, FloorGridCell gridCell, Boolean isManualAdd) {
+    private FireZone(TrainingScenario scenario, Floor floor, FloorGridCell gridCell,
+                     Boolean isManualAdd, Integer spreadGeneration) {
         this.scenario = scenario;
         this.floor = floor;
         this.gridCell = gridCell;
         this.isManualAdd = isManualAdd != null ? isManualAdd : false;
+        this.spreadGeneration = spreadGeneration;
     }
 
     // 화재구역 등록용 정적 팩토리 메서드
-    public static FireZone create(TrainingScenario scenario, Floor floor, FloorGridCell gridCell, Boolean isManualAdd) {
-        return new FireZone(scenario, floor, gridCell, isManualAdd);
+    public static FireZone create(TrainingScenario scenario, Floor floor, FloorGridCell gridCell, Boolean isManualAdd,  Integer spreadGeneration) {
+        return new FireZone(scenario, floor, gridCell, isManualAdd, spreadGeneration);
+    }
+
+    // 관리자가 지정한 최초 발화점 등록용
+    public static FireZone createOrigin(TrainingScenario scenario, Floor floor, FloorGridCell gridCell) {
+        return new FireZone(scenario, floor, gridCell, true, 0);
+    }
+
+    // 확산 시뮬레이션이 새로 옮겨붙인 셀 등록용
+    public static FireZone createSpread(TrainingScenario scenario, Floor floor, FloorGridCell gridCell, int generation) {
+        return new FireZone(scenario, floor, gridCell, false, generation);
     }
 
     public UUID getScenarioId() { return scenario != null ? scenario.getId() : null; }

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingSession.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingSession.java
@@ -80,6 +80,7 @@ public class TrainingSession {
     private TrainingSession(TrainingStatus status, Instant startedAt, User admin, TrainingScenario scenario) {
         this.status = status;
         this.startedAt = startedAt;
+        this.lastSpreadAt = startedAt;
         this.admin = admin;
         this.scenario = scenario;
     }

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingSession.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingSession.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.report.entity.TrainingReport;
 import com.saferoute.domain.user.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
@@ -22,86 +23,99 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TrainingSession {
 
-  @Id
-  @GeneratedValue
-  private UUID id;
+    @Id
+    @GeneratedValue
+    private UUID id;
 
-  @Version
-  private Long version;
+    @Version
+    private Long version;
 
-  //훈련 상태 (RUNNING, STOPPED 등)
-  @NotNull
-  @Enumerated(EnumType.STRING)
-  @Column(name = "training_status", nullable = false, length = 20)
-  private TrainingStatus status;
+    //훈련 상태 (RUNNING, STOPPED 등)
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "training_status", nullable = false, length = 20)
+    private TrainingStatus status;
 
-  @Column(name = "started_at", nullable = false)
-  private Instant startedAt;
+    @Column(name = "started_at", nullable = false)
+    private Instant startedAt;
 
-  @Column(name = "ended_at")
-  private Instant endedAt;
+    @Column(name = "ended_at")
+    private Instant endedAt;
 
-  @Column(name = "act_participants")
-  private Integer actualParticipants;
+    @Column(name = "act_participants")
+    private Integer actualParticipants;
 
-  @Column(name = "survival_rate")
-  private BigDecimal currentSurvivalRate;
+    @Column(name = "survival_rate")
+    private BigDecimal currentSurvivalRate;
 
-  @Column(name = "avg_evacuation_sec")
-  private Integer currentAvgEvacuationSec;
+    @Column(name = "avg_evacuation_sec")
+    private Integer currentAvgEvacuationSec;
 
-  @CreatedDate
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private Instant createdAt;
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
 
-  @LastModifiedDate
-  @Column(name = "updated_at", nullable = false)
-  private Instant updatedAt;
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id", nullable = false)
-  private User admin;
+    @Column(name = "last_spread_at")
+    private Instant lastSpreadAt;
 
-  // 시나리오당 세션은 1개만 존재한다. 재훈련이 필요하면 시나리오를 새로 만든다.
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "training_scenario_id", nullable = false, unique = true)
-  private TrainingScenario scenario;
+    @Column(name = "current_generation", nullable = false)
+    private int currentGeneration = 0;
 
-  @OneToOne(mappedBy = "trainingSession", cascade = CascadeType.ALL)
-  private TrainingReport trainingReport;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User admin;
 
-  private TrainingSession(TrainingStatus status, Instant startedAt, User admin, TrainingScenario scenario) {
-    this.status = status;
-    this.startedAt = startedAt;
-    this.admin = admin;
-    this.scenario = scenario;
-  }
+    // 시나리오당 세션은 1개만 존재한다. 재훈련이 필요하면 시나리오를 새로 만든다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "training_scenario_id", nullable = false, unique = true)
+    private TrainingScenario scenario;
 
-  // 훈련 세션 생성용 정적 팩토리 메서드
-  public static TrainingSession create(TrainingStatus status, Instant startedAt, User admin, TrainingScenario scenario) {
-    return new TrainingSession(status, startedAt, admin, scenario);
-  }
+    @OneToOne(mappedBy = "trainingSession", cascade = CascadeType.ALL)
+    private TrainingReport trainingReport;
 
-  // 관리자가 훈련 시작 버튼을 누른 시각으로 실제 시작 시각을 갱신하며 RUNNING으로 전이한다.
-  public void start(Instant startedAt) {
-    this.status = TrainingStatus.RUNNING;
-    this.startedAt = startedAt;
-  }
+    private TrainingSession(TrainingStatus status, Instant startedAt, User admin, TrainingScenario scenario) {
+        this.status = status;
+        this.startedAt = startedAt;
+        this.admin = admin;
+        this.scenario = scenario;
+    }
 
-  // 훈련 정상 종료
-  public void complete(Instant endedAt) {
-    this.status = TrainingStatus.COMPLETED;
-    this.endedAt = endedAt;
-  }
+    // 훈련 세션 생성용 정적 팩토리 메서드
+    public static TrainingSession create(TrainingStatus status, Instant startedAt, User admin, TrainingScenario scenario) {
+        return new TrainingSession(status, startedAt, admin, scenario);
+    }
 
-  // 관리자에 의한 강제 종료
-  public void stop(Instant endedAt) {
-    this.status = TrainingStatus.STOPPED;
-    this.endedAt = endedAt;
-  }
+    // 관리자가 훈련 시작 버튼을 누른 시각으로 실제 시작 시각을 갱신하며 RUNNING으로 전이한다.
+    public void start(Instant startedAt) {
+        this.status = TrainingStatus.RUNNING;
+        this.startedAt = startedAt;
+        this.lastSpreadAt = startedAt;
+        this.currentGeneration = 0;
+    }
 
-  public void fail(Instant endedAt) {
-    this.status = TrainingStatus.FAILED;
-    this.endedAt = endedAt;
-  }
+    public void advanceSpread(int nextGeneration, Instant spreadAt) {
+        this.currentGeneration = nextGeneration;
+        this.lastSpreadAt = spreadAt;
+    }
+
+    // 훈련 정상 종료
+    public void complete(Instant endedAt) {
+        this.status = TrainingStatus.COMPLETED;
+        this.endedAt = endedAt;
+    }
+
+    // 관리자에 의한 강제 종료
+    public void stop(Instant endedAt) {
+        this.status = TrainingStatus.STOPPED;
+        this.endedAt = endedAt;
+    }
+
+    public void fail(Instant endedAt) {
+        this.status = TrainingStatus.FAILED;
+        this.endedAt = endedAt;
+    }
 }

--- a/src/main/java/com/saferoute/domain/training/repository/FireZoneRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/FireZoneRepository.java
@@ -15,12 +15,20 @@ public interface FireZoneRepository extends JpaRepository<FireZone, UUID> {
     // 현재 세대(frontier)에 속한 FireZone 조회 - 다음 확산의 시작점.
     List<FireZone> findByScenario_IdAndSpreadGeneration(UUID scenarioId, int spreadGeneration);
 
-    // 세션 종료 시 해당 시나리오의 화재 셀들 isFired = false로 일괄 초기화.
+    // 세션 종료 시 해당 시나리오의 화재 셀들 isFired = false로 일괄 초기화
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE FloorGridCell c SET c.isFired = false
         WHERE c.id IN (
             SELECT fz.gridCell.id FROM FireZone fz WHERE fz.scenario.id = :scenarioId
+        )
+        AND c.id NOT IN (
+            SELECT fz2.gridCell.id FROM FireZone fz2
+            WHERE fz2.scenario.id <> :scenarioId
+              AND fz2.scenario.id IN (
+                  SELECT ts.scenario.id FROM TrainingSession ts
+                  WHERE ts.status = com.saferoute.domain.training.entity.TrainingStatus.RUNNING
+              )
         )
         """)
     void resetFiredCellsByScenarioId(@Param("scenarioId") UUID scenarioId);

--- a/src/main/java/com/saferoute/domain/training/repository/FireZoneRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/FireZoneRepository.java
@@ -1,9 +1,27 @@
 package com.saferoute.domain.training.repository;
 
 import com.saferoute.domain.training.entity.FireZone;
+
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FireZoneRepository extends JpaRepository<FireZone, UUID> {
     void deleteAllByFloor_Id(UUID floorId);
+
+    // 현재 세대(frontier)에 속한 FireZone 조회 - 다음 확산의 시작점.
+    List<FireZone> findByScenario_IdAndSpreadGeneration(UUID scenarioId, int spreadGeneration);
+
+    // 세션 종료 시 해당 시나리오의 화재 셀들 isFired = false로 일괄 초기화.
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE FloorGridCell c SET c.isFired = false
+        WHERE c.id IN (
+            SELECT fz.gridCell.id FROM FireZone fz WHERE fz.scenario.id = :scenarioId
+        )
+        """)
+    void resetFiredCellsByScenarioId(@Param("scenarioId") UUID scenarioId);
 }

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -16,6 +16,8 @@ public interface TrainingSessionRepository extends JpaRepository<TrainingSession
 
   List<TrainingSession> findByStatusAndStartedAtBefore(TrainingStatus status, Instant threshold);
 
+  List<TrainingSession> findAllByStatus(TrainingStatus status);
+
   // Pi가 보낸 UUID 세션이 실행 중이고, 혼잡 엣지와 같은 건물에 속하는지 한 번에 검증한다.
   Optional<TrainingSession> findByIdAndStatusAndScenario_Building_Id(
       UUID id, TrainingStatus status, UUID buildingId);

--- a/src/main/java/com/saferoute/domain/training/scheduler/FireSpreadScheduler.java
+++ b/src/main/java/com/saferoute/domain/training/scheduler/FireSpreadScheduler.java
@@ -1,0 +1,24 @@
+package com.saferoute.domain.training.scheduler;
+
+import com.saferoute.domain.training.service.FireSpreadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+// RUNNING 세션들의 화재 확산을 주기적으로 진행
+// 실제 tick 여부(시나리오별 FireSpreadSpeed에 따른 간격, 최소 5초)는
+// FireSpreadService가 세션 단위(lastSpreadAt 기준)로 판단하므로,
+// 이 스캔 주기는 가장 빠른 속도(FAST=5초)보다 촘촘해야 tick을 놓치지 않는다.
+@Component
+@RequiredArgsConstructor
+public class FireSpreadScheduler {
+
+    private static final long SCAN_INTERVAL_MS = 2_000;
+
+    private final FireSpreadService fireSpreadService;
+
+    @Scheduled(fixedDelay = SCAN_INTERVAL_MS)
+    public void scanRunningSessions() {
+        fireSpreadService.spreadAllRunningSessions();
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/FireSpreadService.java
+++ b/src/main/java/com/saferoute/domain/training/service/FireSpreadService.java
@@ -1,96 +1,31 @@
 package com.saferoute.domain.training.service;
 
-import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
-import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
-import com.saferoute.domain.training.entity.FireSpreadSpeed;
-import com.saferoute.domain.training.entity.FireZone;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
-import com.saferoute.domain.training.repository.FireZoneRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
-import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-// RUNNING 세션의 화재를 인접 셀로 한 세대씩 확산
-// FireZone.spreadGeneration으로 확산을 추적해 매 tick마다 마지막 세대의 셀들만 조회
+// 스케줄러 진입점 - RUNNING 세션 전체를 순회하며 각각 독립적으로 확산
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FireSpreadService {
 
     private final TrainingSessionRepository sessionRepository;
-    private final FireZoneRepository fireZoneRepository;
-    private final FloorGridCellRepository gridCellRepository;
-    private final TrainingEventPublisher eventPublisher;
+    private final FireSpreadStepService fireSpreadStepService;
 
-    // 스케줄러 진입점 - RUNNING 세션 전체를 순회하며 각각 독립적으로 확산 시도
     public void spreadAllRunningSessions() {
         List<TrainingSession> running = sessionRepository.findAllByStatus(TrainingStatus.RUNNING);
         for (TrainingSession session : running) {
             try {
-                spreadOneStep(session.getId());
+                fireSpreadStepService.spreadOneStep(session.getId());
             } catch (Exception e) {
                 // 한 세션의 실패가 다른 세션의 확산을 막지 않도록 개별 격리
                 log.error("화재 확산 처리 실패, sessionId={}", session.getId(), e);
             }
         }
-    }
-
-    // 세션 하나의 확산을 1스텝 진행
-    @Transactional
-    public void spreadOneStep(UUID sessionId) {
-        TrainingSession session = sessionRepository.getReferenceById(sessionId);
-
-        Duration interval = tickIntervalOf(session.getScenario().getFireSpreadSpeed());
-        if (Duration.between(session.getLastSpreadAt(), Instant.now()).compareTo(interval) < 0) {
-            return;
-        }
-
-        UUID scenarioId = session.getScenario().getId();
-        int currentGen = session.getCurrentGeneration();
-
-        List<FireZone> frontier = fireZoneRepository
-                .findByScenario_IdAndSpreadGeneration(scenarioId, currentGen);
-
-        if (frontier.isEmpty()) {
-            return; // 더 이상 번질 곳 없음
-        }
-
-        int nextGen = currentGen + 1;
-        List<FireZone> newlyFired = new ArrayList<>();
-
-        for (FireZone fz : frontier) {
-            FloorGridCell cell = fz.getGridCell();
-            for (FloorGridCell neighbor : gridCellRepository
-                    .findAdjacent(cell.getFloor().getId(), cell.getRowIndex(), cell.getColumnIndex())) {
-                if (neighbor.isWalkable() && !neighbor.isFired()) {
-                    neighbor.markFired();
-                    newlyFired.add(FireZone.createSpread(fz.getScenario(), fz.getFloor(), neighbor, nextGen));
-                }
-            }
-        }
-
-        if (!newlyFired.isEmpty()) {
-            fireZoneRepository.saveAll(newlyFired);
-        }
-        session.advanceSpread(nextGen, Instant.now());
-
-        eventPublisher.publishFireSpreadUpdated(sessionId, nextGen, newlyFired);
-    }
-
-    private Duration tickIntervalOf(FireSpreadSpeed speed) {
-        return switch (speed) {
-            case FAST -> Duration.ofSeconds(5);
-            case MEDIUM -> Duration.ofSeconds(15);
-            case SLOW -> Duration.ofSeconds(30);
-        };
     }
 }

--- a/src/main/java/com/saferoute/domain/training/service/FireSpreadService.java
+++ b/src/main/java/com/saferoute/domain/training/service/FireSpreadService.java
@@ -1,0 +1,96 @@
+package com.saferoute.domain.training.service;
+
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.training.entity.FireSpreadSpeed;
+import com.saferoute.domain.training.entity.FireZone;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.FireZoneRepository;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// RUNNING 세션의 화재를 인접 셀로 한 세대씩 확산
+// FireZone.spreadGeneration으로 확산을 추적해 매 tick마다 마지막 세대의 셀들만 조회
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FireSpreadService {
+
+    private final TrainingSessionRepository sessionRepository;
+    private final FireZoneRepository fireZoneRepository;
+    private final FloorGridCellRepository gridCellRepository;
+    private final TrainingEventPublisher eventPublisher;
+
+    // 스케줄러 진입점 - RUNNING 세션 전체를 순회하며 각각 독립적으로 확산 시도
+    public void spreadAllRunningSessions() {
+        List<TrainingSession> running = sessionRepository.findAllByStatus(TrainingStatus.RUNNING);
+        for (TrainingSession session : running) {
+            try {
+                spreadOneStep(session.getId());
+            } catch (Exception e) {
+                // 한 세션의 실패가 다른 세션의 확산을 막지 않도록 개별 격리
+                log.error("화재 확산 처리 실패, sessionId={}", session.getId(), e);
+            }
+        }
+    }
+
+    // 세션 하나의 확산을 1스텝 진행
+    @Transactional
+    public void spreadOneStep(UUID sessionId) {
+        TrainingSession session = sessionRepository.getReferenceById(sessionId);
+
+        Duration interval = tickIntervalOf(session.getScenario().getFireSpreadSpeed());
+        if (Duration.between(session.getLastSpreadAt(), Instant.now()).compareTo(interval) < 0) {
+            return;
+        }
+
+        UUID scenarioId = session.getScenario().getId();
+        int currentGen = session.getCurrentGeneration();
+
+        List<FireZone> frontier = fireZoneRepository
+                .findByScenario_IdAndSpreadGeneration(scenarioId, currentGen);
+
+        if (frontier.isEmpty()) {
+            return; // 더 이상 번질 곳 없음
+        }
+
+        int nextGen = currentGen + 1;
+        List<FireZone> newlyFired = new ArrayList<>();
+
+        for (FireZone fz : frontier) {
+            FloorGridCell cell = fz.getGridCell();
+            for (FloorGridCell neighbor : gridCellRepository
+                    .findAdjacent(cell.getFloor().getId(), cell.getRowIndex(), cell.getColumnIndex())) {
+                if (neighbor.isWalkable() && !neighbor.isFired()) {
+                    neighbor.markFired();
+                    newlyFired.add(FireZone.createSpread(fz.getScenario(), fz.getFloor(), neighbor, nextGen));
+                }
+            }
+        }
+
+        if (!newlyFired.isEmpty()) {
+            fireZoneRepository.saveAll(newlyFired);
+        }
+        session.advanceSpread(nextGen, Instant.now());
+
+        eventPublisher.publishFireSpreadUpdated(sessionId, nextGen, newlyFired);
+    }
+
+    private Duration tickIntervalOf(FireSpreadSpeed speed) {
+        return switch (speed) {
+            case FAST -> Duration.ofSeconds(5);
+            case MEDIUM -> Duration.ofSeconds(15);
+            case SLOW -> Duration.ofSeconds(30);
+        };
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/FireSpreadStepService.java
+++ b/src/main/java/com/saferoute/domain/training/service/FireSpreadStepService.java
@@ -1,0 +1,80 @@
+package com.saferoute.domain.training.service;
+
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.training.entity.FireSpreadSpeed;
+import com.saferoute.domain.training.entity.FireZone;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.repository.FireZoneRepository;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 세션 하나의 화재 확산을 1스텝 진행한다.
+@Service
+@RequiredArgsConstructor
+public class FireSpreadStepService {
+
+    private final TrainingSessionRepository sessionRepository;
+    private final FireZoneRepository fireZoneRepository;
+    private final FloorGridCellRepository gridCellRepository;
+    private final TrainingEventPublisher eventPublisher;
+
+    @Transactional
+    public void spreadOneStep(UUID sessionId) {
+        TrainingSession session = sessionRepository.getReferenceById(sessionId);
+
+        Duration interval = tickIntervalOf(session.getScenario().getFireSpreadSpeed());
+
+        Instant lastSpreadAt = session.getLastSpreadAt() != null ? session.getLastSpreadAt() : session.getStartedAt();
+        if (Duration.between(lastSpreadAt, Instant.now()).compareTo(interval) < 0) {
+            return;
+        }
+
+        UUID scenarioId = session.getScenario().getId();
+        int currentGen = session.getCurrentGeneration();
+
+        List<FireZone> frontier = fireZoneRepository
+                .findByScenario_IdAndSpreadGeneration(scenarioId, currentGen);
+
+        if (frontier.isEmpty()) {
+            return; // 더 이상 번질 곳 없음
+        }
+
+        int nextGen = currentGen + 1;
+        List<FireZone> newlyFired = new ArrayList<>();
+
+        for (FireZone fz : frontier) {
+            FloorGridCell cell = fz.getGridCell();
+            for (FloorGridCell neighbor : gridCellRepository
+                    .findAdjacent(cell.getFloor().getId(), cell.getRowIndex(), cell.getColumnIndex())) {
+                if (neighbor.isWalkable() && !neighbor.isFired()) {
+                    neighbor.markFired();
+                    newlyFired.add(FireZone.createSpread(fz.getScenario(), fz.getFloor(), neighbor, nextGen));
+                }
+            }
+        }
+
+        if (!newlyFired.isEmpty()) {
+            fireZoneRepository.saveAll(newlyFired);
+        }
+        session.advanceSpread(nextGen, Instant.now());
+
+        eventPublisher.publishFireSpreadUpdatedAfterCommit(sessionId, nextGen, newlyFired);
+    }
+
+    private Duration tickIntervalOf(FireSpreadSpeed speed) {
+        return switch (speed) {
+            case FAST -> Duration.ofSeconds(5);
+            case MEDIUM -> Duration.ofSeconds(15);
+            case SLOW -> Duration.ofSeconds(30);
+        };
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/FireZoneService.java
+++ b/src/main/java/com/saferoute/domain/training/service/FireZoneService.java
@@ -1,0 +1,49 @@
+package com.saferoute.domain.training.service;
+
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.training.dto.CreateFireZoneRequest;
+import com.saferoute.domain.training.dto.FireZoneResponse;
+import com.saferoute.domain.training.entity.FireZone;
+import com.saferoute.domain.training.entity.TrainingScenario;
+import com.saferoute.domain.training.repository.FireZoneRepository;
+import com.saferoute.domain.training.repository.TrainingScenarioRepository;
+import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.GridErrorCode;
+import com.saferoute.global.api.error.TrainingErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FireZoneService {
+
+    private final FireZoneRepository fireZoneRepository;
+    private final TrainingScenarioRepository scenarioRepository;
+    private final FloorGridCellRepository gridCellRepository;
+    private final SchoolContextService schoolContextService;
+
+    //시나리오 설정 단계에서 최초 발화점을 지정
+    @Transactional
+    public FireZoneResponse designateOrigin(UUID scenarioId, CreateFireZoneRequest request, String email) {
+        String schoolName = schoolContextService.getSchoolName(email);
+        TrainingScenario scenario = scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, schoolName)
+                .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND));
+
+        FloorGridCell cell = gridCellRepository.findById(request.gridCellId())
+                .orElseThrow(() -> new ApiException(GridErrorCode.GRID_CELL_NOT_FOUND));
+
+        if (!cell.getFloor().getBuilding().getId().equals(scenario.getBuildingId())) {
+            throw new ApiException(GridErrorCode.GRID_CELL_FLOOR_MISMATCH);
+        }
+
+        cell.markFired();
+        FireZone origin = FireZone.createOrigin(scenario, cell.getFloor(), cell);
+        fireZoneRepository.save(origin);
+
+        return FireZoneResponse.from(origin);
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -173,7 +173,14 @@ public class TrainingSessionService {
     for (TrainingSession session : timedOutSessions) {
       session.fail(Instant.now());
       session.getScenario().markError();
-      fireZoneRepository.resetFiredCellsByScenarioId(session.getScenario().getId());
+    }
+
+    timedOutSessions.stream()
+        .map(session -> session.getScenario().getId())
+        .distinct()
+        .forEach(fireZoneRepository::resetFiredCellsByScenarioId);
+
+    for (TrainingSession session : timedOutSessions) {
       routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 타임아웃으로 무효화됨");
       trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
       log.info("훈련 세션 타임아웃 처리: sessionId={}", session.getId());

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -10,6 +10,7 @@ import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
+import com.saferoute.domain.training.repository.FireZoneRepository;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.entity.User;
@@ -43,6 +44,7 @@ public class TrainingSessionService {
   private final UserRepository userRepository;
   private final TrainingSessionRepository trainingSessionRepository;
   private final TrainingScenarioRepository trainingScenarioRepository;
+  private final FireZoneRepository fireZoneRepository;
   private final RouteRecalculationService routeRecalculationService;
   private final TrainingEventPublisher trainingEventPublisher;
   private final SchoolContextService schoolContextService;
@@ -136,6 +138,7 @@ public class TrainingSessionService {
 
     session.complete(Instant.now());
     session.getScenario().markCompleted();
+    fireZoneRepository.resetFiredCellsByScenarioId(session.getScenario().getId());
     routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 종료로 무효화됨");
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
@@ -153,6 +156,7 @@ public class TrainingSessionService {
 
     session.stop(Instant.now());
     session.getScenario().markError();
+    fireZoneRepository.resetFiredCellsByScenarioId(session.getScenario().getId());
     routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 강제 종료로 무효화됨");
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
@@ -169,6 +173,7 @@ public class TrainingSessionService {
     for (TrainingSession session : timedOutSessions) {
       session.fail(Instant.now());
       session.getScenario().markError();
+      fireZoneRepository.resetFiredCellsByScenarioId(session.getScenario().getId());
       routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 타임아웃으로 무효화됨");
       trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
       log.info("훈련 세션 타임아웃 처리: sessionId={}", session.getId());

--- a/src/main/java/com/saferoute/global/api/error/GridErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/GridErrorCode.java
@@ -11,7 +11,9 @@ public enum GridErrorCode implements BaseErrorCode {
     FLOOR_NOT_READY_FOR_GRID(HttpStatus.BAD_REQUEST, "GRID001", "도면 분석(realWidth/realHeight)이 완료되지 않아 그리드를 생성할 수 없습니다."),
     INVALID_CELL_SIZE(HttpStatus.BAD_REQUEST, "GRID002", "그리드 셀 크기는 0보다 커야 합니다."),
     CELL_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "GRID003", "셀 크기가 도면 전체 크기보다 큽니다."),
-    TOO_MANY_GRID_CELLS(HttpStatus.BAD_REQUEST, "GRID004", "셀 크기가 너무 작아 그리드 셀 개수가 허용 범위를 초과합니다.");
+    TOO_MANY_GRID_CELLS(HttpStatus.BAD_REQUEST, "GRID004", "셀 크기가 너무 작아 그리드 셀 개수가 허용 범위를 초과합니다."),
+    GRID_CELL_NOT_FOUND(HttpStatus.NOT_FOUND, "GRID005", "그리드 셀을 찾을 수 없습니다."),
+    GRID_CELL_FLOOR_MISMATCH(HttpStatus.BAD_REQUEST, "GRID006", "그리드 셀이 해당 시나리오의 건물에 속하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/FireSpreadEventData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/FireSpreadEventData.java
@@ -1,0 +1,23 @@
+package com.saferoute.infrastructure.websocket.dto;
+
+import com.saferoute.domain.training.entity.FireZone;
+import java.util.List;
+import java.util.UUID;
+
+public record FireSpreadEventData(
+        int spreadGeneration,
+        List<Cell> newlyFiredCells
+) {
+
+    public static FireSpreadEventData from(int spreadGeneration, List<FireZone> newlyFired) {
+        return new FireSpreadEventData(
+                spreadGeneration,
+                newlyFired.stream()
+                        .map(fz -> new Cell(fz.getGridCellId(), fz.getFloorId()))
+                        .toList()
+        );
+    }
+
+    public record Cell(UUID gridCellId, UUID floorId) {
+    }
+}

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/TrainingEventType.java
@@ -32,5 +32,8 @@ public enum TrainingEventType {
     ROUTE_RECALCULATION_CANCELLED,
 
     // IoTLightService.changeDirection() 호출 시 TrainingEventPublisher.publishIoTLightStatusUpdated()가 발행한다.
-    IOT_LIGHT_STATUS_UPDATED
+    IOT_LIGHT_STATUS_UPDATED,
+
+    // FireSpreadService가 화재 확산을 1스텝 진행시켜 새로 옮겨붙은 셀이 생겼을 때 발행된다.
+    FIRE_SPREAD_UPDATED
 }

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -5,11 +5,13 @@ import com.saferoute.domain.device.entity.IoTLightDirection;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.training.entity.FireZone;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.infrastructure.websocket.dto.CongestionEventData;
 import com.saferoute.infrastructure.websocket.dto.CongestionEventImageUpdatedData;
 import com.saferoute.infrastructure.websocket.dto.CongestionEventReceivedData;
 import com.saferoute.infrastructure.websocket.dto.CongestionImageUpdatedData;
+import com.saferoute.infrastructure.websocket.dto.FireSpreadEventData;
 import com.saferoute.infrastructure.websocket.dto.IoTLightEventMessage;
 import com.saferoute.infrastructure.websocket.dto.IoTLightStatusEventData;
 import com.saferoute.infrastructure.websocket.dto.RouteRecalculationEventData;
@@ -17,6 +19,7 @@ import com.saferoute.infrastructure.websocket.dto.TrainingEventMessage;
 import com.saferoute.infrastructure.websocket.dto.TrainingEventType;
 import com.saferoute.infrastructure.websocket.dto.TrainingStatusEventData;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -301,6 +304,28 @@ public class TrainingEventPublisher {
                 "재탐색 취소 이벤트 발행: sessionId={}, recalculationId={}",
                 sessionId,
                 recalculation.getId()
+        );
+    }
+
+    // FireSpreadService가 확산을 1스텝 진행시킬 때마다 호출한다. 새로 옮겨붙은 셀이 없으면 발행하지 않는다.
+    public void publishFireSpreadUpdated(UUID sessionId, int spreadGeneration, List<FireZone> newlyFired) {
+        if (newlyFired.isEmpty()) {
+            return;
+        }
+
+        TrainingEventMessage<FireSpreadEventData> message = TrainingEventMessage.of(
+                TrainingEventType.FIRE_SPREAD_UPDATED,
+                sessionId,
+                FireSpreadEventData.from(spreadGeneration, newlyFired)
+        );
+
+        messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
+
+        log.debug(
+                "화재 확산 이벤트 발행: sessionId={}, generation={}, newlyFiredCount={}",
+                sessionId,
+                spreadGeneration,
+                newlyFired.size()
         );
     }
 

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -307,6 +307,17 @@ public class TrainingEventPublisher {
         );
     }
 
+    // DB 트랜잭션이 실제로 커밋된 이후에만 발행
+    public void publishFireSpreadUpdatedAfterCommit(UUID sessionId, int spreadGeneration, List<FireZone> newlyFired) {
+        if (newlyFired.isEmpty()) {
+            return;
+        }
+        publishAfterCommit(
+                () -> publishFireSpreadUpdated(sessionId, spreadGeneration, newlyFired),
+                "커밋 후 화재 확산 이벤트 발행 실패: sessionId=" + sessionId
+        );
+    }
+
     // FireSpreadService가 확산을 1스텝 진행시킬 때마다 호출한다. 새로 옮겨붙은 셀이 없으면 발행하지 않는다.
     public void publishFireSpreadUpdated(UUID sessionId, int spreadGeneration, List<FireZone> newlyFired) {
         if (newlyFired.isEmpty()) {

--- a/src/test/java/com/saferoute/domain/training/repository/FireZoneRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/training/repository/FireZoneRepositoryTest.java
@@ -1,0 +1,132 @@
+package com.saferoute.domain.training.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.domain.training.entity.FireSpreadSpeed;
+import com.saferoute.domain.training.entity.FireZone;
+import com.saferoute.domain.training.entity.TrainingScenario;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.user.entity.User;
+import com.saferoute.domain.user.entity.UserRole;
+import com.saferoute.domain.user.repository.UserRepository;
+import com.saferoute.global.config.JpaAuditingConfig;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+// 건물당 동시 RUNNING 세션 1개는 DB로 강제되지 않으므로(TrainingSessionRepository 참고), 서로 다른
+// 시나리오가 같은 물리 그리드 셀을 화재구역으로 참조할 수 있다. resetFiredCellsByScenarioId가 한
+// 시나리오를 리셋할 때 그 셀을 다른 RUNNING 시나리오가 여전히 쓰고 있으면 꺼트리지 않는지 검증한다.
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class FireZoneRepositoryTest {
+
+    @Autowired
+    private FireZoneRepository fireZoneRepository;
+
+    @Autowired
+    private FloorGridCellRepository gridCellRepository;
+
+    @Autowired
+    private BuildingRepository buildingRepository;
+
+    @Autowired
+    private FloorRepository floorRepository;
+
+    @Autowired
+    private TrainingScenarioRepository scenarioRepository;
+
+    @Autowired
+    private TrainingSessionRepository sessionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private User admin;
+    private Building building;
+    private Floor floor;
+
+    private void setUpBuilding() {
+        admin = userRepository.save(User.create("admin", "password123!", "admin@saferoute.com", UserRole.MANAGER, "SafeRoute School"));
+        building = buildingRepository.save(Building.create("테스트관", "서울특별시 안전구 1", BuildingType.CLASSROOM, "SafeRoute School"));
+        floor = floorRepository.save(Floor.create(building, 1));
+    }
+
+    private TrainingScenario scenario(String name) {
+        return scenarioRepository.save(TrainingScenario.create(
+                name, 10, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin));
+    }
+
+    private void sessionWithStatus(TrainingScenario scenario, TrainingStatus status) {
+        TrainingSession session = TrainingSession.create(status, Instant.now(), admin, scenario);
+        sessionRepository.save(session);
+    }
+
+    private FloorGridCell cell(int row, int col) {
+        FloorGridCell created = gridCellRepository.save(FloorGridCell.create(floor, row, col, true, 0.0, 0.0));
+        created.markFired();
+        return created;
+    }
+
+    @Test
+    @DisplayName("다른 시나리오가 RUNNING으로 여전히 쓰는 셀은 리셋 대상에서 제외되고, 그 시나리오만 쓰는 셀은 리셋된다")
+    void resetFiredCellsByScenarioId_preservesCellStillUsedByAnotherRunningScenario() {
+        setUpBuilding();
+        TrainingScenario scenarioA = scenario("시나리오A");
+        TrainingScenario scenarioB = scenario("시나리오B");
+        sessionWithStatus(scenarioA, TrainingStatus.RUNNING);
+        sessionWithStatus(scenarioB, TrainingStatus.RUNNING);
+
+        FloorGridCell sharedCell = cell(0, 0);
+        FloorGridCell onlyACell = cell(0, 1);
+        fireZoneRepository.save(FireZone.createOrigin(scenarioA, floor, sharedCell));
+        fireZoneRepository.save(FireZone.createOrigin(scenarioB, floor, sharedCell));
+        fireZoneRepository.save(FireZone.createOrigin(scenarioA, floor, onlyACell));
+        entityManager.flush();
+
+        // 시나리오A가 종료되어 리셋된다. 시나리오B는 여전히 RUNNING이라 sharedCell은 꺼지면 안 된다.
+        fireZoneRepository.resetFiredCellsByScenarioId(scenarioA.getId());
+        entityManager.clear();
+
+        FloorGridCell reloadedShared = gridCellRepository.findById(sharedCell.getId()).orElseThrow();
+        FloorGridCell reloadedOnlyA = gridCellRepository.findById(onlyACell.getId()).orElseThrow();
+        assertThat(reloadedShared.isFired()).isTrue();
+        assertThat(reloadedOnlyA.isFired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("공유하던 다른 시나리오가 더 이상 RUNNING이 아니면 마지막 참조인 시나리오 종료 시 셀이 꺼진다")
+    void resetFiredCellsByScenarioId_clearsSharedCellWhenNoOtherRunningReference() {
+        setUpBuilding();
+        TrainingScenario scenarioA = scenario("시나리오A");
+        TrainingScenario scenarioB = scenario("시나리오B");
+        sessionWithStatus(scenarioA, TrainingStatus.RUNNING);
+        sessionWithStatus(scenarioB, TrainingStatus.COMPLETED); // 더 이상 RUNNING 아님
+
+        FloorGridCell sharedCell = cell(0, 0);
+        fireZoneRepository.save(FireZone.createOrigin(scenarioA, floor, sharedCell));
+        fireZoneRepository.save(FireZone.createOrigin(scenarioB, floor, sharedCell));
+        entityManager.flush();
+
+        fireZoneRepository.resetFiredCellsByScenarioId(scenarioA.getId());
+        entityManager.clear();
+
+        FloorGridCell reloaded = gridCellRepository.findById(sharedCell.getId()).orElseThrow();
+        assertThat(reloaded.isFired()).isFalse();
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/service/FireSpreadServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/FireSpreadServiceTest.java
@@ -1,36 +1,29 @@
 package com.saferoute.domain.training.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
-import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
-import com.saferoute.domain.floor.entity.Floor;
-import com.saferoute.domain.training.entity.FireSpreadSpeed;
-import com.saferoute.domain.training.entity.FireZone;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
-import com.saferoute.domain.training.repository.FireZoneRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
-import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import com.saferoute.domain.user.entity.User;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+// FireSpreadService는 RUNNING 세션을 순회하며 FireSpreadStepService(별도 빈)의 프록시를 통해
+// spreadOneStep을 호출하는 역할만 한다. 같은 클래스 안에서 직접 호출하면 self-invocation으로
+// @Transactional이 무시되므로, 반드시 다른 빈에 위임해야 한다 - 이 위임과 예외 격리만 검증한다.
 @ExtendWith(MockitoExtension.class)
 class FireSpreadServiceTest {
 
@@ -41,104 +34,41 @@ class FireSpreadServiceTest {
     private TrainingSessionRepository sessionRepository;
 
     @Mock
-    private FireZoneRepository fireZoneRepository;
+    private FireSpreadStepService fireSpreadStepService;
 
-    @Mock
-    private FloorGridCellRepository gridCellRepository;
-
-    @Mock
-    private TrainingEventPublisher eventPublisher;
-
-    private final UUID sessionId = UUID.randomUUID();
-    private final UUID scenarioId = UUID.randomUUID();
-    private final UUID floorId = UUID.randomUUID();
-
-    private FloorGridCell cellAt(Floor floor, int row, int col, boolean walkable) {
-        FloorGridCell cell = FloorGridCell.create(floor, row, col, walkable, 0.0, 0.0);
-        ReflectionTestUtils.setField(cell, "id", UUID.randomUUID());
-        return cell;
-    }
-
-    private TrainingSession sessionWith(FireSpreadSpeed speed, Instant lastSpreadAt, int currentGeneration,
-                                         TrainingScenario scenario) {
-        TrainingSession session = TrainingSession.create(TrainingStatus.RUNNING, lastSpreadAt, mock(
-                com.saferoute.domain.user.entity.User.class), scenario);
-        ReflectionTestUtils.setField(session, "currentGeneration", currentGeneration);
+    private TrainingSession runningSessionWithId(UUID id) {
+        TrainingSession session = TrainingSession.create(
+                TrainingStatus.RUNNING, Instant.now(), mock(User.class), mock(TrainingScenario.class));
+        ReflectionTestUtils.setField(session, "id", id);
         return session;
     }
 
     @Test
-    @DisplayName("마지막 확산 이후 시나리오 속도의 tick 간격이 지나지 않았으면 아무 것도 하지 않는다")
-    void spreadOneStep_intervalNotElapsed_doesNothing() {
-        TrainingScenario scenario = mock(TrainingScenario.class);
-        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST); // 5초 간격
-        TrainingSession session = sessionWith(FireSpreadSpeed.FAST, Instant.now(), 0, scenario);
-        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
+    @DisplayName("RUNNING 세션마다 FireSpreadStepService의 프록시를 통해 spreadOneStep을 호출한다")
+    void spreadAllRunningSessions_delegatesEachSessionToStepService() {
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        given(sessionRepository.findAllByStatus(TrainingStatus.RUNNING))
+                .willReturn(List.of(runningSessionWithId(id1), runningSessionWithId(id2)));
 
-        fireSpreadService.spreadOneStep(sessionId);
+        fireSpreadService.spreadAllRunningSessions();
 
-        verify(fireZoneRepository, never()).findByScenario_IdAndSpreadGeneration(any(), anyInt());
-        verify(eventPublisher, never()).publishFireSpreadUpdated(any(), anyInt(), any());
+        verify(fireSpreadStepService).spreadOneStep(id1);
+        verify(fireSpreadStepService).spreadOneStep(id2);
     }
 
     @Test
-    @DisplayName("tick 간격이 지나면 프론티어의 인접 셀 중 walkable하고 아직 안 붙은 셀에만 불이 옮겨붙고 세대가 1 증가한다")
-    void spreadOneStep_intervalElapsed_spreadsToWalkableUnfiredNeighborsOnly() {
-        Floor floor = mock(Floor.class);
-        given(floor.getId()).willReturn(floorId);
+    @DisplayName("한 세션의 확산 처리가 실패해도 다른 세션 처리는 계속된다")
+    void spreadAllRunningSessions_oneSessionFails_othersStillProcessed() {
+        UUID failingId = UUID.randomUUID();
+        UUID okId = UUID.randomUUID();
+        given(sessionRepository.findAllByStatus(TrainingStatus.RUNNING))
+                .willReturn(List.of(runningSessionWithId(failingId), runningSessionWithId(okId)));
+        doThrow(new RuntimeException("boom")).when(fireSpreadStepService).spreadOneStep(failingId);
 
-        TrainingScenario scenario = mock(TrainingScenario.class);
-        given(scenario.getId()).willReturn(scenarioId);
-        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST); // 5초 간격
+        fireSpreadService.spreadAllRunningSessions();
 
-        // 마지막 확산이 10초 전이라 5초 간격을 이미 지났다 -> 이번 tick에서 확산되어야 한다
-        TrainingSession session = sessionWith(FireSpreadSpeed.FAST, Instant.now().minusSeconds(10), 0, scenario);
-        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
-
-        FloorGridCell originCell = cellAt(floor, 1, 1, true);
-        FireZone origin = FireZone.createOrigin(scenario, floor, originCell);
-        given(fireZoneRepository.findByScenario_IdAndSpreadGeneration(scenarioId, 0))
-                .willReturn(List.of(origin));
-
-        FloorGridCell walkableUnfired = cellAt(floor, 1, 2, true);
-        FloorGridCell alreadyFired = cellAt(floor, 1, 0, true);
-        alreadyFired.markFired();
-        FloorGridCell notWalkable = cellAt(floor, 0, 1, false);
-        given(gridCellRepository.findAdjacent(floorId, 1, 1))
-                .willReturn(List.of(walkableUnfired, alreadyFired, notWalkable));
-
-        fireSpreadService.spreadOneStep(sessionId);
-
-        assertThat(walkableUnfired.isFired()).isTrue();
-        assertThat(notWalkable.isFired()).isFalse();
-        assertThat(session.getCurrentGeneration()).isEqualTo(1);
-
-        ArgumentCaptor<List<FireZone>> savedCaptor = ArgumentCaptor.forClass(List.class);
-        verify(fireZoneRepository).saveAll(savedCaptor.capture());
-        List<FireZone> saved = savedCaptor.getValue();
-        assertThat(saved).hasSize(1);
-        assertThat(saved.get(0).getGridCellId()).isEqualTo(walkableUnfired.getId());
-        assertThat(saved.get(0).getSpreadGeneration()).isEqualTo(1);
-
-        verify(eventPublisher).publishFireSpreadUpdated(sessionId, 1, saved);
-    }
-
-    @Test
-    @DisplayName("현재 세대의 프론티어가 비어있으면(더 이상 번질 곳이 없으면) 세대를 진행시키지 않는다")
-    void spreadOneStep_emptyFrontier_doesNotAdvanceGeneration() {
-        TrainingScenario scenario = mock(TrainingScenario.class);
-        given(scenario.getId()).willReturn(scenarioId);
-        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST);
-
-        TrainingSession session = sessionWith(FireSpreadSpeed.FAST, Instant.now().minusSeconds(10), 3, scenario);
-        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
-        given(fireZoneRepository.findByScenario_IdAndSpreadGeneration(scenarioId, 3))
-                .willReturn(List.of());
-
-        fireSpreadService.spreadOneStep(sessionId);
-
-        assertThat(session.getCurrentGeneration()).isEqualTo(3);
-        verify(fireZoneRepository, never()).saveAll(any());
-        verify(eventPublisher, never()).publishFireSpreadUpdated(any(), anyInt(), any());
+        verify(fireSpreadStepService).spreadOneStep(failingId);
+        verify(fireSpreadStepService).spreadOneStep(okId);
     }
 }

--- a/src/test/java/com/saferoute/domain/training/service/FireSpreadServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/FireSpreadServiceTest.java
@@ -1,0 +1,144 @@
+package com.saferoute.domain.training.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.training.entity.FireSpreadSpeed;
+import com.saferoute.domain.training.entity.FireZone;
+import com.saferoute.domain.training.entity.TrainingScenario;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.FireZoneRepository;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class FireSpreadServiceTest {
+
+    @InjectMocks
+    private FireSpreadService fireSpreadService;
+
+    @Mock
+    private TrainingSessionRepository sessionRepository;
+
+    @Mock
+    private FireZoneRepository fireZoneRepository;
+
+    @Mock
+    private FloorGridCellRepository gridCellRepository;
+
+    @Mock
+    private TrainingEventPublisher eventPublisher;
+
+    private final UUID sessionId = UUID.randomUUID();
+    private final UUID scenarioId = UUID.randomUUID();
+    private final UUID floorId = UUID.randomUUID();
+
+    private FloorGridCell cellAt(Floor floor, int row, int col, boolean walkable) {
+        FloorGridCell cell = FloorGridCell.create(floor, row, col, walkable, 0.0, 0.0);
+        ReflectionTestUtils.setField(cell, "id", UUID.randomUUID());
+        return cell;
+    }
+
+    private TrainingSession sessionWith(FireSpreadSpeed speed, Instant lastSpreadAt, int currentGeneration,
+                                         TrainingScenario scenario) {
+        TrainingSession session = TrainingSession.create(TrainingStatus.RUNNING, lastSpreadAt, mock(
+                com.saferoute.domain.user.entity.User.class), scenario);
+        ReflectionTestUtils.setField(session, "currentGeneration", currentGeneration);
+        return session;
+    }
+
+    @Test
+    @DisplayName("마지막 확산 이후 시나리오 속도의 tick 간격이 지나지 않았으면 아무 것도 하지 않는다")
+    void spreadOneStep_intervalNotElapsed_doesNothing() {
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST); // 5초 간격
+        TrainingSession session = sessionWith(FireSpreadSpeed.FAST, Instant.now(), 0, scenario);
+        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
+
+        fireSpreadService.spreadOneStep(sessionId);
+
+        verify(fireZoneRepository, never()).findByScenario_IdAndSpreadGeneration(any(), anyInt());
+        verify(eventPublisher, never()).publishFireSpreadUpdated(any(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("tick 간격이 지나면 프론티어의 인접 셀 중 walkable하고 아직 안 붙은 셀에만 불이 옮겨붙고 세대가 1 증가한다")
+    void spreadOneStep_intervalElapsed_spreadsToWalkableUnfiredNeighborsOnly() {
+        Floor floor = mock(Floor.class);
+        given(floor.getId()).willReturn(floorId);
+
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getId()).willReturn(scenarioId);
+        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST); // 5초 간격
+
+        // 마지막 확산이 10초 전이라 5초 간격을 이미 지났다 -> 이번 tick에서 확산되어야 한다
+        TrainingSession session = sessionWith(FireSpreadSpeed.FAST, Instant.now().minusSeconds(10), 0, scenario);
+        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
+
+        FloorGridCell originCell = cellAt(floor, 1, 1, true);
+        FireZone origin = FireZone.createOrigin(scenario, floor, originCell);
+        given(fireZoneRepository.findByScenario_IdAndSpreadGeneration(scenarioId, 0))
+                .willReturn(List.of(origin));
+
+        FloorGridCell walkableUnfired = cellAt(floor, 1, 2, true);
+        FloorGridCell alreadyFired = cellAt(floor, 1, 0, true);
+        alreadyFired.markFired();
+        FloorGridCell notWalkable = cellAt(floor, 0, 1, false);
+        given(gridCellRepository.findAdjacent(floorId, 1, 1))
+                .willReturn(List.of(walkableUnfired, alreadyFired, notWalkable));
+
+        fireSpreadService.spreadOneStep(sessionId);
+
+        assertThat(walkableUnfired.isFired()).isTrue();
+        assertThat(notWalkable.isFired()).isFalse();
+        assertThat(session.getCurrentGeneration()).isEqualTo(1);
+
+        ArgumentCaptor<List<FireZone>> savedCaptor = ArgumentCaptor.forClass(List.class);
+        verify(fireZoneRepository).saveAll(savedCaptor.capture());
+        List<FireZone> saved = savedCaptor.getValue();
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getGridCellId()).isEqualTo(walkableUnfired.getId());
+        assertThat(saved.get(0).getSpreadGeneration()).isEqualTo(1);
+
+        verify(eventPublisher).publishFireSpreadUpdated(sessionId, 1, saved);
+    }
+
+    @Test
+    @DisplayName("현재 세대의 프론티어가 비어있으면(더 이상 번질 곳이 없으면) 세대를 진행시키지 않는다")
+    void spreadOneStep_emptyFrontier_doesNotAdvanceGeneration() {
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getId()).willReturn(scenarioId);
+        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST);
+
+        TrainingSession session = sessionWith(FireSpreadSpeed.FAST, Instant.now().minusSeconds(10), 3, scenario);
+        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
+        given(fireZoneRepository.findByScenario_IdAndSpreadGeneration(scenarioId, 3))
+                .willReturn(List.of());
+
+        fireSpreadService.spreadOneStep(sessionId);
+
+        assertThat(session.getCurrentGeneration()).isEqualTo(3);
+        verify(fireZoneRepository, never()).saveAll(any());
+        verify(eventPublisher, never()).publishFireSpreadUpdated(any(), anyInt(), any());
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/service/FireSpreadStepServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/FireSpreadStepServiceTest.java
@@ -1,0 +1,162 @@
+package com.saferoute.domain.training.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.training.entity.FireSpreadSpeed;
+import com.saferoute.domain.training.entity.FireZone;
+import com.saferoute.domain.training.entity.TrainingScenario;
+import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
+import com.saferoute.domain.training.repository.FireZoneRepository;
+import com.saferoute.domain.training.repository.TrainingSessionRepository;
+import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class FireSpreadStepServiceTest {
+
+    @InjectMocks
+    private FireSpreadStepService fireSpreadStepService;
+
+    @Mock
+    private TrainingSessionRepository sessionRepository;
+
+    @Mock
+    private FireZoneRepository fireZoneRepository;
+
+    @Mock
+    private FloorGridCellRepository gridCellRepository;
+
+    @Mock
+    private TrainingEventPublisher eventPublisher;
+
+    private final UUID sessionId = UUID.randomUUID();
+    private final UUID scenarioId = UUID.randomUUID();
+    private final UUID floorId = UUID.randomUUID();
+
+    private FloorGridCell cellAt(Floor floor, int row, int col, boolean walkable) {
+        FloorGridCell cell = FloorGridCell.create(floor, row, col, walkable, 0.0, 0.0);
+        ReflectionTestUtils.setField(cell, "id", UUID.randomUUID());
+        return cell;
+    }
+
+    private TrainingSession sessionWith(Instant lastSpreadAt, int currentGeneration, TrainingScenario scenario) {
+        TrainingSession session = TrainingSession.create(TrainingStatus.RUNNING, lastSpreadAt, mock(
+                com.saferoute.domain.user.entity.User.class), scenario);
+        ReflectionTestUtils.setField(session, "currentGeneration", currentGeneration);
+        return session;
+    }
+
+    @Test
+    @DisplayName("마지막 확산 이후 시나리오 속도의 tick 간격이 지나지 않았으면 아무 것도 하지 않는다")
+    void spreadOneStep_intervalNotElapsed_doesNothing() {
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST); // 5초 간격
+        TrainingSession session = sessionWith(Instant.now(), 0, scenario);
+        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
+
+        fireSpreadStepService.spreadOneStep(sessionId);
+
+        verify(fireZoneRepository, never()).findByScenario_IdAndSpreadGeneration(any(), anyInt());
+        verify(eventPublisher, never()).publishFireSpreadUpdatedAfterCommit(any(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("lastSpreadAt이 null이어도 startedAt을 기준으로 간격을 판단해 NPE 없이 동작한다")
+    void spreadOneStep_lastSpreadAtNull_fallsBackToStartedAtWithoutNpe() {
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getId()).willReturn(scenarioId);
+        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST);
+
+        // lastSpreadAt=null인 세션 (예: 이 방어 코드가 없던 시절 생성된 RUNNING 세션)
+        TrainingSession session = TrainingSession.create(
+                TrainingStatus.RUNNING, Instant.now().minusSeconds(10), mock(com.saferoute.domain.user.entity.User.class), scenario);
+        ReflectionTestUtils.setField(session, "lastSpreadAt", null);
+        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
+        given(fireZoneRepository.findByScenario_IdAndSpreadGeneration(scenarioId, 0)).willReturn(List.of());
+
+        fireSpreadStepService.spreadOneStep(sessionId);
+
+        verify(fireZoneRepository).findByScenario_IdAndSpreadGeneration(scenarioId, 0);
+    }
+
+    @Test
+    @DisplayName("tick 간격이 지나면 프론티어의 인접 셀 중 walkable하고 아직 안 붙은 셀에만 불이 옮겨붙고 세대가 1 증가한다")
+    void spreadOneStep_intervalElapsed_spreadsToWalkableUnfiredNeighborsOnly() {
+        Floor floor = mock(Floor.class);
+        given(floor.getId()).willReturn(floorId);
+
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getId()).willReturn(scenarioId);
+        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST); // 5초 간격
+
+        // 마지막 확산이 10초 전이라 5초 간격을 이미 지났다 -> 이번 tick에서 확산되어야 한다
+        TrainingSession session = sessionWith(Instant.now().minusSeconds(10), 0, scenario);
+        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
+
+        FloorGridCell originCell = cellAt(floor, 1, 1, true);
+        FireZone origin = FireZone.createOrigin(scenario, floor, originCell);
+        given(fireZoneRepository.findByScenario_IdAndSpreadGeneration(scenarioId, 0))
+                .willReturn(List.of(origin));
+
+        FloorGridCell walkableUnfired = cellAt(floor, 1, 2, true);
+        FloorGridCell alreadyFired = cellAt(floor, 1, 0, true);
+        alreadyFired.markFired();
+        FloorGridCell notWalkable = cellAt(floor, 0, 1, false);
+        given(gridCellRepository.findAdjacent(floorId, 1, 1))
+                .willReturn(List.of(walkableUnfired, alreadyFired, notWalkable));
+
+        fireSpreadStepService.spreadOneStep(sessionId);
+
+        assertThat(walkableUnfired.isFired()).isTrue();
+        assertThat(notWalkable.isFired()).isFalse();
+        assertThat(session.getCurrentGeneration()).isEqualTo(1);
+
+        ArgumentCaptor<List<FireZone>> savedCaptor = ArgumentCaptor.forClass(List.class);
+        verify(fireZoneRepository).saveAll(savedCaptor.capture());
+        List<FireZone> saved = savedCaptor.getValue();
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getGridCellId()).isEqualTo(walkableUnfired.getId());
+        assertThat(saved.get(0).getSpreadGeneration()).isEqualTo(1);
+
+        verify(eventPublisher).publishFireSpreadUpdatedAfterCommit(sessionId, 1, saved);
+    }
+
+    @Test
+    @DisplayName("현재 세대의 프론티어가 비어있으면(더 이상 번질 곳이 없으면) 세대를 진행시키지 않는다")
+    void spreadOneStep_emptyFrontier_doesNotAdvanceGeneration() {
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getId()).willReturn(scenarioId);
+        given(scenario.getFireSpreadSpeed()).willReturn(FireSpreadSpeed.FAST);
+
+        TrainingSession session = sessionWith(Instant.now().minusSeconds(10), 3, scenario);
+        given(sessionRepository.getReferenceById(sessionId)).willReturn(session);
+        given(fireZoneRepository.findByScenario_IdAndSpreadGeneration(scenarioId, 3))
+                .willReturn(List.of());
+
+        fireSpreadStepService.spreadOneStep(sessionId);
+
+        assertThat(session.getCurrentGeneration()).isEqualTo(3);
+        verify(fireZoneRepository, never()).saveAll(any());
+        verify(eventPublisher, never()).publishFireSpreadUpdatedAfterCommit(any(), anyInt(), any());
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -14,6 +14,7 @@ import com.saferoute.domain.training.dto.CreateSessionRequest;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.entity.TrainingScenario;
+import com.saferoute.domain.training.repository.FireZoneRepository;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.entity.User;
@@ -55,6 +56,9 @@ class TrainingSessionServiceTest {
 
     @Mock
     private TrainingScenarioRepository trainingScenarioRepository;
+
+    @Mock
+    private FireZoneRepository fireZoneRepository;
 
     @Mock
     private RouteRecalculationService routeRecalculationService;


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #140 
- Branch:

## 주요 내용

-

## ✅ Check List

- [ ] 테스트 통과
- [ ] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 시나리오에 초기 화재 발생 지점을 지정할 수 있습니다.
  * 화재가 인접한 보행 가능 셀로 주기적으로 확산되며, 확산 단계와 신규 발화 셀이 실시간 이벤트로 전달됩니다.
  * 화재 확산 속도와 세션 상태에 따라 확산 처리가 진행됩니다.
* **개선**
  * 잘못된 셀 지정 시 명확한 오류가 제공됩니다.
  * 훈련 종료 또는 시간 초과 시 화재 상태가 자동으로 초기화됩니다.
* **문서화**
  * 사용자 구역 API에 Swagger/OpenAPI 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->