### PR TITLE
[Feature] 층 도면 삭제(초기화) API 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
+++ b/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
@@ -107,4 +107,15 @@ public class FloorController {
         floorService.deleteFloor(buildingId, floorId, authentication.getName());
         return ResponseEntity.ok(ApiResponse.success(FloorSuccessCode.FLOOR_DELETED, null));
     }
+
+    // 도면 초기화 (이미지·노드·엣지만 삭제, 층은 유지)
+    @DeleteMapping("/{floorId}/map")
+    public ResponseEntity<ApiResponse<FloorResponse>> clearFloorMap(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID floorId,
+            Authentication authentication
+    ) {
+        FloorResponse response = floorService.clearFloorMap(buildingId, floorId, authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success(FloorSuccessCode.FLOOR_MAP_CLEARED, response));
+    }
 }

--- a/src/main/java/com/saferoute/domain/floor/entity/Floor.java
+++ b/src/main/java/com/saferoute/domain/floor/entity/Floor.java
@@ -124,4 +124,18 @@ public class Floor {
     this.gridRows = gridRows;
     this.gridColumns = gridColumns;
   }
+
+  // 도면 초기화: 이미지/세그멘테이션/그리드 정보를 지우고 재업로드 가능한 상태로 되돌림 (층 자체는 유지)
+  public void clearMap() {
+    this.mapImageKey = null;
+    this.realWidth = null;
+    this.realHeight = null;
+    this.gridCellSizeMeter = null;
+    this.gridRows = null;
+    this.gridColumns = null;
+    this.planWidthPx = null;
+    this.planHeightPx = null;
+    this.segmentationStatus = SegmentationStatus.PENDING;
+    this.processedAt = null;
+  }
 }

--- a/src/main/java/com/saferoute/domain/floor/service/FloorService.java
+++ b/src/main/java/com/saferoute/domain/floor/service/FloorService.java
@@ -3,6 +3,8 @@ package com.saferoute.domain.floor.service;
 import com.saferoute.domain.analysis.service.FloorAnalysisService;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.floor.dto.request.CreateFloorRequest;
 import com.saferoute.domain.floor.dto.request.UpdateFloorRequest;
 import com.saferoute.domain.floor.dto.request.UploadFloorRequest;
