### PR TITLE
[FEAT] #152: refresh token 발급 및 재발급 API 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/user/controller/UserController.java
+++ b/src/main/java/com/saferoute/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.saferoute.domain.user.controller;
 
 import com.saferoute.domain.user.dto.LoginRequest;
 import com.saferoute.domain.user.dto.LoginResponse;
+import com.saferoute.domain.user.dto.ReissueRequest;
+import com.saferoute.domain.user.dto.ReissueResponse;
 import com.saferoute.domain.user.dto.SignupRequest;
 import com.saferoute.domain.user.dto.SignupResponse;
 import com.saferoute.domain.user.dto.UpdateUserProfileRequest;
@@ -10,6 +12,8 @@ import com.saferoute.domain.user.service.UserService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.UserSuccessCode;
 import com.saferoute.global.security.AccessTokenRevocationService;
+import com.saferoute.global.security.JwtTokenProvider;
+import com.saferoute.global.security.RefreshTokenService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +37,8 @@ public class UserController {
 
     private final UserService userService;
     private final AccessTokenRevocationService accessTokenRevocationService;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 회원가입
     @PostMapping("/auth/signup")
@@ -64,6 +70,18 @@ public class UserController {
     ) {
         UserProfileResponse response = userService.updateProfile(authentication.getName(), request);
         return ResponseEntity.ok(ApiResponse.success(UserSuccessCode.PROFILE_UPDATED, response));
+    }
+
+    // 토큰 재발급: refresh token을 검증하고 새 access/refresh token을 발급한다.
+    @PostMapping("/auth/reissue")
+    public ResponseEntity<ApiResponse<ReissueResponse>> reissue(@Valid @RequestBody ReissueRequest request) {
+        RefreshTokenService.ReissuedTokens tokens = refreshTokenService.reissue(request.refreshToken());
+        ReissueResponse response = ReissueResponse.of(
+                tokens.accessToken(),
+                jwtTokenProvider.getAccessTokenExpirationSeconds(),
+                tokens.refreshToken()
+        );
+        return ResponseEntity.ok(ApiResponse.success(UserSuccessCode.REISSUE_COMPLETED, response));
     }
 
     @PostMapping("/auth/logout")

--- a/src/main/java/com/saferoute/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/saferoute/domain/user/dto/LoginResponse.java
@@ -13,13 +13,15 @@ public record LoginResponse(
         String schoolName,
         String tokenType,
         String accessToken,
-        long expiresIn
+        long expiresIn,
+        String refreshToken
 ) {
 
     public static LoginResponse of(
             User user,
             String accessToken,
-            long expiresIn
+            long expiresIn,
+            String refreshToken
     ) {
         return new LoginResponse(
                 user.getId(),
@@ -30,7 +32,8 @@ public record LoginResponse(
                 user.getSchoolName(),
                 "Bearer",
                 accessToken,
-                expiresIn
+                expiresIn,
+                refreshToken
         );
     }
 }

--- a/src/main/java/com/saferoute/domain/user/dto/ReissueRequest.java
+++ b/src/main/java/com/saferoute/domain/user/dto/ReissueRequest.java
@@ -1,0 +1,7 @@
+package com.saferoute.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueRequest(
+        @NotBlank String refreshToken
+) {}

--- a/src/main/java/com/saferoute/domain/user/dto/ReissueResponse.java
+++ b/src/main/java/com/saferoute/domain/user/dto/ReissueResponse.java
@@ -1,0 +1,17 @@
+package com.saferoute.domain.user.dto;
+
+public record ReissueResponse(
+        String tokenType,
+        String accessToken,
+        long expiresIn,
+        String refreshToken
+) {
+
+    public static ReissueResponse of(
+            String accessToken,
+            long expiresIn,
+            String refreshToken
+    ) {
+        return new ReissueResponse("Bearer", accessToken, expiresIn, refreshToken);
+    }
+}

--- a/src/main/java/com/saferoute/domain/user/service/UserService.java
+++ b/src/main/java/com/saferoute/domain/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.saferoute.global.api.error.UserErrorCode;
 import com.saferoute.global.api.code.ErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.global.security.JwtTokenProvider;
+import com.saferoute.global.security.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,6 +28,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -48,6 +50,7 @@ public class UserService {
     }
 
     // 로그인
+    @Transactional
     public LoginResponse login(LoginRequest request) {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() ->
@@ -61,11 +64,13 @@ public class UserService {
         }
 
         String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = refreshTokenService.issue(user);
 
         return LoginResponse.of(
                 user,
                 accessToken,
-                jwtTokenProvider.getAccessTokenExpirationSeconds()
+                jwtTokenProvider.getAccessTokenExpirationSeconds(),
+                refreshToken
         );
     }
 

--- a/src/main/java/com/saferoute/global/api/error/UserErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/UserErrorCode.java
@@ -12,7 +12,8 @@ public enum UserErrorCode implements BaseErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USER001", "이미 사용 중인 이메일입니다."),
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "USER002", "이미 사용 중인 아이디입니다."),
     INVALID_CREDENTIAL(HttpStatus.UNAUTHORIZED, "USER003", "이메일 또는 비밀번호가 올바르지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER004", "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER004", "사용자를 찾을 수 없습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "USER005", "리프레시 토큰이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/api/response/UserSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/UserSuccessCode.java
@@ -14,7 +14,8 @@ public enum UserSuccessCode implements BaseCode {
     LOGIN_COMPLETED(HttpStatus.OK, "USER_SUCCESS_002", "로그인에 성공했습니다."),
     PROFILE_RETRIEVED(HttpStatus.OK, "USER_SUCCESS_003", "사용자 정보 조회에 성공했습니다."),
     PROFILE_UPDATED(HttpStatus.OK, "USER_SUCCESS_004", "사용자 정보 수정에 성공했습니다."),
-    LOGOUT_COMPLETED(HttpStatus.OK, "USER_SUCCESS_005", "로그아웃에 성공했습니다.");
+    LOGOUT_COMPLETED(HttpStatus.OK, "USER_SUCCESS_005", "로그아웃에 성공했습니다."),
+    REISSUE_COMPLETED(HttpStatus.OK, "USER_SUCCESS_006", "토큰 재발급에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/v1/auth/signup",
                                 "/api/v1/auth/login",
+                                "/api/v1/auth/reissue",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/ws/**"

--- a/src/main/java/com/saferoute/global/security/JwtProperties.java
+++ b/src/main/java/com/saferoute/global/security/JwtProperties.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record JwtProperties(
         String secret,
         String issuer,
-        Duration accessTokenExpiration
+        Duration accessTokenExpiration,
+        Duration refreshTokenExpiration
 ) {
 }

--- a/src/main/java/com/saferoute/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/saferoute/global/security/JwtTokenProvider.java
@@ -47,6 +47,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .issuer(properties.issuer())
                 .subject(user.getId().toString())
+                .id(UUID.randomUUID().toString())
                 .claim("type", "refresh")
                 .issuedAt(Date.from(issuedAt))
                 .expiration(Date.from(expiresAt))

--- a/src/main/java/com/saferoute/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/saferoute/global/security/JwtTokenProvider.java
@@ -33,6 +33,21 @@ public class JwtTokenProvider {
                 .subject(user.getId().toString())
                 .claim("email", user.getEmail())
                 .claim("role", user.getRole().name())
+                .claim("type", "access")
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiresAt))
+                .signWith(signingKey)
+                .compact();
+    }
+
+    public String createRefreshToken(User user) {
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = issuedAt.plus(properties.refreshTokenExpiration());
+
+        return Jwts.builder()
+                .issuer(properties.issuer())
+                .subject(user.getId().toString())
+                .claim("type", "refresh")
                 .issuedAt(Date.from(issuedAt))
                 .expiration(Date.from(expiresAt))
                 .signWith(signingKey)
@@ -69,6 +84,18 @@ public class JwtTokenProvider {
 
     public long getAccessTokenExpirationSeconds() {
         return properties.accessTokenExpiration().toSeconds();
+    }
+
+    public long getRefreshTokenExpirationSeconds() {
+        return properties.refreshTokenExpiration().toSeconds();
+    }
+
+    public void validateRefreshToken(String token) {
+        String type = parseClaims(token).get("type", String.class);
+
+        if (!"refresh".equals(type)) {
+            throw new JwtException("refresh token이 아닙니다.");
+        }
     }
 
     private Claims parseClaims(String token) {
@@ -109,6 +136,14 @@ public class JwtTokenProvider {
                 || properties.accessTokenExpiration().isNegative()) {
             throw new IllegalStateException(
                     "JWT access token 만료 시간은 0보다 커야 합니다."
+            );
+        }
+
+        if (properties.refreshTokenExpiration() == null
+                || properties.refreshTokenExpiration().isZero()
+                || properties.refreshTokenExpiration().isNegative()) {
+            throw new IllegalStateException(
+                    "JWT refresh token 만료 시간은 0보다 커야 합니다."
             );
         }
     }

--- a/src/main/java/com/saferoute/global/security/RefreshToken.java
+++ b/src/main/java/com/saferoute/global/security/RefreshToken.java
@@ -1,0 +1,38 @@
+package com.saferoute.global.security;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "refresh_tokens")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @Column(name = "token_hash", nullable = false, length = 64)
+    private String tokenHash;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    private RefreshToken(String tokenHash, UUID userId, Instant expiresAt) {
+        this.tokenHash = tokenHash;
+        this.userId = userId;
+        this.expiresAt = expiresAt;
+    }
+
+    public static RefreshToken create(String tokenHash, UUID userId, Instant expiresAt) {
+        return new RefreshToken(tokenHash, userId, expiresAt);
+    }
+}

--- a/src/main/java/com/saferoute/global/security/RefreshTokenRepository.java
+++ b/src/main/java/com/saferoute/global/security/RefreshTokenRepository.java
@@ -1,9 +1,28 @@
 package com.saferoute.global.security;
 
 import java.time.Instant;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
 
     void deleteAllByExpiresAtBefore(Instant expiresAt);
+
+    // 단일 사용(rotation) 보장을 위해 조회 없이 조건부로 원자적 삭제한다.
+    // 영향받은 행 수가 1이어야 이 요청이 토큰을 정당하게 소비한 것이다.
+    @Modifying
+    @Query(
+            "delete from RefreshToken t "
+                    + "where t.tokenHash = :tokenHash "
+                    + "and t.userId = :userId "
+                    + "and t.expiresAt > :now"
+    )
+    int deleteValidToken(
+            @Param("tokenHash") String tokenHash,
+            @Param("userId") UUID userId,
+            @Param("now") Instant now
+    );
 }

--- a/src/main/java/com/saferoute/global/security/RefreshTokenRepository.java
+++ b/src/main/java/com/saferoute/global/security/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.saferoute.global.security;
+
+import java.time.Instant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+
+    void deleteAllByExpiresAtBefore(Instant expiresAt);
+}

--- a/src/main/java/com/saferoute/global/security/RefreshTokenService.java
+++ b/src/main/java/com/saferoute/global/security/RefreshTokenService.java
@@ -1,0 +1,82 @@
+package com.saferoute.global.security;
+
+import com.saferoute.domain.user.entity.User;
+import com.saferoute.domain.user.repository.UserRepository;
+import com.saferoute.global.api.error.UserErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import io.jsonwebtoken.JwtException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public String issue(User user) {
+        refreshTokenRepository.deleteAllByExpiresAtBefore(Instant.now());
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+        refreshTokenRepository.save(
+                RefreshToken.create(
+                        hash(refreshToken),
+                        user.getId(),
+                        jwtTokenProvider.getExpiration(refreshToken)
+                )
+        );
+
+        return refreshToken;
+    }
+
+    @Transactional
+    public ReissuedTokens reissue(String refreshToken) {
+        UUID userId;
+        try {
+            jwtTokenProvider.validateRefreshToken(refreshToken);
+            userId = jwtTokenProvider.getUserId(refreshToken);
+        } catch (JwtException exception) {
+            throw new ApiException(UserErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        String tokenHash = hash(refreshToken);
+        RefreshToken stored = refreshTokenRepository.findById(tokenHash)
+                .filter(token -> token.getUserId().equals(userId))
+                .filter(token -> token.getExpiresAt().isAfter(Instant.now()))
+                .orElseThrow(() -> new ApiException(UserErrorCode.INVALID_REFRESH_TOKEN));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(UserErrorCode.INVALID_REFRESH_TOKEN));
+
+        refreshTokenRepository.delete(stored);
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(user);
+        String newRefreshToken = issue(user);
+
+        return new ReissuedTokens(newAccessToken, newRefreshToken);
+    }
+
+    private String hash(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", exception);
+        }
+    }
+
+    public record ReissuedTokens(String accessToken, String refreshToken) {
+    }
+}

--- a/src/main/java/com/saferoute/global/security/RefreshTokenService.java
+++ b/src/main/java/com/saferoute/global/security/RefreshTokenService.java
@@ -50,16 +50,20 @@ public class RefreshTokenService {
             throw new ApiException(UserErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        String tokenHash = hash(refreshToken);
-        RefreshToken stored = refreshTokenRepository.findById(tokenHash)
-                .filter(token -> token.getUserId().equals(userId))
-                .filter(token -> token.getExpiresAt().isAfter(Instant.now()))
-                .orElseThrow(() -> new ApiException(UserErrorCode.INVALID_REFRESH_TOKEN));
+        // 조회 후 삭제하면 동시 요청이 삭제 전에 모두 조회를 통과해 토큰이 중복 소비될 수 있다.
+        // 조건부 DELETE 자체를 소비 판정 기준으로 삼아, 영향받은 행이 정확히 1개일 때만 계속 진행한다.
+        int deletedCount = refreshTokenRepository.deleteValidToken(
+                hash(refreshToken),
+                userId,
+                Instant.now()
+        );
+
+        if (deletedCount != 1) {
+            throw new ApiException(UserErrorCode.INVALID_REFRESH_TOKEN);
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(UserErrorCode.INVALID_REFRESH_TOKEN));
-
-        refreshTokenRepository.delete(stored);
 
         String newAccessToken = jwtTokenProvider.createAccessToken(user);
         String newRefreshToken = issue(user);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ jwt:
   secret: ${JWT_SECRET}
   issuer: saferoute
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:1h}
+  refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:14d}
 
 aws:
   region: ${AWS_REGION:us-east-2}

--- a/src/test/java/com/saferoute/domain/user/ReissueConcurrencyIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/user/ReissueConcurrencyIntegrationTest.java
@@ -1,0 +1,135 @@
+package com.saferoute.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ReissueConcurrencyIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("동일한 refresh token으로 동시에 재발급을 요청하면 한 요청만 성공한다")
+    void concurrentReissueWithSameRefreshToken() throws Exception {
+        String refreshToken = signupAndLoginNormalUser();
+        String requestBody = """
+                {
+                  "refreshToken": "%s"
+                }
+                """.formatted(refreshToken);
+
+        List<MvcResult> results = reissueConcurrently(requestBody);
+
+        assertThat(results)
+                .extracting(result -> result.getResponse().getStatus())
+                .containsExactlyInAnyOrder(200, 401);
+
+        MvcResult rejected = results.stream()
+                .filter(result -> result.getResponse().getStatus() == 401)
+                .findFirst()
+                .orElseThrow();
+        JsonNode rejectedResponse = objectMapper.readTree(
+                rejected.getResponse().getContentAsString()
+        );
+        assertThat(rejectedResponse.path("code").asText()).isEqualTo("USER005");
+    }
+
+    private List<MvcResult> reissueConcurrently(String requestBody) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        try {
+            Future<MvcResult> first = executor.submit(
+                    () -> performReissue(requestBody, ready, start)
+            );
+            Future<MvcResult> second = executor.submit(
+                    () -> performReissue(requestBody, ready, start)
+            );
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            return List.of(
+                    first.get(10, TimeUnit.SECONDS),
+                    second.get(10, TimeUnit.SECONDS)
+            );
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private MvcResult performReissue(
+            String requestBody,
+            CountDownLatch ready,
+            CountDownLatch start
+    ) throws Exception {
+        ready.countDown();
+        if (!start.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("동시 요청 시작 신호를 기다리는 중 시간 초과되었습니다.");
+        }
+
+        return mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andReturn();
+    }
+
+    private String signupAndLoginNormalUser() throws Exception {
+        String unique = UUID.randomUUID().toString().substring(0, 8);
+        String email = unique + "@saferoute.com";
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "user%s",
+                                  "password": "password123!",
+                                  "email": "%s",
+                                  "schoolName": "SafeRoute School",
+                                  "role": "NORMAL"
+                                }
+                                """.formatted(unique, email)))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "password123!"
+                                }
+                                """.formatted(email)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .path("result")
+                .path("refreshToken")
+                .asText();
+    }
+}

--- a/src/test/java/com/saferoute/domain/user/ReissueIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/user/ReissueIntegrationTest.java
@@ -1,0 +1,146 @@
+package com.saferoute.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ReissueIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("유효한 refresh token으로 새 access token과 refresh token을 재발급받는다")
+    void reissueWithValidRefreshToken() throws Exception {
+        JsonNode loginResult = signupAndLoginNormalUser();
+        String refreshToken = loginResult.path("refreshToken").asText();
+
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "refreshToken": "%s"
+                                }
+                                """.formatted(refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("USER_SUCCESS_006"))
+                .andExpect(jsonPath("$.result.accessToken").exists())
+                .andExpect(jsonPath("$.result.refreshToken").exists())
+                .andReturn();
+
+        JsonNode reissueResponse = objectMapper.readTree(result.getResponse().getContentAsString())
+                .path("result");
+
+        // refresh token은 매 발급마다 고유한 jti를 가지므로 재발급 시 항상 새 값으로 회전한다.
+        assertThat(reissueResponse.path("refreshToken").asText())
+                .isNotEqualTo(refreshToken);
+    }
+
+    @Test
+    @DisplayName("사용한 refresh token은 재사용할 수 없다")
+    void reusedRefreshTokenIsRejected() throws Exception {
+        JsonNode loginResult = signupAndLoginNormalUser();
+        String refreshToken = loginResult.path("refreshToken").asText();
+
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "refreshToken": "%s"
+                                }
+                                """.formatted(refreshToken)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "refreshToken": "%s"
+                                }
+                                """.formatted(refreshToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("USER005"));
+    }
+
+    @Test
+    @DisplayName("access token으로는 재발급을 받을 수 없다")
+    void rejectAccessTokenAsRefreshToken() throws Exception {
+        JsonNode loginResult = signupAndLoginNormalUser();
+        String accessToken = loginResult.path("accessToken").asText();
+
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "refreshToken": "%s"
+                                }
+                                """.formatted(accessToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("USER005"));
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 refresh token은 거부한다")
+    void rejectMalformedRefreshToken() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "refreshToken": "not-a-valid-token"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("USER005"));
+    }
+
+    private JsonNode signupAndLoginNormalUser() throws Exception {
+        String unique = UUID.randomUUID().toString().substring(0, 8);
+        String email = unique + "@saferoute.com";
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "user%s",
+                                  "password": "password123!",
+                                  "email": "%s",
+                                  "schoolName": "SafeRoute School",
+                                  "role": "NORMAL"
+                                }
+                                """.formatted(unique, email)))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "password123!"
+                                }
+                                """.formatted(email)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString()).path("result");
+    }
+}

--- a/src/test/java/com/saferoute/global/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/saferoute/global/security/JwtTokenProviderTest.java
@@ -23,7 +23,8 @@ class JwtTokenProviderTest {
                     new JwtProperties(
                             SECRET,
                             "saferoute",
-                            Duration.ofHours(1)
+                            Duration.ofHours(1),
+                            Duration.ofDays(14)
                     )
             );
 
@@ -84,7 +85,8 @@ class JwtTokenProviderTest {
                 new JwtProperties(
                         "",
                         "saferoute",
-                        Duration.ofHours(1)
+                        Duration.ofHours(1),
+                        Duration.ofDays(14)
                 );
 
         assertThatThrownBy(

--- a/src/test/java/com/saferoute/global/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/saferoute/global/security/JwtTokenProviderTest.java
@@ -79,6 +79,31 @@ class JwtTokenProviderTest {
     }
 
     @Test
+    @DisplayName("발급한 refresh token은 type claim이 refresh이고 access token으로는 통과되지 않는다")
+    void createAndValidateRefreshToken() {
+        User user = mock(User.class);
+
+        given(user.getId()).willReturn(UUID.randomUUID());
+        given(user.getEmail())
+                .willReturn("normal@saferoute.com");
+        given(user.getRole())
+                .willReturn(UserRole.NORMAL);
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+
+        jwtTokenProvider.validateRefreshToken(refreshToken);
+
+        assertThatThrownBy(
+                () -> jwtTokenProvider.validateRefreshToken(accessToken)
+        ).isInstanceOf(JwtException.class);
+
+        assertThat(
+                jwtTokenProvider.getRefreshTokenExpirationSeconds()
+        ).isEqualTo(Duration.ofDays(14).toSeconds());
+    }
+
+    @Test
     @DisplayName("JWT secret이 비어 있으면 시작 단계에서 실패한다")
     void rejectBlankSecret() {
         JwtProperties properties =

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,6 +15,7 @@ jwt:
   secret: c2FmZXJvdXRlLXRlc3Qtand0LXNlY3JldC1rZXktMzItYnl0ZXM=
   issuer: saferoute
   access-token-expiration: 1h
+  refresh-token-expiration: 14d
 
 # AiAnalysisClient 는 컨텍스트 로딩 시점에 값이 필요하므로 더미값을 넣는다.
 # src/test/resources/application.yml이 클래스패스에서 src/main/resources/application.yml과


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #152
- Branch: feat/#152

## 요약
- Refresh token 발급/재발급(reissue) API 추가 (`POST /api/v1/auth/reissue`)
- 로그인 시 access token과 함께 refresh token을 발급/저장하도록 변경
- refresh token은 재발급 시마다 회전(rotate)되어 재사용 불가

## 작업 내용
- `RefreshToken` 엔티티 및 Repository 추가 (기존 `RevokedAccessToken`과 동일한 해시 저장 패턴)
- `JwtTokenProvider`에 refresh token 발급/검증 로직 추가 (`type` claim으로 access token과 구분)
- `RefreshTokenService` 추가: 로그인 시 발급/저장, 재발급 시 검증 후 회전
- `LoginResponse`에 `refreshToken` 필드 추가
- `POST /api/v1/auth/reissue` 엔드포인트 및 `SecurityConfig` permitAll 반영
- refresh token에 `jti`(UUID) claim 추가 — 같은 초(second)에 발급 시 토큰이 완전히 동일해져 rotation이 무력화되는 버그를 테스트 중 발견해 수정
- 관련 테스트 추가 (정상 재발급, 재사용 방지, access token으로 재발급 시도 차단, 잘못된 형식 거부)

## 변경 사항
- 저장 방식은 별도 Redis 도입 없이 기존 DB 테이블(JPA) 방식 사용 (`refresh_tokens` 테이블)
- `application.yml`에 `jwt.refresh-token-expiration` 설정 추가 (기본 14일)

## 테스트
- [x] `./gradlew test` 전체 통과 (512개)
- [x] `JwtTokenProviderTest` — refresh token 발급/타입 검증
- [x] `ReissueIntegrationTest` — 재발급 정상 흐름/재사용 방지/오남용 케이스

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 시 액세스 토큰과 리프레시 토큰을 함께 제공합니다.
  * 리프레시 토큰으로 새 토큰을 발급받을 수 있습니다.
  * 리프레시 토큰 재사용과 잘못된 토큰을 차단합니다.
  * 리프레시 토큰의 기본 만료 기간은 14일입니다.

* **버그 수정**
  * 액세스 토큰이나 유효하지 않은 토큰을 재발급에 사용할 수 없도록 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->