### PR TITLE
Feat/#144 훈련 이벤트 타임라인 API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -2,6 +2,8 @@ package com.saferoute.domain.training.controller;
 
 import com.saferoute.domain.training.dto.MonitoringCameraListApiResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.dto.MonitoringEventListApiResponse;
+import com.saferoute.domain.training.dto.MonitoringEventListResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameListApiResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
 import com.saferoute.domain.training.service.TrainingMonitoringService;
@@ -391,6 +393,133 @@ public class TrainingMonitoringController {
                 sessionId, cctvId, limit, cursor, authentication.getName());
         return ResponseEntity.ok(ApiResponse.success(
                 TrainingSuccessCode.MONITORING_FRAME_LIST_FOUND,
+                response
+        ));
+    }
+
+    @Operation(
+            summary = "이벤트 타임라인 조회",
+            description = """
+                    실행 중인 훈련 세션에서 발생한 혼잡 감지 이벤트(CongestionEventItem)와
+                    경로 재탐색 이벤트(RouteRecalculation)를 발생 시각 오름차순으로 통합해 반환합니다.
+
+                    경로 재탐색 한 건은 요청 시점 이벤트 하나로 시작해, 관리자가 승인/거절하거나
+                    시스템이 자동 취소하면 해소 시점 이벤트가 하나 더 추가됩니다.
+
+                    cctvCode를 지정하면 해당 CCTV와 관련된 이벤트만 반환합니다.
+
+                    AI 분석 시작, 경로 이탈, 위험 구역 진입 이벤트는 아직 Pi/AI 쪽 이벤트 수신
+                    계약이 없어 이 API에 포함되지 않습니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "이벤트 타임라인 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    implementation = MonitoringEventListApiResponse.class
+                            ),
+                            examples = @ExampleObject(
+                                    name = "이벤트 타임라인",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "TRAINING_SUCCESS_009",
+                                              "message": "모니터링 이벤트 타임라인 조회에 성공했습니다.",
+                                              "result": {
+                                                "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                                "events": [
+                                                  {
+                                                    "eventId": "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11",
+                                                    "type": "CONGESTION_STARTED",
+                                                    "severity": "WARNING",
+                                                    "occurredAt": 1787722095000,
+                                                    "cctvCode": "CCTV_001",
+                                                    "congestionLevel": "CAUTION",
+                                                    "message": "혼잡 감지 · CCTV_001"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "JWT가 없거나 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "MANAGER 권한이 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON403",
+                                      "message": "접근 권한이 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "세션이 없거나 요청자와 다른 학교의 세션",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING001",
+                                      "message": "훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "훈련 세션이 RUNNING 상태가 아님",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING006",
+                                      "message": "진행 중인 훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    @GetMapping("/events")
+    public ResponseEntity<ApiResponse<MonitoringEventListResponse>> getEvents(
+            @Parameter(
+                    description = "조회할 RUNNING 훈련 세션의 UUID",
+                    required = true,
+                    example = "d669294e-55e1-4c00-bf67-229d89b76948"
+            )
+            @PathVariable UUID sessionId,
+            @Parameter(description = "특정 CCTV의 이벤트만 조회하려면 지정", example = "CCTV_001")
+            @RequestParam(required = false) String cctvCode,
+            Authentication authentication
+    ) {
+        MonitoringEventListResponse response = trainingMonitoringService.getEvents(
+                sessionId, cctvCode, authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success(
+                TrainingSuccessCode.MONITORING_EVENT_LIST_FOUND,
                 response
         ));
     }

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringEventListApiResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringEventListApiResponse.java
@@ -1,0 +1,22 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "MonitoringEventListApiResponse",
+        description = "이벤트 타임라인의 공통 API 응답 스키마"
+)
+public record MonitoringEventListApiResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean isSuccess,
+
+        @Schema(description = "응답 코드", example = "TRAINING_SUCCESS_009")
+        String code,
+
+        @Schema(description = "응답 메시지", example = "모니터링 이벤트 타임라인 조회에 성공했습니다.")
+        String message,
+
+        @Schema(description = "이벤트 타임라인")
+        MonitoringEventListResponse result
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringEventListResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringEventListResponse.java
@@ -1,0 +1,19 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "훈련 세션의 이벤트 타임라인")
+public record MonitoringEventListResponse(
+        @Schema(description = "조회한 훈련 세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
+        UUID sessionId,
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "발생 시각 오름차순으로 정렬된 이벤트 목록. 없으면 빈 배열"),
+                schema = @Schema(implementation = MonitoringEventResponse.class)
+        )
+        List<MonitoringEventResponse> events
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringEventResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringEventResponse.java
@@ -1,0 +1,75 @@
+package com.saferoute.domain.training.dto;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이벤트 타임라인 항목")
+public record MonitoringEventResponse(
+        @Schema(
+                description = "이벤트 ID. 혼잡 이벤트는 CongestionEventItem의 eventId, 경로 재탐색은 "
+                        + "recalculationId에 상태 접미사를 붙인 값(같은 재탐색이 요청/해소 두 항목으로 나뉠 수 있어서)",
+                example = "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11"
+        )
+        String eventId,
+
+        @Schema(description = "이벤트 종류")
+        MonitoringEventType type,
+
+        @Schema(description = "심각도")
+        MonitoringEventSeverity severity,
+
+        @Schema(description = "발생 시각(Unix epoch milliseconds)", example = "1787722095000")
+        long occurredAt,
+
+        @Schema(description = "관련 CCTV 코드", example = "CCTV_001")
+        String cctvCode,
+
+        @Schema(description = "이벤트 시점의 혼잡 단계", example = "CROWDED", nullable = true)
+        CongestionLevel congestionLevel,
+
+        @Schema(description = "사용자 표시 문구", example = "혼잡 감지 · CCTV_001")
+        String message
+) {
+
+    public static MonitoringEventResponse fromCongestionEvent(CongestionEventItem item) {
+        MonitoringEventType type = MonitoringEventType.from(item.getEventType());
+        return new MonitoringEventResponse(
+                item.getEventId(),
+                type,
+                type.severity(item.getCongestionLevel()),
+                item.getDetectedAt(),
+                item.getCctvCode(),
+                item.getCongestionLevel(),
+                type.message(item.getCctvCode(), item.getCongestionLevel())
+        );
+    }
+
+    public static MonitoringEventResponse requestedFrom(RouteRecalculation recalculation) {
+        MonitoringEventType type = MonitoringEventType.ROUTE_RECALCULATION_REQUESTED;
+        return new MonitoringEventResponse(
+                recalculation.getId() + ":REQUESTED",
+                type,
+                type.severity(recalculation.getCongestionLevel()),
+                recalculation.getRequestedAt().toEpochMilli(),
+                recalculation.getCctvCode(),
+                recalculation.getCongestionLevel(),
+                type.message(recalculation.getCctvCode(), recalculation.getCongestionLevel())
+        );
+    }
+
+    // recalculation.getResolvedAt()이 null이 아닌 경우에만 호출해야 한다 (MonitoringEventType.fromResolution 참고).
+    public static MonitoringEventResponse resolvedFrom(RouteRecalculation recalculation) {
+        MonitoringEventType type = MonitoringEventType.fromResolution(recalculation.getStatus());
+        return new MonitoringEventResponse(
+                recalculation.getId() + ":" + recalculation.getStatus(),
+                type,
+                type.severity(recalculation.getCongestionLevel()),
+                recalculation.getResolvedAt().toEpochMilli(),
+                recalculation.getCctvCode(),
+                recalculation.getCongestionLevel(),
+                type.message(recalculation.getCctvCode(), recalculation.getCongestionLevel())
+        );
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringEventSeverity.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringEventSeverity.java
@@ -1,0 +1,8 @@
+package com.saferoute.domain.training.dto;
+
+// 모니터링 타임라인 항목의 심각도. 프론트가 배지 색상을 고르는 데 사용한다.
+public enum MonitoringEventSeverity {
+    INFO,
+    WARNING,
+    DANGER
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringEventType.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringEventType.java
@@ -1,0 +1,114 @@
+package com.saferoute.domain.training.dto;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
+
+// 이벤트 타임라인(GET /api/v1/sessions/{sessionId}/monitoring/events)에 노출되는 이벤트 종류.
+// 심각도와 사용자 표시 문구를 종류별로 이 열거형이 직접 정의한다 (이슈 #144).
+//
+// AI 분석 시작/경로 이탈/위험 구역 진입은 아직 Pi/AI 쪽 이벤트 수신 계약이 없어 이 타임라인에 포함하지 않는다.
+public enum MonitoringEventType {
+    CONGESTION_STARTED {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return MonitoringEventSeverity.WARNING;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "혼잡 감지 · " + cctvCode;
+        }
+    },
+    CONGESTION_LEVEL_UP {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return level == CongestionLevel.VERY_CROWDED
+                    ? MonitoringEventSeverity.DANGER
+                    : MonitoringEventSeverity.WARNING;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "혼잡 단계 상승 · " + cctvCode + " (" + level + ")";
+        }
+    },
+    CONGESTION_ENDED {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return MonitoringEventSeverity.INFO;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "혼잡 해소 · " + cctvCode;
+        }
+    },
+    ROUTE_RECALCULATION_REQUESTED {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return MonitoringEventSeverity.WARNING;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "경로 재탐색 요청 · " + cctvCode;
+        }
+    },
+    EVACUATION_ROUTE_UPDATED {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return MonitoringEventSeverity.INFO;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "대피 경로 갱신 승인 · " + cctvCode;
+        }
+    },
+    ROUTE_RECALCULATION_REJECTED {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return MonitoringEventSeverity.INFO;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "경로 재탐색 거절 · " + cctvCode;
+        }
+    },
+    ROUTE_RECALCULATION_CANCELLED {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return MonitoringEventSeverity.INFO;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "경로 재탐색 취소 · " + cctvCode;
+        }
+    };
+
+    public abstract MonitoringEventSeverity severity(CongestionLevel level);
+
+    public abstract String message(String cctvCode, CongestionLevel level);
+
+    public static MonitoringEventType from(CongestionEventType congestionEventType) {
+        return switch (congestionEventType) {
+            case CONGESTION_STARTED -> CONGESTION_STARTED;
+            case CONGESTION_LEVEL_UP -> CONGESTION_LEVEL_UP;
+            case CONGESTION_ENDED -> CONGESTION_ENDED;
+        };
+    }
+
+    // PENDING은 아직 해소되지 않은 상태라 타임라인의 "해소" 이벤트로 변환할 대상이 아니다.
+    // 호출자(TrainingMonitoringService)가 resolvedAt이 있는 재탐색에 대해서만 호출해야 한다.
+    public static MonitoringEventType fromResolution(RecalculationStatus status) {
+        return switch (status) {
+            case APPROVED -> EVACUATION_ROUTE_UPDATED;
+            case REJECTED -> ROUTE_RECALCULATION_REJECTED;
+            case CANCELLED -> ROUTE_RECALCULATION_CANCELLED;
+            case PENDING -> throw new IllegalArgumentException("PENDING 상태는 해소 이벤트로 변환할 수 없습니다.");
+        };
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -2,12 +2,17 @@ package com.saferoute.domain.training.service;
 
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
 import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.dto.MonitoringEventListResponse;
+import com.saferoute.domain.training.dto.MonitoringEventResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameResponse;
 import com.saferoute.domain.training.entity.TrainingSession;
@@ -19,8 +24,11 @@ import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
 import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -37,6 +45,8 @@ public class TrainingMonitoringService {
     private final CctvJpaRepository cctvJpaRepository;
     private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final ObservationRepository observationRepository;
+    private final CongestionEventRepository congestionEventRepository;
+    private final RouteRecalculationRepository routeRecalculationRepository;
     private final S3PresignedUrlService s3PresignedUrlService;
     private final SchoolContextService schoolContextService;
 
@@ -92,6 +102,38 @@ public class TrainingMonitoringService {
                 : null;
 
         return new MonitoringFrameListResponse(sessionId, cctvId, frames, nextCursor, hasNext);
+    }
+
+    // 혼잡 감지 이벤트(CongestionEventItem)와 경로 재탐색 이벤트(RouteRecalculation)를 발생 시각순으로 합친다.
+    // 관측값(ObservationItem)은 5초 주기 스냅샷이라 타임라인에 넣으면 너무 촘촘해져서 제외한다 -
+    // "이벤트"로 부를 만한 STARTED/LEVEL_UP/ENDED 전환만 대상으로 한다.
+    // 재탐색 한 건은 요청 시점과(있다면) 해소 시점 두 항목으로 나뉠 수 있다.
+    public MonitoringEventListResponse getEvents(UUID sessionId, String cctvCode, String email) {
+        findRunningSessionForSchool(sessionId, email);
+
+        List<MonitoringEventResponse> events = new ArrayList<>();
+        congestionEventRepository.findAllBySessionId(sessionId.toString()).stream()
+                .filter(item -> matchesCctv(item.getCctvCode(), cctvCode))
+                .map(MonitoringEventResponse::fromCongestionEvent)
+                .forEach(events::add);
+
+        routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(sessionId).stream()
+                .filter(recalculation -> matchesCctv(recalculation.getCctvCode(), cctvCode))
+                .forEach(recalculation -> addRecalculationEvents(events, recalculation));
+
+        events.sort(Comparator.comparingLong(MonitoringEventResponse::occurredAt));
+        return new MonitoringEventListResponse(sessionId, events);
+    }
+
+    private void addRecalculationEvents(List<MonitoringEventResponse> events, RouteRecalculation recalculation) {
+        events.add(MonitoringEventResponse.requestedFrom(recalculation));
+        if (recalculation.getResolvedAt() != null) {
+            events.add(MonitoringEventResponse.resolvedFrom(recalculation));
+        }
+    }
+
+    private boolean matchesCctv(String eventCctvCode, String filterCctvCode) {
+        return filterCctvCode == null || Objects.equals(eventCctvCode, filterCctvCode);
     }
 
     private Cctv findCctvInSessionBuilding(UUID cctvId, TrainingSession session) {

--- a/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
@@ -28,6 +28,11 @@ public enum TrainingSuccessCode implements BaseCode {
             HttpStatus.OK,
             "TRAINING_SUCCESS_008",
             "훈련 세션 목록 조회에 성공했습니다."
+    ),
+    MONITORING_EVENT_LIST_FOUND(
+            HttpStatus.OK,
+            "TRAINING_SUCCESS_009",
+            "모니터링 이벤트 타임라인 조회에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -127,11 +127,13 @@ public class SecurityConfig {
                         ).hasRole("MANAGER")
 
                         // 훈련 모니터링 카메라와 캡처 이미지는 관리자 화면에서만 조회한다.
-                        // 카메라 카드 목록(/cameras)과 프레임 목록(/cameras/{cctvId}/frames)을 모두 포함해야 한다.
+                        // 카메라 카드 목록(/cameras), 프레임 목록(/cameras/{cctvId}/frames), 이벤트
+                        // 타임라인(/events)을 모두 포함해야 한다.
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/api/v1/sessions/*/monitoring/cameras",
-                                "/api/v1/sessions/*/monitoring/cameras/**"
+                                "/api/v1/sessions/*/monitoring/cameras/**",
+                                "/api/v1/sessions/*/monitoring/events"
                         ).hasRole("MANAGER")
 
                         // 세션 목록은 모니터링 화면 진입점으로 쓰이므로 카메라 조회와 동일하게 관리자 전용이다.

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -8,6 +8,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.dto.MonitoringEventListResponse;
+import com.saferoute.domain.training.dto.MonitoringEventResponse;
+import com.saferoute.domain.training.dto.MonitoringEventSeverity;
+import com.saferoute.domain.training.dto.MonitoringEventType;
 import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameResponse;
 import com.saferoute.domain.training.service.TrainingMonitoringService;
@@ -307,5 +311,69 @@ class TrainingMonitoringControllerTest {
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("COMMON400"));
+    }
+
+    @Test
+    void 이벤트_타임라인을_공통_응답으로_반환한다() throws Exception {
+        MonitoringEventResponse event = new MonitoringEventResponse(
+                "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11",
+                MonitoringEventType.CONGESTION_STARTED,
+                MonitoringEventSeverity.WARNING,
+                1_787_722_095_000L,
+                "CCTV_001",
+                CongestionLevel.CAUTION,
+                "혼잡 감지 · CCTV_001"
+        );
+        given(trainingMonitoringService.getEvents(SESSION_ID, null, EMAIL))
+                .willReturn(new MonitoringEventListResponse(SESSION_ID, List.of(event)));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("TRAINING_SUCCESS_009"))
+                .andExpect(jsonPath("$.result.sessionId").value(SESSION_ID.toString()))
+                .andExpect(jsonPath("$.result.events[0].eventId")
+                        .value("3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11"))
+                .andExpect(jsonPath("$.result.events[0].type").value("CONGESTION_STARTED"))
+                .andExpect(jsonPath("$.result.events[0].severity").value("WARNING"))
+                .andExpect(jsonPath("$.result.events[0].occurredAt").value(1_787_722_095_000L))
+                .andExpect(jsonPath("$.result.events[0].cctvCode").value("CCTV_001"))
+                .andExpect(jsonPath("$.result.events[0].congestionLevel").value("CAUTION"))
+                .andExpect(jsonPath("$.result.events[0].message").value("혼잡 감지 · CCTV_001"));
+    }
+
+    @Test
+    void cctvCode_쿼리파라미터를_서비스에_그대로_전달한다() throws Exception {
+        given(trainingMonitoringService.getEvents(SESSION_ID, "CCTV_001", EMAIL))
+                .willReturn(new MonitoringEventListResponse(SESSION_ID, List.of()));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
+                        .param("cctvCode", "CCTV_001")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.events").isEmpty());
+    }
+
+    @Test
+    void 이벤트_타임라인_조회시_세션을_찾을_수_없으면_404를_반환한다() throws Exception {
+        given(trainingMonitoringService.getEvents(SESSION_ID, null, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
+    void 이벤트_타임라인_조회시_실행_중인_세션이_아니면_409를_반환한다() throws Exception {
+        given(trainingMonitoringService.getEvents(SESSION_ID, null, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("TRAINING006"));
     }
 }

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -10,14 +10,23 @@ import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
+import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.dto.MonitoringEventListResponse;
+import com.saferoute.domain.training.dto.MonitoringEventResponse;
+import com.saferoute.domain.training.dto.MonitoringEventType;
 import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameResponse;
 import com.saferoute.domain.training.entity.TrainingScenario;
@@ -60,6 +69,10 @@ class TrainingMonitoringServiceTest {
     @Mock
     private ObservationRepository observationRepository;
     @Mock
+    private CongestionEventRepository congestionEventRepository;
+    @Mock
+    private RouteRecalculationRepository routeRecalculationRepository;
+    @Mock
     private S3PresignedUrlService s3PresignedUrlService;
     @Mock
     private SchoolContextService schoolContextService;
@@ -73,6 +86,8 @@ class TrainingMonitoringServiceTest {
                 cctvJpaRepository,
                 latestMonitoringCaptureRepository,
                 observationRepository,
+                congestionEventRepository,
+                routeRecalculationRepository,
                 s3PresignedUrlService,
                 schoolContextService
         );
@@ -562,6 +577,112 @@ class TrainingMonitoringServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
     }
 
+    @Test
+    void 혼잡_이벤트와_재탐색_이벤트를_발생_시각순으로_합쳐_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        CongestionEventItem congestionEvent = congestionEventItem(
+                "CCTV_001", CongestionEventType.CONGESTION_STARTED, 1_000L, CongestionLevel.CAUTION);
+        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(congestionEvent));
+        RouteRecalculation recalculation = recalculation(
+                "CCTV_001", CongestionLevel.CROWDED, Instant.ofEpochMilli(2_000L), null, null);
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of(recalculation));
+
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, EMAIL);
+
+        assertThat(response.sessionId()).isEqualTo(SESSION_ID);
+        assertThat(response.events())
+                .extracting(MonitoringEventResponse::type, MonitoringEventResponse::occurredAt)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.CONGESTION_STARTED, 1_000L),
+                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.ROUTE_RECALCULATION_REQUESTED, 2_000L)
+                );
+    }
+
+    @Test
+    void 해소된_재탐색은_요청과_해소_두_이벤트로_나뉜다() {
+        stubSession(TrainingStatus.RUNNING);
+        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString())).willReturn(List.of());
+        RouteRecalculation recalculation = recalculation(
+                "CCTV_001", CongestionLevel.CROWDED,
+                Instant.ofEpochMilli(1_000L), Instant.ofEpochMilli(3_000L), RecalculationStatus.APPROVED);
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of(recalculation));
+
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, EMAIL);
+
+        assertThat(response.events())
+                .extracting(MonitoringEventResponse::type)
+                .containsExactly(
+                        MonitoringEventType.ROUTE_RECALCULATION_REQUESTED,
+                        MonitoringEventType.EVACUATION_ROUTE_UPDATED
+                );
+    }
+
+    @Test
+    void cctvCode로_필터링한다() {
+        stubSession(TrainingStatus.RUNNING);
+        CongestionEventItem matching = congestionEventItem(
+                "CCTV_001", CongestionEventType.CONGESTION_STARTED, 1_000L, CongestionLevel.CAUTION);
+        CongestionEventItem other = congestionEventItem(
+                "CCTV_002", CongestionEventType.CONGESTION_STARTED, 1_500L, CongestionLevel.CAUTION);
+        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(matching, other));
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of());
+
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, "CCTV_001", EMAIL);
+
+        assertThat(response.events()).singleElement()
+                .extracting(MonitoringEventResponse::cctvCode)
+                .isEqualTo("CCTV_001");
+    }
+
+    @Test
+    void 이벤트가_없는_세션은_빈_타임라인을_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString())).willReturn(List.of());
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of());
+
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, EMAIL);
+
+        assertThat(response.events()).isEmpty();
+    }
+
+    @Test
+    void 이벤트_타임라인_조회는_실행_중이_아닌_세션은_거부한다() {
+        stubSession(TrainingStatus.COMPLETED);
+
+        assertThatThrownBy(() -> service.getEvents(SESSION_ID, null, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND);
+        verify(congestionEventRepository, never()).findAllBySessionId(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    private CongestionEventItem congestionEventItem(
+            String cctvCode, CongestionEventType type, long detectedAt, CongestionLevel level) {
+        return CongestionEventItem.received(
+                UUID.randomUUID(), SESSION_ID, cctvCode, type, detectedAt,
+                5, 0.3, CongestionLevel.NORMAL, 0.5, level, 1L, null);
+    }
+
+    private RouteRecalculation recalculation(
+            String cctvCode, CongestionLevel level, Instant requestedAt, Instant resolvedAt,
+            RecalculationStatus status) {
+        RouteRecalculation recalculation = org.mockito.Mockito.mock(RouteRecalculation.class);
+        given(recalculation.getId()).willReturn(UUID.randomUUID());
+        given(recalculation.getCctvCode()).willReturn(cctvCode);
+        given(recalculation.getCongestionLevel()).willReturn(level);
+        given(recalculation.getRequestedAt()).willReturn(requestedAt);
+        given(recalculation.getResolvedAt()).willReturn(resolvedAt);
+        if (resolvedAt != null) {
+            given(recalculation.getStatus()).willReturn(status);
+        }
+        return recalculation;
+    }
+
     private Cctv frameCctv() {
         Cctv cctv = org.mockito.Mockito.mock(Cctv.class);
         given(cctv.getCode()).willReturn("CCTV_001");
@@ -589,7 +710,7 @@ class TrainingMonitoringServiceTest {
         );
     }
 
-    private void stubSession(TrainingStatus status) {
+    private TrainingSession stubSession(TrainingStatus status) {
         TrainingSession session = org.mockito.Mockito.mock(TrainingSession.class);
         TrainingScenario scenario = org.mockito.Mockito.mock(TrainingScenario.class);
         Building building = org.mockito.Mockito.mock(Building.class);
@@ -597,10 +718,12 @@ class TrainingMonitoringServiceTest {
                 SESSION_ID, SCHOOL_NAME)).willReturn(Optional.of(session));
         given(session.getStatus()).willReturn(status);
         if (status == TrainingStatus.RUNNING) {
-            given(session.getScenario()).willReturn(scenario);
-            given(scenario.getBuilding()).willReturn(building);
-            given(building.getId()).willReturn(BUILDING_ID);
+            // getEvents()는 건물 정보를 쓰지 않으므로, 그 테스트들에서는 아래 스텁이 사용되지 않는다 - lenient 처리.
+            org.mockito.Mockito.lenient().when(session.getScenario()).thenReturn(scenario);
+            org.mockito.Mockito.lenient().when(scenario.getBuilding()).thenReturn(building);
+            org.mockito.Mockito.lenient().when(building.getId()).thenReturn(BUILDING_ID);
         }
+        return session;
     }
 
     private Cctv cctv(int floorNum) {

--- a/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
@@ -184,6 +184,32 @@ class SecurityAuthorizationIntegrationTest {
     }
 
     @Test
+    @DisplayName("일반 사용자는 훈련 모니터링 이벤트 타임라인을 조회할 수 없다")
+    void normalUserCannotReadTrainingMonitoringEvents() throws Exception {
+        String token = signupAndLogin(UserRole.NORMAL);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/events", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("관리자는 훈련 모니터링 이벤트 타임라인 엔드포인트에 접근할 수 있다")
+    void managerCanReadTrainingMonitoringEvents() throws Exception {
+        String token = signupAndLogin(UserRole.MANAGER);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/events", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
     @DisplayName("일반 사용자는 훈련 세션 목록을 조회할 수 없다")
     void normalUserCannotReadTrainingSessions() throws Exception {
         String token = signupAndLogin(UserRole.NORMAL);


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #144
- Branch: feat/#144

## 주요 내용

- `GET /api/v1/sessions/{sessionId}/monitoring/events` 이벤트 타임라인 API 추가
- 혼잡 감지 이벤트(CongestionEventItem)와 경로 재탐색 이벤트(RouteRecalculation)를 발생 시각순으로 병합해 반환
- 이벤트 종류별 심각도(INFO/WARNING/DANGER)와 사용자 표시 문구를 `MonitoringEventType`이 직접 정의
- 재탐색 한 건은 요청 시점과(해소됐다면) 해소 시점, 두 개의 타임라인 항목으로 분리
- `cctvCode` 쿼리 파라미터로 특정 CCTV 이벤트만 필터링 가능
- 카메라/프레임 목록 API와 동일하게 RUNNING 세션 검증 + MANAGER 권한만 접근 가능하도록 SecurityConfig 적용
- AI 분석 시작/경로 이탈/위험 구역 진입 이벤트는 Pi/AI 이벤트 수신 계약이 아직 없어 이번 범위에서 제외 (컨트롤러 문서에도 명시)
- 관측값(ObservationItem, 5초 주기 스냅샷)은 타임라인이 과도하게 촘촘해져 의도적으로 제외

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?