### PR TITLE
feat(websocket): CONGESTION_UPDATED 이벤트에 카드 식별 필드 추가 - #142

### DIFF
--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventData.java
@@ -4,23 +4,32 @@ import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import java.util.UUID;
 
+// 프론트가 카드 단위로 갱신 대상을 식별할 수 있도록 eventId/cctvCode/capturedAt/hasMonitoringImage를 포함한다 (이슈 #142).
 public record CongestionEventData(
+        UUID eventId,
         UUID edgeId,
+        String cctvCode,
         Double avgHeadcount,
         Integer peakHeadcount,
         CongestionLevel congestionLevel,
         Long windowStart,
-        Long windowEnd
+        Long windowEnd,
+        Long capturedAt,
+        boolean hasMonitoringImage
 ) {
 
     public static CongestionEventData from(UUID edgeId, ObservationItem item) {
         return new CongestionEventData(
+                UUID.fromString(item.getEventId()),
                 edgeId,
+                item.getCctvCode(),
                 item.getAvgHeadcount(),
                 item.getPeakHeadcount(),
                 item.getCongestionLevel(),
                 item.getWindowStart(),
-                item.getWindowEnd()
+                item.getWindowEnd(),
+                item.getCapturedAt(),
+                item.getMonitoringImageKey() != null && !item.getMonitoringImageKey().isBlank()
         );
     }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #142 
- Branch: feat/#142

## 주요 내용

- 프론트가 CCTV 카드 단위로 재조회할 대상을 식별할 수 있도록
eventId, cctvCode, capturedAt, hasMonitoringImage를 CongestionEventData에 추가

### 구현 내용

CongestionEventData.java에 필드 4개를 추가

- eventId — ObservationItem.eventId에서 가져옴 (UUID로 파싱)
- cctvCode — ObservationItem.cctvCode 그대로 노출
- capturedAt — ObservationItem.capturedAt 그대로 노출
- hasMonitoringImage — monitoringImageKey가 null/blank가 아니면 true. Pi가 관측값 저장 시점에 이미지 키를 함께 보내는 구조라(비동기 업로드가 아니라 CongestionObservationService.reportObservation에서 즉시 세팅), 값 존재 여부만으로 이미지 유무를 판단하면 됩니다.

- CongestionEventData.from(edgeId, item) 정적 팩토리만 수정하면 됐고, 
호출부인 TrainingEventPublisher.publishCongestionUpdated와 CongestionObservationService는 변경할 필요가 없었습니다 (이미 ObservationItem 전체를 넘기고 있었음).

### 범위에서 제외한 것 

- 프론트 "해당 CCTV 카드만 재조회" 로직 — FE 작업
- WebSocket 연결 끊김 시 polling fallback — 이미 5초 polling이 초기 버전 fallback 역할

컴파일 및 관련 유닛 테스트(CongestionObservationServiceTest, TrainingEventPublisherTest) 통과 확인했습니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?