### PR TITLE
feat(training): 훈련 시작/종료 시 유도등 자동 점등·복귀 연동

### DIFF
--- a/src/main/java/com/saferoute/domain/device/entity/IoTLightDirection.java
+++ b/src/main/java/com/saferoute/domain/device/entity/IoTLightDirection.java
@@ -3,5 +3,7 @@ package com.saferoute.domain.device.entity;
 public enum IoTLightDirection {
     LEFT,
     RIGHT,
+    // 평상시(훈련 미진행) 상태 - 양방향 모두 점등
+    BOTH,
     OFF
 }

--- a/src/main/java/com/saferoute/domain/device/repository/IoTLightJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/IoTLightJpaRepository.java
@@ -15,6 +15,9 @@ public interface IoTLightJpaRepository extends JpaRepository<IoTLight, UUID> {
 
     List<IoTLight> findAllByCustomNode_Floor_Building_SchoolName(String schoolName);
 
+    // 훈련 종료 시 평상시 상태로 되돌릴 대상 조회용 (건물 전체 유도등)
+    List<IoTLight> findAllByCustomNode_Floor_Building_Id(UUID buildingId);
+
     List<IoTLight> findAllByCustomNode_Floor_IdAndCustomNode_Floor_Building_SchoolName(
             UUID floorId, String schoolName);
 

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -248,6 +248,21 @@ public class IoTLightService {
         }
     }
 