@@ -36,6 +38,8 @@ public class FloorService {
     private final S3Service s3Service;
     private final S3PresignedUrlService s3PresignedUrlService;
     private final SchoolContextService schoolContextService;
+    private final MapNodeJpaRepository mapNodeRepository;
+    private final MapEdgeJpaRepository mapEdgeRepository;
 
     public List<FloorResponse> getFloors(UUID buildingId, String email) {
         findBuilding(buildingId, email);
@@ -134,6 +138,22 @@ public class FloorService {
         Floor floor = findFloor(buildingId, floorId, email);
         floor.getBuilding().removeFloor(floor.getFloorNum());
         floorRepository.delete(floor);
+    }
+
+    // 도면 초기화: 이미지·세그멘테이션·그리드·노드·엣지만 지우고 층(Floor row)과 층수 카운트는 유지
+    @Transactional
+    public FloorResponse clearFloorMap(UUID buildingId, UUID floorId, String email) {
+        Floor floor = findFloor(buildingId, floorId, email);
+
+        if (floor.getSegmentationStatus() == SegmentationStatus.PROCESSING) {
+            throw new ApiException(AnalysisErrorCode.ANALYSIS_ALREADY_IN_PROGRESS);
+        }
+
+        mapEdgeRepository.deleteAllByFloor(floor);
+        mapNodeRepository.deleteAllByFloor(floor);
+        floor.clearMap();
+
+        return FloorResponse.from(floor);
     }
 
     private Building findBuilding(UUID buildingId, String email) {

--- a/src/main/java/com/saferoute/global/api/response/FloorSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/FloorSuccessCode.java
@@ -14,7 +14,8 @@ public enum FloorSuccessCode implements BaseCode {
     FLOOR_DETAIL_FOUND(HttpStatus.OK, "FLOOR_SUCCESS_003", "도면 상세 조회에 성공했습니다."),
     FLOOR_DELETED(HttpStatus.OK, "FLOOR_SUCCESS_004", "도면이 삭제되었습니다."),
     FLOOR_UPDATED(HttpStatus.OK, "FLOOR_SUCCESS_005", "도면 정보 수정에 성공했습니다."),
-    FLOOR_IMAGE_URL_ISSUED(HttpStatus.OK, "FLOOR_SUCCESS_006", "도면 이미지 URL 발급에 성공했습니다.");
+    FLOOR_IMAGE_URL_ISSUED(HttpStatus.OK, "FLOOR_SUCCESS_006", "도면 이미지 URL 발급에 성공했습니다."),
+    FLOOR_MAP_CLEARED(HttpStatus.OK, "FLOOR_SUCCESS_007", "도면이 초기화되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
+++ b/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
@@ -5,13 +5,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
 import com.saferoute.domain.analysis.service.FloorAnalysisService;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.floor.dto.response.FloorImageUrlResponse;
 import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
 import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
+import com.saferoute.global.api.error.AnalysisErrorCode;
 import com.saferoute.global.api.error.BuildingErrorCode;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.exception.ApiException;
@@ -53,6 +60,12 @@ class FloorServiceTest {
 
     @Mock
     private SchoolContextService schoolContextService;
+
+    @Mock
+    private MapNodeJpaRepository mapNodeRepository;
+
+    @Mock
+    private MapEdgeJpaRepository mapEdgeRepository;
 
     @Test
     void hidesFloorsOfBuildingFromAnotherSchool() {
@@ -136,5 +149,50 @@ class FloorServiceTest {
                 .isInstanceOf(ApiException.class)
                 .extracting(exception -> ((ApiException) exception).getErrorCode())
                 .isEqualTo(BuildingErrorCode.BUILDING_NOT_FOUND);
+    }
+
+    @Test
+    void clearsFloorMapAndCascadesGraphDeletion() {
+        UUID buildingId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        Floor floor = Floor.create(building, 1);
+        floor.upload(3.0, 4.0, "floors/map.png");
+
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(buildingRepository.findByIdAndSchoolName(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(building));
+        given(floorRepository.findByIdAndBuilding_Id(floorId, building.getId()))
+                .willReturn(Optional.of(floor));
+
+        floorService.clearFloorMap(buildingId, floorId, EMAIL);
+
+        then(mapEdgeRepository).should().deleteAllByFloor(floor);
+        then(mapNodeRepository).should().deleteAllByFloor(floor);
+        assertThat(floor.getMapImageKey()).isNull();
+        assertThat(floor.getSegmentationStatus()).isEqualTo(SegmentationStatus.PENDING);
+    }
+
+    @Test
+    void rejectsClearingFloorMapWhileAnalysisInProgress() {
+        UUID buildingId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        Floor floor = Floor.create(building, 1);
+        floor.updateSegmentationStatus(SegmentationStatus.PROCESSING);
+
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(buildingRepository.findByIdAndSchoolName(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(building));
+        given(floorRepository.findByIdAndBuilding_Id(floorId, building.getId()))
+                .willReturn(Optional.of(floor));
+
+        assertThatThrownBy(() -> floorService.clearFloorMap(buildingId, floorId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(AnalysisErrorCode.ANALYSIS_ALREADY_IN_PROGRESS);
+
+        then(mapEdgeRepository).should(never()).deleteAllByFloor(floor);
+        then(mapNodeRepository).should(never()).deleteAllByFloor(floor);
     }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #146
- Branch: feature/146-floor-map-clear

## 주요 내용

- 층별 관리 모달의 개별 행 "도면 삭제" 버튼용 API 추가: `DELETE /api/v1/buildings/{buildingId}/floors/{floorId}/map`
- 층(Floor) row와 `Building`의 층수 카운트는 유지한 채, 도면 이미지·세그멘테이션·그리드·노드·엣지만 지워 재업로드 가능한 상태로 되돌림 (기존 층 자체 삭제 `deleteFloor`와는 분리된 액션)
- `Floor.clearMap()` 추가: mapImageKey/real(Width|Height)/grid* 필드를 null로, segmentationStatus를 PENDING으로 리셋
- 노드/엣지 cascade 삭제는 `FloorAnalysisService`와 동일하게 `MapNodeJpaRepository`/`MapEdgeJpaRepository.deleteAllByFloor()`를 재사용
- 분석 진행 중(`SegmentationStatus.PROCESSING`)에는 초기화를 막아 `persistAnalysisResult`가 이미 초기화된 층에 결과를 덮어쓰는 경합을 방지 (`AnalysisErrorCode.ANALYSIS_ALREADY_IN_PROGRESS` 재사용)
- `FloorSuccessCode.FLOOR_MAP_CLEARED` 추가
- `FloorServiceTest`에 정상 초기화(cascade 삭제 + 필드 리셋) / 분석 진행 중 거부 테스트 케이스 추가

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?