### PR TITLE
feat(congestion): 매핑 누락으로 재계산 스킵 시 경고 로그 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -113,6 +113,13 @@ public class CongestionEventService {
             // ENDED는 레벨이 NORMAL이라 requiresRouteRecalculation()이 false지만, 정상 경로로의
             // 복구 후보를 제시해야 하므로(RouteRecalculationService.trigger 참고) 별도로 포함한다.
             if (savedLevel.requiresRouteRecalculation() || triggerType == RecalculationTriggerType.ENDED) {
+                if (affectedEdges.isEmpty()) {
+                    log.warn(
+                            "재계산 기준을 충족했지만 감시 중인 MapEdge가 없어 재계산을 건너뜀: "
+                                    + "sessionId={}, cctvCode={}, level={}, triggerType={}",
+                            session.getId(), cctv.getCode(), savedLevel, triggerType
+                    );
+                }
                 for (MapEdge edge : affectedEdges) {
                     routeRecalculationService.trigger(
                             session, edge, savedLevel, triggerType, cctv.getCode(), density);

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -127,6 +127,13 @@ public class CongestionObservationService {
             // 관측값은 5초 단위 스냅샷이라 STARTED/ENDED 같은 이벤트 구분이 없다 - 항상 LEVEL_UP으로 취급한다
             // (즉시 이벤트의 CONGESTION_ENDED 기반 복구 트리거는 CongestionEventService가 전담한다).
             if (savedLevel.requiresRouteRecalculation()) {
+                if (affectedEdges.isEmpty()) {
+                    log.warn(
+                            "혼잡 레벨이 재계산 기준을 충족했지만 감시 중인 MapEdge가 없어 재계산을 건너뜀: "
+                                    + "sessionId={}, cctvCode={}, level={}",
+                            session.getId(), cctv.getCode(), savedLevel
+                    );
+                }
                 for (MapEdge edge : affectedEdges) {
                     routeRecalculationService.trigger(
                             session, edge, savedLevel, RecalculationTriggerType.LEVEL_UP, cctv.getCode(), density);


### PR DESCRIPTION
## 관련 이슈

- Closes #149 

## Summary
- 혼잡 레벨이 경로 재계산 기준(CROWDED/VERY_CROWDED)을 충족해도 CCTV가 감시하는 MapEdge가 없으면 재계산 트리거가 조용히 스킵되던 문제를, `CongestionObservationService`/`CongestionEventService`에 경고 로그를 추가해 원인 파악이 가능하도록 함
- sessionId, cctvCode, level(이벤트 쪽은 triggerType까지)을 로그에 남겨 CCTV-GridCell-MapEdge 매핑 누락 여부를 바로 확인할 수 있음

## Test plan
- [x] `./gradlew compileJava` 빌드 성공 확인