+    // 훈련 종료(정상/강제/타임아웃) 시 호출한다. 건물 내 안내 설정이 끝난 유도등을 모두 평상시(BOTH)
+    // 상태로 되돌린다. applyRouteGuidance와 동일하게 개별 유도등의 실패는 흡수한다.
+    public void resetToNormal(UUID buildingId) {
+        for (IoTLight light : iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)) {
+            if (!light.isEnabled() || !light.isGuidanceConfigured()) {
+                continue;
+            }
+            try {
+                changeDirection(light, new ChangeLightDirectionRequest(IoTLightDirection.BOTH));
+            } catch (ApiException exception) {
+                log.warn("훈련 종료에 따른 유도등 평상시 복귀 실패: lightId={}", light.getId(), exception);
+            }
+        }
+    }
+
     // leftEdge/rightEdge 중 다음 노드로 이어지는 쪽을 찾는다. 둘 다 아니면(이 유도등은 이 경로와 무관) null.
     private IoTLightDirection resolveDirection(IoTLight light, UUID decisionNodeId, UUID nextNodeId) {
         if (!light.isGuidanceConfigured()) {

--- a/src/main/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationService.java
@@ -97,7 +97,9 @@ public class RouteDeviationService {
         for (WindowHeadcount headcount : windows.values()) {
             // 방향 조회는 관측 구간의 실제 보고 시각(capturedAt)을 기준으로 한다. windowStart는 병합 키일 뿐이다.
             IoTLightDirection activeDirection = activeDirectionAt(directionEvents, headcount.capturedAt);
-            if (activeDirection == null || activeDirection == IoTLightDirection.OFF) {
+            // BOTH(평상시)는 "안내 반대쪽"이라는 개념이 없어 이탈 여부를 판단할 기준이 없으므로 OFF와 함께 제외한다.
+            if (activeDirection == null || activeDirection == IoTLightDirection.OFF
+                    || activeDirection == IoTLightDirection.BOTH) {
                 continue;
             }
             total++;

--- a/src/main/java/com/saferoute/domain/training/dto/CreateScenarioRequest.java
+++ b/src/main/java/com/saferoute/domain/training/dto/CreateScenarioRequest.java
@@ -35,4 +35,8 @@ public class CreateScenarioRequest {
 
     // 미지정 시 Service에서 MEDIUM으로 기본 처리
     private FireSpreadSpeed fireSpreadSpeed;
+
+    // 훈련 시작 시 최초 대피 경로 계산의 출발 노드
+    @NotNull
+    private UUID startNodeId;
 }

--- a/src/main/java/com/saferoute/domain/training/dto/ScenarioResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/ScenarioResponse.java
@@ -16,6 +16,7 @@ public class ScenarioResponse {
     private String name;
     private UUID buildingId;
     private UUID adminId;
+    private UUID startNodeId;
     private Integer expectedParticipants;
     private Instant scheduledAt;
     private Boolean isTemplate;
@@ -38,6 +39,7 @@ public class ScenarioResponse {
                 .name(scenario.getName())
                 .buildingId(scenario.getBuildingId())
                 .adminId(scenario.getAdminId())
+                .startNodeId(scenario.getStartNodeId())
                 .expectedParticipants(scenario.getExpectedParticipants())
                 .scheduledAt(scenario.getScheduledAt())
                 .isTemplate(scenario.getIsTemplate())

--- a/src/main/java/com/saferoute/domain/training/dto/UpdateScenarioRequest.java
+++ b/src/main/java/com/saferoute/domain/training/dto/UpdateScenarioRequest.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.training.dto;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
 import lombok.AllArgsConstructor;
@@ -17,4 +18,5 @@ public class UpdateScenarioRequest {
     private Instant scheduledAt;
     private Boolean isTemplate;
     private FireSpreadSpeed fireSpreadSpeed;
+    private UUID startNodeId;
 }

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.training.entity;
 
 import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -69,6 +70,12 @@ public class TrainingScenario {
     @JoinColumn(name = "building_id", nullable = false)
     private Building building;
 
+    // 훈련 시작 시 최초 대피 경로 계산의 출발 노드. 기존 시나리오는 값이 없을 수 있어 DB 컬럼은
+    // nullable로 두고, 신규 생성 시 필수 여부는 CreateScenarioRequest에서 강제한다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "start_node_id")
+    private MapNode startNode;
+
     // ERD 기준 admin_id (팀원 원본 코드의 user_id에서 변경)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "admin_id", nullable = false)
@@ -88,7 +95,8 @@ public class TrainingScenario {
                                           Boolean isTemplate,
                                           FireSpreadSpeed fireSpreadSpeed,
                                           Building building,
-                                          User admin) {
+                                          User admin,
+                                          MapNode startNode) {
         TrainingScenario scenario = new TrainingScenario();
         scenario.name = name;
         scenario.expectedParticipants = expectedParticipants;
@@ -97,6 +105,7 @@ public class TrainingScenario {
         scenario.fireSpreadSpeed = fireSpreadSpeed != null ? fireSpreadSpeed : FireSpreadSpeed.MEDIUM;
         scenario.building = building;
         scenario.admin = admin;
+        scenario.startNode = startNode;
         // 생성 시점엔 필수 필드가 모두 채워져 있어 바로 실행 가능한 상태로 시작한다.
         // 초안 저장(DRAFT) 플로우는 별도 엔드포인트가 생기면 그때 지정한다.
         scenario.status = ScenarioStatus.READY;
@@ -107,12 +116,14 @@ public class TrainingScenario {
                        Integer expectedParticipants,
                        Instant scheduledAt,
                        Boolean isTemplate,
-                       FireSpreadSpeed fireSpreadSpeed) {
+                       FireSpreadSpeed fireSpreadSpeed,
+                       MapNode startNode) {
         if (name != null) this.name = name;
         if (expectedParticipants != null) this.expectedParticipants = expectedParticipants;
         if (scheduledAt != null) this.scheduledAt = scheduledAt;
         if (isTemplate != null) this.isTemplate = isTemplate;
         if (fireSpreadSpeed != null) this.fireSpreadSpeed = fireSpreadSpeed;
+        if (startNode != null) this.startNode = startNode;
     }
 
     // 상태 전이 가드는 이 엔티티가 아니라 TrainingSessionService가 담당한다
@@ -136,5 +147,9 @@ public class TrainingScenario {
 
     public UUID getAdminId() {
         return admin != null ? admin.getId() : null;
+    }
+
+    public UUID getStartNodeId() {
+        return startNode != null ? startNode.getId() : null;
     }
 }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -2,6 +2,8 @@ package com.saferoute.domain.training.service;
 
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
@@ -13,6 +15,7 @@ import com.saferoute.domain.user.entity.User;
 import com.saferoute.domain.user.repository.UserRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
 import com.saferoute.global.api.error.BuildingErrorCode;
+import com.saferoute.global.api.error.EvacuationErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.error.UserErrorCode;
 import com.saferoute.global.api.exception.ApiException;
@@ -35,6 +38,7 @@ public class TrainingScenarioService {
     private final TrainingReportRepository trainingReportRepository;
     private final BuildingRepository buildingRepository;
     private final UserRepository userRepository;
+    private final MapNodeJpaRepository mapNodeRepository;
     private final SchoolContextService schoolContextService;
 
     // 목록 조회 (deletable = 연결된 훈련 세션이 하나도 없는 시나리오인지 여부, reportId = 리포트가 있으면 그 id)
@@ -75,6 +79,7 @@ public class TrainingScenarioService {
                 .orElseThrow(() -> new ApiException(BuildingErrorCode.BUILDING_NOT_FOUND));
         User admin = userRepository.findByIdAndSchoolName(request.getAdminId(), schoolName)
                 .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
+        MapNode startNode = resolveStartNode(request.getStartNodeId(), building.getId());
 
         TrainingScenario scenario = TrainingScenario.create(
                 request.getName(),
@@ -83,7 +88,8 @@ public class TrainingScenarioService {
                 request.getIsTemplate(),
                 request.getFireSpreadSpeed(),
                 building,
-                admin
+                admin,
+                startNode
         );
         return ScenarioResponse.from(scenarioRepository.save(scenario));
     }
@@ -92,14 +98,28 @@ public class TrainingScenarioService {
     @Transactional
     public ScenarioResponse updateScenario(UUID id, UpdateScenarioRequest request, String email) {
         TrainingScenario scenario = findByIdAndEmail(id, email);
+        MapNode startNode = request.getStartNodeId() != null
+                ? resolveStartNode(request.getStartNodeId(), scenario.getBuildingId())
+                : null;
         scenario.update(
                 request.getName(),
                 request.getExpectedParticipants(),
                 request.getScheduledAt(),
                 request.getIsTemplate(),
-                request.getFireSpreadSpeed()
+                request.getFireSpreadSpeed(),
+                startNode
         );
         return ScenarioResponse.from(scenario);
+    }
+
+    // 시작 노드가 존재하고, 시나리오와 같은 건물 소속인지 검증 (FireZoneService.designateOrigin의 그리드 셀 검증과 동일한 컨벤션)
+    private MapNode resolveStartNode(UUID startNodeId, UUID buildingId) {
+        MapNode startNode = mapNodeRepository.findById(startNodeId)
+                .orElseThrow(() -> new ApiException(EvacuationErrorCode.MAP_NODE_NOT_FOUND));
+        if (!startNode.getFloor().getBuilding().getId().equals(buildingId)) {
+            throw new ApiException(TrainingErrorCode.START_NODE_BUILDING_MISMATCH);
+        }
+        return startNode;
     }
 
     // 삭제 (훈련 세션이 하나라도 연결된 시나리오는 삭제 불가 - 과거 훈련 기록 보존을 위해)

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -1,6 +1,10 @@
 package com.saferoute.domain.training.service;
 
 import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.device.service.IoTLightService;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.service.EvacuationRoute;
+import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
 import com.saferoute.domain.training.dto.RunningSessionResponse;
 import com.saferoute.domain.training.dto.ScheduledSessionResponse;
@@ -48,6 +52,8 @@ public class TrainingSessionService {
   private final TrainingScenarioRepository trainingScenarioRepository;
   private final FireZoneRepository fireZoneRepository;
   private final RouteRecalculationService routeRecalculationService;
+  private final EvacuationRouteService evacuationRouteService;
+  private final IoTLightService ioTLightService;
   private final TrainingEventPublisher trainingEventPublisher;
   private final SchoolContextService schoolContextService;
 
@@ -135,8 +141,17 @@ public class TrainingSessionService {
       throw new ApiException(TrainingErrorCode.INVALID_STATUS_TRANSITION);
     }
 
+    // 유도등 반영 전 최초 경로부터 계산해, EXIT 미지정/도달 불가 시 세션 상태를 바꾸지 않고 막는다.
+    MapNode startNode = session.getScenario().getStartNode();
+    if (startNode == null) {
+      throw new ApiException(TrainingErrorCode.START_NODE_NOT_CONFIGURED);
+    }
+    EvacuationRoute initialRoute =
+        evacuationRouteService.findShortestRoute(startNode.getFloor().getId(), startNode.getId());
+
     session.start(Instant.now());
     session.getScenario().markInProgress();
+    ioTLightService.applyRouteGuidance(initialRoute.path().stream().map(MapNode::getId).toList());
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
     return TrainingSessionResponse.from(session);
@@ -154,6 +169,7 @@ public class TrainingSessionService {
     session.getScenario().markCompleted();
     fireZoneRepository.resetFiredCellsByScenarioId(session.getScenario().getId());
     routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 종료로 무효화됨");
+    ioTLightService.resetToNormal(session.getScenario().getBuildingId());
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
     return TrainingSessionResponse.from(session);
@@ -172,6 +188,7 @@ public class TrainingSessionService {
     session.getScenario().markError();
     fireZoneRepository.resetFiredCellsByScenarioId(session.getScenario().getId());
     routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 강제 종료로 무효화됨");
+    ioTLightService.resetToNormal(session.getScenario().getBuildingId());
     trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
 
     return TrainingSessionResponse.from(session);
@@ -196,6 +213,7 @@ public class TrainingSessionService {
 
     for (TrainingSession session : timedOutSessions) {
       routeRecalculationService.cancelAllPendingForSession(session.getId(), "훈련 타임아웃으로 무효화됨");
+      ioTLightService.resetToNormal(session.getScenario().getBuildingId());
       trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
       log.info("훈련 세션 타임아웃 처리: sessionId={}", session.getId());
     }

--- a/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
@@ -16,7 +16,8 @@ public enum TrainingErrorCode implements BaseErrorCode {
     UNSUPPORTED_STATUS(HttpStatus.CONFLICT, "TRAINING005", "지원하지 않는 훈련 상태입니다."),
     RUNNING_TRAINING_SESSION_NOT_FOUND(HttpStatus.CONFLICT,"TRAINING006", "진행 중인 훈련 세션을 찾을 수 없습니다."),
     SCENARIO_DELETE_NOT_ALLOWED(HttpStatus.CONFLICT, "TRAINING007", "훈련 세션이 존재하는 시나리오는 삭제할 수 없습니다."),
-    SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "TRAINING008", "이미 훈련 세션이 존재하는 시나리오입니다.");
+    SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "TRAINING008", "이미 훈련 세션이 존재하는 시나리오입니다."),
+    START_NODE_BUILDING_MISMATCH(HttpStatus.BAD_REQUEST, "TRAINING009", "시작 노드가 해당 시나리오의 건물에 속하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
@@ -17,7 +17,8 @@ public enum TrainingErrorCode implements BaseErrorCode {
     RUNNING_TRAINING_SESSION_NOT_FOUND(HttpStatus.CONFLICT,"TRAINING006", "진행 중인 훈련 세션을 찾을 수 없습니다."),
     SCENARIO_DELETE_NOT_ALLOWED(HttpStatus.CONFLICT, "TRAINING007", "훈련 세션이 존재하는 시나리오는 삭제할 수 없습니다."),
     SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "TRAINING008", "이미 훈련 세션이 존재하는 시나리오입니다."),
-    START_NODE_BUILDING_MISMATCH(HttpStatus.BAD_REQUEST, "TRAINING009", "시작 노드가 해당 시나리오의 건물에 속하지 않습니다.");
+    START_NODE_BUILDING_MISMATCH(HttpStatus.BAD_REQUEST, "TRAINING009", "시작 노드가 해당 시나리오의 건물에 속하지 않습니다."),
+    START_NODE_NOT_CONFIGURED(HttpStatus.CONFLICT, "TRAINING010", "출발 노드가 지정되지 않은 시나리오는 훈련을 시작할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
@@ -576,6 +576,85 @@ class IoTLightServiceTest {
         verify(trainingEventPublisher).publishIoTLightStatusUpdatedAfterCommit(light, IoTLightDirection.OFF);
     }
 
+    // === resetToNormal ===
+
+    @Test
+    @DisplayName("건물 내 안내 설정이 끝난 유도등을 평상시(BOTH) 상태로 되돌린다")
+    void resetToNormal_success() {
+        // given
+        MapNode customNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight light = createLight("LIGHT_001", customNode);
+        light.updatePiEndpoint("http://192.168.0.50:5000");
+        MapNode decisionNode = createNode("HALLWAY1", NodeType.HALLWAY);
+        MapNode leftTarget = createNode("HALLWAY2", NodeType.HALLWAY);
+        MapNode rightTarget = createNode("HALLWAY3", NodeType.HALLWAY);
+        light.configureGuidance(decisionNode, createEdge(decisionNode, leftTarget), createEdge(decisionNode, rightTarget));
+
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+
+        // when
+        iotLightService.resetToNormal(buildingId);
+
+        // then
+        verify(iotLightPiClient).sendDirection("http://192.168.0.50:5000", "LIGHT_001", IoTLightDirection.BOTH);
+        verify(iotLightDirectionStore).update(light.getId(), IoTLightDirection.BOTH);
+    }
+
+    @Test
+    @DisplayName("비활성화되었거나 안내가 설정되지 않은 유도등은 건너뛴다")
+    void resetToNormal_skipsDisabledOrUnconfiguredLights() {
+        // given
+        MapNode disabledNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight disabledLight = createLight("LIGHT_001", disabledNode);
+        disabledLight.disable();
+
+        MapNode unconfiguredNode = createNode("LIGHT_002", NodeType.CUSTOM);
+        IoTLight unconfiguredLight = createLight("LIGHT_002", unconfiguredNode);
+
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId))
+                .willReturn(List.of(disabledLight, unconfiguredLight));
+
+        // when
+        iotLightService.resetToNormal(buildingId);
+
+        // then
+        verifyNoInteractions(iotLightPiClient, iotLightDirectionStore);
+    }
+
+    @Test
+    @DisplayName("일부 유도등 명령이 실패해도 나머지 유도등 전환은 계속 진행된다")
+    void resetToNormal_individualFailureDoesNotStopOthers() {
+        // given
+        MapNode failingNode = createNode("LIGHT_001", NodeType.CUSTOM);
+        IoTLight failingLight = createLight("LIGHT_001", failingNode);
+        // piEndpoint 미설정 -> changeDirection이 DEVICE_UNREACHABLE을 던짐
+        MapNode decisionNodeA = createNode("HALLWAY1", NodeType.HALLWAY);
+        MapNode leftTargetA = createNode("HALLWAY2", NodeType.HALLWAY);
+        MapNode rightTargetA = createNode("HALLWAY3", NodeType.HALLWAY);
+        failingLight.configureGuidance(
+                decisionNodeA, createEdge(decisionNodeA, leftTargetA), createEdge(decisionNodeA, rightTargetA));
+
+        MapNode succeedingNode = createNode("LIGHT_002", NodeType.CUSTOM);
+        IoTLight succeedingLight = createLight("LIGHT_002", succeedingNode);
+        succeedingLight.updatePiEndpoint("http://192.168.0.51:5000");
+        MapNode decisionNodeB = createNode("HALLWAY4", NodeType.HALLWAY);
+        MapNode leftTargetB = createNode("HALLWAY5", NodeType.HALLWAY);
+        MapNode rightTargetB = createNode("HALLWAY6", NodeType.HALLWAY);
+        succeedingLight.configureGuidance(
+                decisionNodeB, createEdge(decisionNodeB, leftTargetB), createEdge(decisionNodeB, rightTargetB));
+
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId))
+                .willReturn(List.of(failingLight, succeedingLight));
+
+        // when
+        iotLightService.resetToNormal(buildingId);
+
+        // then
+        verify(iotLightPiClient).sendDirection("http://192.168.0.51:5000", "LIGHT_002", IoTLightDirection.BOTH);
+        verify(iotLightDirectionStore).update(succeedingLight.getId(), IoTLightDirection.BOTH);
+        verify(trainingEventPublisher).publishIoTLightStatusUpdatedAfterCommit(succeedingLight, IoTLightDirection.BOTH);
+    }
+
     @Test
     @DisplayName("다른 기관 유도등의 모든 변경 요청은 not-found로 거부한다")
     void mutations_otherSchool_throwNotFoundWithoutChangingState() {

--- a/src/test/java/com/saferoute/domain/training/repository/FireZoneRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/training/repository/FireZoneRepositoryTest.java
@@ -69,7 +69,7 @@ class FireZoneRepositoryTest {
 
     private TrainingScenario scenario(String name) {
         return scenarioRepository.save(TrainingScenario.create(
-                name, 10, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin));
+                name, 10, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null));
     }
 
     private void sessionWithStatus(TrainingScenario scenario, TrainingStatus status) {

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.report.repository.TrainingReportRepository;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
@@ -58,6 +59,9 @@ class TrainingScenarioServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private MapNodeJpaRepository mapNodeRepository;
+
+    @Mock
     private SchoolContextService schoolContextService;
 
     private TrainingScenario scenarioWithId(UUID id) {
@@ -68,7 +72,8 @@ class TrainingScenarioServiceTest {
                 false,
                 FireSpreadSpeed.MEDIUM,
                 mock(Building.class),
-                mock(User.class));
+                mock(User.class),
+                null);
         ReflectionTestUtils.setField(scenario, "id", id);
         return scenario;
     }

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -10,7 +10,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.device.service.IoTLightService;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
+import com.saferoute.domain.evacuation.service.EvacuationRoute;
+import com.saferoute.domain.evacuation.service.EvacuationRouteService;
+import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
 import com.saferoute.domain.training.dto.TrainingSessionListResponse;
 import com.saferoute.domain.training.dto.TrainingSessionSummaryResponse;
@@ -67,12 +72,19 @@ class TrainingSessionServiceTest {
     private RouteRecalculationService routeRecalculationService;
 
     @Mock
+    private EvacuationRouteService evacuationRouteService;
+
+    @Mock
+    private IoTLightService ioTLightService;
+
+    @Mock
     private TrainingEventPublisher trainingEventPublisher;
 
     @Mock
     private SchoolContextService schoolContextService;
 
     private final UUID sessionId = UUID.randomUUID();
+    private final UUID buildingId = UUID.randomUUID();
 
     @BeforeEach
     void setUpSchoolContext() {
@@ -82,8 +94,9 @@ class TrainingSessionServiceTest {
     }
 
     private TrainingSession sessionWithStatus(TrainingStatus status) {
-        TrainingSession session =
-                TrainingSession.create(status, Instant.now(), mock(User.class), mock(TrainingScenario.class));
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        org.mockito.Mockito.lenient().when(scenario.getBuildingId()).thenReturn(buildingId);
+        TrainingSession session = TrainingSession.create(status, Instant.now(), mock(User.class), scenario);
         ReflectionTestUtils.setField(session, "id", sessionId);
         return session;
     }
@@ -237,16 +250,84 @@ class TrainingSessionServiceTest {
     // === start ===
 
     @Test
-    @DisplayName("SCHEDULED 상태의 세션을 시작하면 RUNNING으로 전이하고 이벤트를 발행하며 시나리오도 IN_PROGRESS로 바뀐다")
-    void start_fromScheduled_transitionsToRunningAndPublishesEvent() {
-        TrainingSession session = sessionWithStatus(TrainingStatus.SCHEDULED);
+    @DisplayName("SCHEDULED 상태의 세션을 시작하면 RUNNING으로 전이하고 최초 경로를 유도등에 반영한다")
+    void start_fromScheduled_transitionsToRunningAndAppliesRouteGuidance() {
+        UUID floorId = UUID.randomUUID();
+        UUID startNodeId = UUID.randomUUID();
+        UUID exitNodeId = UUID.randomUUID();
+        MapNode startNode = mock(MapNode.class);
+        Floor floor = mock(Floor.class);
+        given(floor.getId()).willReturn(floorId);
+        given(startNode.getFloor()).willReturn(floor);
+        given(startNode.getId()).willReturn(startNodeId);
+        MapNode exitNode = mock(MapNode.class);
+        given(exitNode.getId()).willReturn(exitNodeId);
+
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getStartNode()).willReturn(startNode);
+        TrainingSession session =
+                TrainingSession.create(TrainingStatus.SCHEDULED, Instant.now(), mock(User.class), scenario);
+        ReflectionTestUtils.setField(session, "id", sessionId);
         given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME)).willReturn(Optional.of(session));
+        given(evacuationRouteService.findShortestRoute(floorId, startNodeId))
+                .willReturn(new EvacuationRoute(List.of(startNode, exitNode), 12.0));
 
         trainingSessionService.start(sessionId, EMAIL);
 
         assertThat(session.getStatus()).isEqualTo(TrainingStatus.RUNNING);
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
-        verify(session.getScenario(), times(1)).markInProgress();
+        verify(scenario, times(1)).markInProgress();
+        verify(ioTLightService).applyRouteGuidance(List.of(startNodeId, exitNodeId));
+    }
+
+    @Test
+    @DisplayName("시작 노드가 지정되지 않은 시나리오는 훈련을 시작할 수 없다")
+    void start_startNodeNotConfigured_throwsExceptionWithoutChangingState() {
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getStartNode()).willReturn(null);
+        TrainingSession session =
+                TrainingSession.create(TrainingStatus.SCHEDULED, Instant.now(), mock(User.class), scenario);
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME)).willReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> trainingSessionService.start(sessionId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.START_NODE_NOT_CONFIGURED);
+        assertThat(session.getStatus()).isEqualTo(TrainingStatus.SCHEDULED);
+        verify(scenario, never()).markInProgress();
+        verify(trainingEventPublisher, never()).publishTrainingStatusUpdatedAfterCommit(any());
+        verify(ioTLightService, never()).applyRouteGuidance(any());
+    }
+
+    @Test
+    @DisplayName("출발 노드에서 경로를 찾지 못하면 훈련 시작이 차단되고 상태가 바뀌지 않는다")
+    void start_routeNotFound_throwsExceptionWithoutChangingState() {
+        UUID floorId = UUID.randomUUID();
+        UUID startNodeId = UUID.randomUUID();
+        MapNode startNode = mock(MapNode.class);
+        Floor floor = mock(Floor.class);
+        given(floor.getId()).willReturn(floorId);
+        given(startNode.getFloor()).willReturn(floor);
+        given(startNode.getId()).willReturn(startNodeId);
+
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getStartNode()).willReturn(startNode);
+        TrainingSession session =
+                TrainingSession.create(TrainingStatus.SCHEDULED, Instant.now(), mock(User.class), scenario);
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME)).willReturn(Optional.of(session));
+        given(evacuationRouteService.findShortestRoute(floorId, startNodeId))
+                .willThrow(new ApiException(com.saferoute.global.api.error.EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
+
+        assertThatThrownBy(() -> trainingSessionService.start(sessionId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(com.saferoute.global.api.error.EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND);
+        assertThat(session.getStatus()).isEqualTo(TrainingStatus.SCHEDULED);
+        verify(scenario, never()).markInProgress();
+        verify(trainingEventPublisher, never()).publishTrainingStatusUpdatedAfterCommit(any());
+        verify(ioTLightService, never()).applyRouteGuidance(any());
     }
 
     @Test
@@ -287,6 +368,7 @@ class TrainingSessionServiceTest {
         assertThat(session.getEndedAt()).isNotNull();
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
         verify(session.getScenario(), times(1)).markCompleted();
+        verify(ioTLightService).resetToNormal(buildingId);
     }
 
     @Test
@@ -327,6 +409,7 @@ class TrainingSessionServiceTest {
         assertThat(session.getStatus()).isEqualTo(TrainingStatus.STOPPED);
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
         verify(session.getScenario(), times(1)).markError();
+        verify(ioTLightService).resetToNormal(buildingId);
     }
 
     @Test
@@ -359,11 +442,13 @@ class TrainingSessionServiceTest {
     @Test
     @DisplayName("10분 타임아웃을 넘긴 RUNNING 세션을 FAILED로 처리하고 이벤트를 발행하며 시나리오는 ERROR로 바뀐다")
     void failTimedOutSessions_marksExpiredSessionsAsFailed() {
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getBuildingId()).willReturn(buildingId);
         TrainingSession timedOut = TrainingSession.create(
                 TrainingStatus.RUNNING,
                 Instant.now().minus(11, ChronoUnit.MINUTES),
                 mock(User.class),
-                mock(TrainingScenario.class));
+                scenario);
         ReflectionTestUtils.setField(timedOut, "id", sessionId);
 
         given(trainingSessionRepository.findByStatusAndStartedAtBefore(any(), any()))
@@ -374,6 +459,7 @@ class TrainingSessionServiceTest {
         assertThat(timedOut.getStatus()).isEqualTo(TrainingStatus.FAILED);
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(timedOut);
         verify(timedOut.getScenario(), times(1)).markError();
+        verify(ioTLightService).resetToNormal(buildingId);
     }
 
     @Test

--- a/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
@@ -11,7 +11,10 @@ import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.device.entity.IoTLight;
 import com.saferoute.domain.device.entity.IoTLightDirection;
 import com.saferoute.domain.device.repository.IoTLightJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.repository.FloorRepository;
@@ -88,6 +91,9 @@ class WebSocketIntegrationTest {
     private MapNodeJpaRepository mapNodeJpaRepository;
 
     @Autowired
+    private MapEdgeJpaRepository mapEdgeJpaRepository;
+
+    @Autowired
     private IoTLightJpaRepository iotLightJpaRepository;
 
     @Autowired
@@ -104,6 +110,9 @@ class WebSocketIntegrationTest {
     private User normalUser;
     private String managerToken;
     private String normalToken;
+    // newScenario()가 만드는 Floor는 building FK를 갖고 있어, tearDown의 building 삭제보다
+    // 먼저 정리해야 한다 (연결된 MapNode/MapEdge는 Floor 삭제에 cascade로 함께 지워진다).
+    private final java.util.List<Floor> scenarioFloors = new java.util.ArrayList<>();
 
     @BeforeEach
     void setUp() {
@@ -157,6 +166,7 @@ class WebSocketIntegrationTest {
         // @Transactional을 쓰지 않으므로 테스트가 만든 데이터를 직접 정리한다.
         trainingSessionRepository.deleteById(trainingSession.getId());
         trainingScenarioRepository.delete(trainingScenario);
+        scenarioFloors.forEach(floorRepository::delete);
         buildingRepository.delete(building);
         userRepository.delete(managerUser);
         userRepository.delete(normalUser);
@@ -201,9 +211,19 @@ class WebSocketIntegrationTest {
 
     // 시나리오당 세션은 1개만 허용되므로(UNIQUE 제약), setUp()의 trainingScenario를 재사용하지 않고
     // 테스트마다 별도 시나리오를 만들어 추가 세션을 붙인다.
+    // start() 통합 테스트가 최초 경로 계산을 실제로 성공시킬 수 있도록, 출발 노드에서
+    // EXIT 노드까지 이어지는 최소 그래프(노드 2개 + 엣지 1개)를 함께 만든다.
     private TrainingScenario newScenario() {
+        Floor floor = floorRepository.save(Floor.create(building, 1));
+        scenarioFloors.add(floor);
+        MapNode startNode = mapNodeJpaRepository.save(
+                MapNode.create(floor, "START", NodeType.ROOM, "출발 지점", 0.1, 0.1, false));
+        MapNode exitNode = mapNodeJpaRepository.save(
+                MapNode.create(floor, "EXIT", NodeType.EXIT, "출구", 0.9, 0.9, true));
+        mapEdgeJpaRepository.save(MapEdge.create(floor, startNode, exitNode, 3.0, true));
+
         TrainingScenario scenario = TrainingScenario.create(
-                "정기 훈련", 50, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, managerUser, null);
+                "정기 훈련", 50, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, managerUser, startNode);
         return trainingScenarioRepository.save(scenario);
     }
 

--- a/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
@@ -138,7 +138,8 @@ class WebSocketIntegrationTest {
                 false,
                 FireSpreadSpeed.MEDIUM,
                 building,
-                managerUser
+                managerUser,
+                null
         );
         trainingScenarioRepository.save(trainingScenario);
 
@@ -202,7 +203,7 @@ class WebSocketIntegrationTest {
     // 테스트마다 별도 시나리오를 만들어 추가 세션을 붙인다.
     private TrainingScenario newScenario() {
         TrainingScenario scenario = TrainingScenario.create(
-                "정기 훈련", 50, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, managerUser);
+                "정기 훈련", 50, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, managerUser, null);
         return trainingScenarioRepository.save(scenario);
     }
 


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #148
- Branch: feature/148

## 주요 내용

- `TrainingScenario`에 `startNode`(출발 노드) 필드 추가 - 훈련 시작 시 최초 대피 경로 계산의 기준점. 시나리오 생성/수정 API에 `startNodeId` 파라미터 추가, 시나리오와 같은 건물 소속인지 검증 (`START_NODE_BUILDING_MISMATCH`)
- `IoTLightDirection`에 평상시(양방향 점등) 상태 `BOTH` 추가, `IoTLightService.resetToNormal(buildingId)` 신설 - `applyRouteGuidance`의 대칭 메서드로 건물 내 안내 설정이 끝난 유도등을 모두 평상시 상태로 되돌림
- `BOTH` 도입에 따라 `RouteDeviationService`가 "LEFT가 아니면 RIGHT"로 가정하던 방향 판정 로직을 보정 (안 그러면 평상시 상태에서도 이탈로 잘못 집계됨)
- `TrainingSessionService.start()`: 세션 상태 전이 전에 시나리오의 출발 노드 기준 최초 경로를 계산해 유도등에 반영. 출발 노드 미지정(`START_NODE_NOT_CONFIGURED`), EXIT 미지정/도달 불가(기존 `EvacuationErrorCode`) 시 각각 구체적인 에러로 훈련 시작을 차단
- `TrainingSessionService.end()`/`forceEnd()`/`failTimedOutSessions()`: 훈련 종료 시 유도등을 평상시 상태로 복귀시키는 `resetToNormal()` 호출 추가
- 마이그레이션 스크립트는 불필요 (`ddl-auto: update`로 컬럼 자동 반영)

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?