### PR TITLE
Feature/161 swagger api 설명 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/saferoute/domain/analysis/controller/AnalysisController.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.analysis.controller;
 
 import com.saferoute.domain.floor.service.FloorService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,25 @@ public class AnalysisController {
 
   private final FloorService floorService;
 
+    @Operation(
+            summary = "도면 AI 세그멘테이션 분석 요청",
+            description = """
+                    업로드된 층 도면 이미지를 AI 세그멘테이션 서버로 보내 분석하고, 그 결과로
+                    받은 노드/엣지 그래프를 해당 층의 대피 경로 그래프로 저장합니다. 요청 스레드
+                    안에서 AI 서버 호출까지 동기로 처리되므로, 응답이 올 때까지 시간이 걸릴 수
+                    있습니다(폴링 없이 응답 자체가 완료 신호입니다).
+
+                    분석에 성공하면 해당 층의 기존 노드/엣지를 모두 삭제하고 AI 응답으로 새로
+                    교체하며, segmentationStatus가 DONE으로 바뀝니다. AI 호출이 실패하거나 결과
+                    그래프가 유효하지 않으면(중복된 노드 임시 ID, 존재하지 않는 노드를 참조하는
+                    엣지 등) 저장 없이 segmentationStatus가 FAILED로 바뀌고 오류가 반환됩니다.
+
+                    도면 이미지가 아직 업로드되지 않은 층이면 요청할 수 없습니다. 이미
+                    segmentationStatus가 PROCESSING인 층(분석이 진행 중)에는 중복 요청할 수
+                    없으며, 이 경우 오류가 반환됩니다. 이 API는 응답 본문 없이 처리 결과를
+                    HTTP 상태로만 알려줍니다.
+                    """
+    )
     @PostMapping("/{floorId}/analyse")
     public void analyze(@PathVariable UUID floorId, Authentication authentication) {
       floorService.requestAnalysis(floorId, authentication.getName());

--- a/src/main/java/com/saferoute/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/saferoute/domain/building/controller/BuildingController.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.building.dto.request.UpdateBuildingRequest;
 import com.saferoute.domain.building.service.BuildingService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.BuildingSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
@@ -27,6 +28,17 @@ public class BuildingController {
     private final BuildingService buildingService;
 
     // 건물 등록
+    @Operation(
+            summary = "건물 등록",
+            description = """
+                    요청자가 속한 학교(schoolName) 소속으로 새 건물을 등록합니다. schoolName은
+                    요청자의 인증 정보로부터 서버가 직접 결정하며 요청 바디로 받지 않습니다.
+
+                    groundFloorCount/basementFloorCount/totalFloors는 이 API로 지정할 수 없고
+                    항상 0으로 시작하며, 이후 층 등록/삭제 API를 호출할 때마다 자동으로
+                    증감합니다. isActive는 생성 시 true로 설정됩니다.
+                    """
+    )
     @PostMapping
     public ResponseEntity<ApiResponse<BuildingResponse>> createBuilding(
             @Valid @RequestBody CreateBuildingRequest request,
@@ -37,6 +49,16 @@ public class BuildingController {
     }
 
     // 건물 목록 조회
+    @Operation(
+            summary = "건물 목록 조회",
+            description = """
+                    요청자가 속한 학교의 모든 건물을 등록일(createdAt) 최신순으로 반환합니다.
+
+                    isActive가 false로 비활성화된 건물도 목록에서 제외되지 않고 그대로
+                    포함되므로, 비활성 건물을 화면에서 숨기거나 다르게 표시하려면 프론트에서
+                    응답의 isActive 값을 보고 직접 필터링해야 합니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<List<BuildingResponse>>> getBuildings(Authentication authentication) {
         return ResponseEntity.ok(ApiResponse.success(BuildingSuccessCode.BUILDING_LIST_FOUND,
@@ -44,6 +66,17 @@ public class BuildingController {
     }
 
     // 건물 상세 조회
+    @Operation(
+            summary = "건물 상세 조회",
+            description = """
+                    buildingId로 건물 단건을 조회합니다. 요청자와 같은 학교 소속 건물만 조회할
+                    수 있으며, 존재하지 않거나 다른 학교 소속 건물이면 404가 반환됩니다.
+
+                    groundFloorCount/basementFloorCount/totalFloors는 층 등록/삭제에 따라
+                    서버가 자동 계산한 값이며, isActive가 false여도 상세 조회 자체는 계속
+                    가능합니다.
+                    """
+    )
     @GetMapping("/{buildingId}")
     public ResponseEntity<ApiResponse<BuildingResponse>> getBuilding(
             @PathVariable UUID buildingId,
@@ -53,6 +86,18 @@ public class BuildingController {
     }
 
     // 건물 정보 수정
+    @Operation(
+            summary = "건물 정보 수정",
+            description = """
+                    건물의 name/address/buildingType을 수정합니다. 요청 바디에 없는 필드는
+                    부분 수정(PATCH)이 아니라 항상 세 값을 모두 함께 덮어쓰는 방식이므로,
+                    프론트는 기존 값을 채운 뒤 변경분만 반영해 전체 필드를 보내야 합니다.
+
+                    groundFloorCount/basementFloorCount/totalFloors, isActive는 이 API로
+                    수정할 수 없습니다(층수는 층 등록/삭제로만, isActive는 비활성화 API로만
+                    변경됩니다).
+                    """
+    )
     @PutMapping("/{buildingId}")
     public ResponseEntity<ApiResponse<BuildingResponse>> updateBuilding(
             @PathVariable UUID buildingId,
@@ -64,6 +109,19 @@ public class BuildingController {
     }
 
     // 건물 비활성화 (삭제 대신 비활성 처리)
+    @Operation(
+            summary = "건물 비활성화",
+            description = """
+                    건물을 삭제하지 않고 isActive만 false로 바꾸는 소프트 삭제 API입니다.
+                    건물에 속한 층, 훈련 이력 등 다른 데이터는 그대로 남아 있으며, 이후에도
+                    건물 상세/목록 조회에서는 계속 노출됩니다(목록 API가 isActive로 걸러주지
+                    않으므로 화면에서 숨기려면 프론트에서 필터링이 필요합니다).
+
+                    훈련 기록이 있어 건물 삭제 API가 실패하는 건물은 이 API로 비활성 처리하는
+                    것을 대신 사용하면 됩니다. 다만 현재 이 API를 다시 활성화(isActive=true로
+                    되돌리는) 엔드포인트는 제공되지 않습니다.
+                    """
+    )
     @PatchMapping("/{buildingId}/deactivate")
     public ResponseEntity<ApiResponse<Void>> deactivateBuilding(
             @PathVariable UUID buildingId,
@@ -73,6 +131,18 @@ public class BuildingController {
     }
 
     // 건물 삭제
+    @Operation(
+            summary = "건물 삭제",
+            description = """
+                    건물을 DB에서 완전히 삭제합니다. TrainingScenario.building 관계에는 삭제
+                    전파(CASCADE)가 설정되어 있지 않으므로, 이 건물을 참조하는 훈련 기록이
+                    하나라도 있으면 FK 제약 위반으로 삭제가 거부되고 실패 응답이 반환됩니다.
+                    이 경우에는 완전 삭제 대신 건물 비활성화 API를 사용해야 합니다.
+
+                    요청자와 같은 학교 소속 건물만 삭제할 수 있으며, 존재하지 않거나 다른
+                    학교 소속이면 404가 반환됩니다.
+                    """
+    )
     @DeleteMapping("/{buildingId}")
     public ResponseEntity<ApiResponse<Void>> deleteBuilding(
             @PathVariable UUID buildingId,

--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionConfigController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionConfigController.java
@@ -5,6 +5,7 @@ import com.saferoute.domain.congestion.service.CongestionConfigQueryService;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.global.security.DevicePrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,26 @@ public class CongestionConfigController {
     private final DeviceAuthorizationService deviceAuthorizationService;
     private final CongestionConfigQueryService congestionConfigQueryService;
 
+    @Operation(
+            summary = "Pi 혼잡 설정 조회",
+            description = """
+                    Pi가 주기적으로 호출해 해당 CCTV에 적용할 혼잡 판정 설정을 조회합니다.
+
+                    CCTV가 속한 건물에 RUNNING 상태 훈련 세션이 없으면 trainingActive가 false로
+                    반환되며, 이 경우 trainingSessionId/monitoredAreaM2/snapshotIntervalSec/
+                    targetInferenceFps/congestionThresholds/eventDetection은 모두 null입니다.
+                    Pi는 이때 설정을 적용하지 않고 configVersion만으로 재시도 주기를 판단하면 됩니다.
+
+                    훈련이 RUNNING 상태이면 trainingActive가 true가 되고, 해당 CCTV의 GridCell
+                    개수와 층의 격자 한 칸 크기(m)로 계산한 감시 면적(monitoredAreaM2)과 함께
+                    혼잡 임계값(congestionThresholds)·탐지 설정(eventDetection)이 채워집니다.
+
+                    congestionThresholds의 CAUTION_FROM/CROWDED_FROM/VERY_CROWDED_FROM은
+                    밀도(인원수/㎡) 기준 하한값이며, BE는 이 값 이상(>=)일 때 해당 단계로 판정합니다.
+                    configVersion은 이 임계값들이나 CCTV 감시 영역(GridCell)이 바뀔 때마다
+                    증가하는 값으로, Pi와 BE의 설정 동기화 여부를 판단하는 데 사용됩니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<CongestionConfigQueryResponse> getConfig(
             @AuthenticationPrincipal DevicePrincipal principal,

--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionController.java
@@ -10,6 +10,7 @@ import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.global.security.DevicePrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,25 @@ public class CongestionController {
     private final CongestionEventImageService congestionEventImageService;
     private final DeviceAuthorizationService deviceAuthorizationService;
 
+    @Operation(
+            summary = "혼잡 이벤트 즉시 수신",
+            description = """
+                    Pi가 혼잡 진입(CONGESTION_STARTED)/상승(CONGESTION_LEVEL_UP)/종료(CONGESTION_ENDED)를
+                    감지한 순간 즉시 보내는 이벤트를 저장합니다. Pi가 함께 보낸 localDensity/
+                    localCongestionLevel은 참고용일 뿐이며, 응답의 density/congestionLevel은 BE가
+                    해당 CCTV의 감시 면적(GridCell 기반)과 headcount로 다시 계산한 값입니다.
+
+                    eventId 기준으로 멱등 처리됩니다. 같은 eventId로 재전송하면 새로 만들지 않고
+                    저장된 기존 이벤트를 그대로 반환하며, 최초 저장 시에만 201 Created, 이미 존재하면
+                    200 OK로 응답합니다. eventId는 저장돼 있는데 trainingSessionId/cctvCode가 요청과
+                    다르면 오류가 됩니다(다른 이벤트와 충돌).
+
+                    congestionLevel이 CROWDED 이상이거나, CONGESTION_ENDED로 정상(NORMAL) 상태로
+                    돌아온 경우 해당 CCTV가 감시하는 모든 경로 구간(MapEdge)에 대해 경로 재계산이
+                    비동기로 트리거됩니다. 이 응답의 eventImageKey/imageUploadStatus는 아직 이미지가
+                    연결되지 않은 상태(PENDING)로, 이후 PATCH /{eventId}/image로 채워집니다.
+                    """
+    )
     @PostMapping
     public ResponseEntity<CongestionEventResponse> reportCongestionEvent(
             @AuthenticationPrincipal DevicePrincipal principal,
@@ -47,6 +67,25 @@ public class CongestionController {
         return ResponseEntity.status(status).body(response);
     }
 
+    @Operation(
+            summary = "혼잡 이벤트 이미지 연결",
+            description = """
+                    Pi가 S3에 직접 업로드를 마친 혼잡 이벤트 이미지의 object key를 해당 이벤트에
+                    연결합니다. 사전에 POST /api/v1/device/congestion-images/presigned-url로
+                    발급받은 presigned URL로 이미지를 업로드한 뒤 이 API를 호출하는 흐름입니다.
+
+                    대상 이벤트는 처리(PROCESSED)까지 끝난 상태여야 하며, eventImageKey는
+                    "training/{trainingSessionId}/events/{cctvCode}/{eventId}.jpg" 형식이고
+                    경로 안의 세션/CCTV/이벤트 식별자가 실제 이벤트와 일치해야 합니다. 형식이
+                    다르거나 신원이 맞지 않으면 오류가 됩니다.
+
+                    이미 같은 키·업로드 시각으로 완료(COMPLETED) 처리된 이벤트에 대한 재요청은
+                    새로 처리하지 않고 그대로 성공(204)만 반환합니다(멱등). 이미 다른 이미지가
+                    연결되어 있는 등 상태가 맞지 않으면 충돌 오류가 나며, S3에 실제로 해당 객체가
+                    존재하지 않아도 오류가 됩니다. 성공 시 본문 없이 204 No Content를 반환하고,
+                    관리자 화면에는 웹소켓으로 이미지 갱신 이벤트가 발행됩니다.
+                    """
+    )
     @PatchMapping("/{eventId}/image")
     public ResponseEntity<Void> connectEventImage(
             @AuthenticationPrincipal DevicePrincipal principal,

--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionImageController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionImageController.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.congestion.dto.request.CreatePresignedImageUrlReques
 import com.saferoute.domain.congestion.dto.response.PresignedImageUrlResponse;
 import com.saferoute.domain.congestion.service.CongestionImageService;
 import com.saferoute.global.security.DevicePrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,25 @@ public class CongestionImageController {
 
     private final CongestionImageService congestionImageService;
 
+    @Operation(
+            summary = "혼잡 이미지 업로드 URL 발급",
+            description = """
+                    Pi가 모니터링 캡처(MONITORING) 또는 혼잡 이벤트(CONGESTION_EVENT) 이미지를 S3에
+                    직접 업로드할 수 있도록 presigned PUT URL을 발급합니다. Pi는 이 URL로 이미지를
+                    올린 뒤, 응답의 objectKey를 각각 관측값 신고(monitoringImageKey)나 이벤트 이미지
+                    연결(PATCH /congestion-events/{eventId}/image)에 전달해야 합니다.
+
+                    objectKey는 imageType에 따라 자동으로 결정됩니다. MONITORING이면
+                    "training/{trainingSessionId}/monitoring/{cctvCode}/{capturedAt}.jpg",
+                    그 외(CONGESTION_EVENT)면 "training/{trainingSessionId}/events/{cctvCode}/{referenceId}.jpg"
+                    형식이며, 경로의 cctvCode는 요청 바디 값이 아니라 인증된 CCTV(Pi 토큰)의 코드로
+                    고정됩니다. 이 요청은 해당 CCTV가 속한 건물에 RUNNING 상태 훈련 세션이 있을
+                    때만 허용됩니다.
+
+                    uploadUrl은 만료 시각(expiresAt, epoch millis)이 지나면 사용할 수 없으므로
+                    발급 후 곧바로 업로드해야 하며, contentType은 image/jpeg만 허용됩니다.
+                    """
+    )
     @PostMapping("/presigned-url")
     public ResponseEntity<PresignedImageUrlResponse> createPresignedUrl(
             @AuthenticationPrincipal DevicePrincipal principal,

--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionImageUrlController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionImageUrlController.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.congestion.dto.response.CongestionImageUrlResponse;
 import com.saferoute.domain.congestion.service.CongestionImageUrlService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.CongestionSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,22 @@ public class CongestionImageUrlController {
 
     private final CongestionImageUrlService congestionImageUrlService;
 
+    @Operation(
+            summary = "혼잡 이벤트 이미지 조회 URL 발급",
+            description = """
+                    관리자 화면에서 혼잡 이벤트(CongestionEventItem)에 연결된 이미지를 열람하기 위한
+                    S3 presigned GET URL을 발급합니다. S3 버킷이 비공개이므로 object key만으로는
+                    브라우저에서 바로 열 수 없어, 열람할 때마다 이 API로 URL을 새로 받아야 합니다.
+
+                    이벤트의 이미지 업로드 상태(imageUploadStatus)가 COMPLETED이고 eventImageKey가
+                    존재할 때만 성공합니다. 아직 이미지가 연결되지 않았거나(PENDING) 업로드가
+                    실패한(FAILED) 이벤트를 조회하면 이미지를 찾을 수 없다는 오류가 됩니다.
+
+                    응답의 imageUrl은 expiresAt 이후 만료되는 임시 URL이므로 화면에 오래 캐시하지
+                    말고, 만료 전에 다시 호출해 새 URL을 받아야 합니다. eventId가 속한 훈련
+                    세션이 요청자와 다른 학교 소속이면 조회할 수 없습니다.
+                    """
+    )
     @GetMapping("/api/v1/congestion-events/{eventId}/image-url")
     public ResponseEntity<ApiResponse<CongestionImageUrlResponse>> getEventImageUrl(
             @PathVariable UUID eventId,
@@ -29,6 +46,22 @@ public class CongestionImageUrlController {
         return ResponseEntity.ok(ApiResponse.success(CongestionSuccessCode.CONGESTION_IMAGE_URL_ISSUED, response));
     }
 
+    @Operation(
+            summary = "혼잡 관측값 이미지 조회 URL 발급",
+            description = """
+                    관리자 화면에서 5초 주기 혼잡 관측값(ObservationItem)에 연결된 모니터링
+                    이미지를 열람하기 위한 S3 presigned GET URL을 발급합니다. 동작 방식은 혼잡
+                    이벤트 이미지 조회 URL 발급 API와 동일하며, 대상 리소스만 관측값입니다.
+
+                    경로의 {eventId}는 혼잡 이벤트가 아니라 관측값(Observation)의 eventId를
+                    가리킵니다. 관측값에 monitoringImageKey가 없으면(Pi가 이미지 없이 관측값만
+                    보낸 경우) 이미지를 찾을 수 없다는 오류가 됩니다.
+
+                    응답의 imageUrl은 expiresAt 이후 만료되는 임시 URL이므로 화면에 오래 캐시하지
+                    말고, 만료 전에 다시 호출해 새 URL을 받아야 합니다. eventId가 속한 훈련
+                    세션이 요청자와 다른 학교 소속이면 조회할 수 없습니다.
+                    """
+    )
     @GetMapping("/api/v1/congestion-observations/{eventId}/image-url")
     public ResponseEntity<ApiResponse<CongestionImageUrlResponse>> getObservationImageUrl(
             @PathVariable UUID eventId,

--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionObservationController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionObservationController.java
@@ -8,6 +8,7 @@ import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.global.security.DevicePrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,26 @@ public class CongestionObservationController {
     private final DeviceAuthorizationService deviceAuthorizationService;
     private final CongestionObservationService congestionObservationService;
 
+    @Operation(
+            summary = "5초 관측값 수신",
+            description = """
+                    Pi가 5초 주기로 보내는 혼잡 관측값(평균/최대 인원, 표본 수 등)을 저장합니다.
+                    Pi가 보낸 avgHeadcount와 해당 CCTV의 감시 면적(GridCell 기반)으로 BE가 직접
+                    density를 계산하고, 그 값을 congestionThresholds 기준으로 판정한 congestionLevel을
+                    함께 저장합니다. Pi가 보낸 localDensity/localCongestionLevel 같은 값은 없으며,
+                    이 응답의 density/congestionLevel이 최종 판정값입니다.
+
+                    eventId 기준으로 멱등 처리됩니다. 같은 eventId로 재전송하면 새로 만들지 않고
+                    저장된 기존 관측값을 그대로 반환하며, 최초 저장 시에만 201 Created, 이미
+                    존재하면 200 OK로 응답합니다. monitoringImageKey를 함께 보내면 형식과
+                    세션/CCTV/캡처시각 신원이 검증된 뒤 저장되고, 비어 있으면 이미지 없음(null)으로
+                    처리됩니다. 응답의 expiresAt은 이 관측값 레코드(DynamoDB TTL)의 만료 시각입니다.
+
+                    congestionLevel이 CROWDED 이상이면 해당 CCTV가 감시하는 모든 경로 구간(MapEdge)에
+                    대해 경로 재계산이 비동기로 트리거됩니다. 관측값은 즉시 이벤트(CONGESTION_ENDED)와
+                    달리 상태 전환 구분이 없어, 정상 복귀만으로는 재계산이 트리거되지 않습니다.
+                    """
+    )
     @PostMapping
     public ResponseEntity<ObservationResponse> reportObservation(
             @AuthenticationPrincipal DevicePrincipal principal,

--- a/src/main/java/com/saferoute/domain/dashboard/DashboardController.java
+++ b/src/main/java/com/saferoute/domain/dashboard/DashboardController.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.training.dto.TrainingStatusResponse;
 import com.saferoute.domain.report.service.TrainingReportService;
 import com.saferoute.domain.training.service.TrainingSessionService;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
@@ -26,6 +27,19 @@ public class DashboardController {
   private final TrainingReportService trainingReportService;
   private final TrainingSessionService trainingSessionService;
 
+  @Operation(
+      summary = "최근 훈련 리포트 목록 조회",
+      description = """
+          요청자가 속한 학교에서 생성된 훈련 리포트 중 최신 5건을 생성일(createdAt) 기준
+          내림차순으로 반환합니다. 대시보드 메인 화면의 "최근 훈련" 목록에 사용됩니다.
+
+          각 항목은 시나리오 이름, 세션 시작 시각, 참여 인원, 평균(세션 전체) 대피 소요 시간,
+          생존률, 등급으로 구성되며, 리포트가 아직 생성되지 않은 세션은 이 목록에 포함되지
+          않습니다.
+
+          현재 5건으로 개수가 고정되어 있으며 페이지네이션은 지원하지 않습니다.
+          """
+  )
   @GetMapping("/trainings")
   public ResponseEntity<ApiResponse<List<RecentTrainingReportResponse>>> getRecentReports(
       Authentication authentication
@@ -35,6 +49,21 @@ public class DashboardController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
+  @Operation(
+      summary = "대시보드 통계 조회",
+      description = """
+          요청자가 속한 학교 전체를 대상으로 한 요약 통계를 반환합니다.
+
+          totalSessions는 학교에 속한 전체 훈련 세션 수(리포트 생성 여부와 무관)이지만,
+          avgEvacuationSec·avgSurvivalRate·totalParticipants 세 값은 리포트가 생성된
+          세션만 집계 대상이므로, 리포트가 없는 세션이 있으면 totalSessions보다 실제 집계에
+          사용된 세션 수가 더 적을 수 있습니다. avgEvacuationSec/avgSurvivalRate는 리포트
+          기준 평균, totalParticipants는 리포트에 기록된 참여 인원의 합계입니다.
+
+          해당 학교에 생성된 리포트가 하나도 없으면 avgEvacuationSec, avgSurvivalRate,
+          totalParticipants는 모두 0으로 반환됩니다.
+          """
+  )
   @GetMapping("/stats")
   public ResponseEntity<ApiResponse<DashboardStatsResponse>> getStats(
       Authentication authentication
@@ -43,6 +72,25 @@ public class DashboardController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
+  @Operation(
+      summary = "훈련 세션 실시간 상태 조회",
+      description = """
+          훈련 세션의 현재 상태(SCHEDULED 또는 RUNNING)에 따라 서로 다른 응답 형태를
+          반환합니다. 응답에 상태를 구분하는 별도 필드는 없으므로, 프론트엔드는 응답에 포함된
+          필드 조합(scheduledAt/totalFloors/expectedParticipants가 있으면 예정된 훈련,
+          elapsedSeconds/actualParticipants/currentSurvivalRate가 있으면 진행 중인 훈련)으로
+          두 형태를 구분해야 합니다.
+
+          SCHEDULED 상태에서는 건물명, 총 층수, 예정 시각, 예상 참여 인원을 반환합니다.
+
+          RUNNING 상태에서는 건물명과 함께, 세션 시작 시각부터 현재까지 경과한 시간(초)을
+          매 요청마다 서버에서 새로 계산해 반환합니다. actualParticipants와
+          currentSurvivalRate는 아직 값이 채워지지 않았으면 각각 0으로 대체되어 내려갑니다.
+
+          SCHEDULED, RUNNING 외의 상태(예: 종료된 세션)는 아직 지원하지 않으며 오류가
+          발생하므로, 실시간 모니터링 용도로만 폴링해 사용해야 합니다.
+          """
+  )
   @GetMapping("/training-status/{sessionId}")
   public ResponseEntity<ApiResponse<TrainingStatusResponse>> getTrainingStatus(
       @PathVariable UUID sessionId,

--- a/src/main/java/com/saferoute/domain/device/controller/CctvController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/CctvController.java
@@ -9,6 +9,7 @@ import com.saferoute.domain.device.dto.response.DeviceTokenIssueResponse;
 import com.saferoute.domain.device.service.CctvService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.CctvSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -34,6 +35,22 @@ public class CctvController {
 
     private final CctvService cctvService;
 
+    @Operation(
+            summary = "CCTV 등록",
+            description = """
+                    CCTV를 새로 등록하고 감시 GridCell을 함께 지정합니다. code는 클라이언트가
+                    보내지 않으며 서버가 CCTV_001 형식으로 자동 채번하고, DB sequence 기반이라
+                    등록이 실패하거나 이후 CCTV가 삭제되어도 같은 번호가 재사용되지 않습니다.
+
+                    등록과 동시에 디바이스 토큰을 발급해 응답의 deviceToken 필드로 평문 그대로
+                    한 번만 반환합니다. 이 값은 서버에 해시로만 저장되므로 이후에는 다시 조회할
+                    수 없고, 분실 시 별도 재발급 절차가 필요합니다.
+
+                    floorId가 가리키는 층에 그리드(gridCellSizeMeter)가 아직 설정되지 않았으면
+                    등록할 수 없습니다. gridCellIds는 비어 있을 수 없고, 중복되거나 해당 층 소속이
+                    아니거나 보행 불가능(walkable=false) 셀이 섞여 있으면 실패합니다.
+                    """
+    )
     @PostMapping
     public ResponseEntity<ApiResponse<CctvRegistrationResponse>> createCctv(
             @Valid @RequestBody CreateCctvRequest request
@@ -43,6 +60,18 @@ public class CctvController {
                 .body(ApiResponse.success(CctvSuccessCode.CCTV_CREATED, response));
     }
 
+    @Operation(
+            summary = "CCTV 디바이스 토큰 발급",
+            description = """
+                    지정한 CCTV의 디바이스 토큰을 발급해 평문 값을 한 번만 반환합니다.
+                    라즈베리파이가 이 토큰으로 자기 자신을 인증하므로, 등록 API가 발급한 토큰을
+                    분실했거나 등록 당시 토큰 없이 생성된 CCTV에 사용합니다.
+
+                    이미 토큰이 발급된 CCTV(deviceTokenHash가 이미 존재)에는 호출할 수 없고
+                    실패합니다 - 재발급이 아니라 아직 토큰이 없는 CCTV에 대한 최초 발급 전용
+                    API입니다. 발급된 값은 서버에 해시로만 저장되어 이후 다시 조회할 수 없습니다.
+                    """
+    )
     @PostMapping("/{cctvId}/device-token")
     public ResponseEntity<ApiResponse<DeviceTokenIssueResponse>> issueDeviceToken(
             @PathVariable UUID cctvId
@@ -50,6 +79,18 @@ public class CctvController {
         return ResponseEntity.ok(ApiResponse.success(cctvService.issueDeviceToken(cctvId)));
     }
 
+    @Operation(
+            summary = "CCTV 목록 조회",
+            description = """
+                    요청자 소속 학교의 CCTV 목록을 조회합니다. 활성/비활성 여부와 관계없이
+                    모두 포함되며, enabled 필드로 구분해야 합니다.
+
+                    floorId를 지정하면 해당 층의 CCTV만 반환하고, 생략하면 학교 전체 CCTV를
+                    반환합니다. 각 항목에는 감시 영역(monitoredGridCellCount, monitoredAreaM2)이
+                    함께 포함되며, 층에 그리드가 아직 설정되지 않은 경우 gridCellSizeMeter와
+                    monitoredAreaM2는 null입니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<List<CctvResponse>>> getCctvs(
             @RequestParam(required = false) UUID floorId,
@@ -61,6 +102,17 @@ public class CctvController {
         ));
     }
 
+    @Operation(
+            summary = "CCTV 상세 조회",
+            description = """
+                    CCTV 한 건의 상세 정보와 감시 GridCell 목록을 조회합니다. 요청자와 다른
+                    학교 소속 CCTV는 조회할 수 없고 찾을 수 없음으로 처리됩니다.
+
+                    gridCells는 행(rowIndex) 오름차순, 같은 행에서는 열(columnIndex) 오름차순으로
+                    정렬되어 반환됩니다. 아직 감시 영역이 설정되지 않은 CCTV는 gridCells가
+                    빈 배열로 반환됩니다.
+                    """
+    )
     @GetMapping("/{cctvId}")
     public ResponseEntity<ApiResponse<CctvResponse>> getCctv(
             @PathVariable UUID cctvId,
@@ -71,6 +123,17 @@ public class CctvController {
         ));
     }
 
+    @Operation(
+            summary = "CCTV 감시 GridCell 조회",
+            description = """
+                    CCTV 한 건에 매핑된 감시 GridCell 목록을 조회합니다. 내부적으로 CCTV 상세
+                    조회(GET /{cctvId})와 동일한 응답을 반환하므로, 감시 영역만 필요한 화면에서도
+                    CCTV 기본 정보가 함께 내려옵니다.
+
+                    gridCells는 행(rowIndex) 오름차순, 같은 행에서는 열(columnIndex) 오름차순으로
+                    정렬됩니다. 아직 설정되지 않았다면 빈 배열입니다.
+                    """
+    )
     @GetMapping("/{cctvId}/grid-cells")
     public ResponseEntity<ApiResponse<CctvResponse>> getGridCells(
             @PathVariable UUID cctvId,
@@ -81,6 +144,22 @@ public class CctvController {
         ));
     }
 
+    @Operation(
+            summary = "CCTV 감시 GridCell 설정",
+            description = """
+                    CCTV가 감시하는 GridCell 목록을 새 목록으로 전체 교체합니다. 기존 매핑은
+                    모두 삭제되고 요청에 담긴 gridCellIds로 다시 채워지므로, 부분 추가/삭제가
+                    아니라 항상 전체 목록을 보내야 합니다.
+
+                    설정이 성공하면 혼잡도 설정 버전이 증가합니다 - 이 버전은 혼잡도 계산
+                    로직이 그리드-엣지 매핑 변경을 감지해 캐시를 무효화하는 데 쓰이므로,
+                    프론트에서 별도로 처리할 값은 아닙니다.
+
+                    CCTV가 속한 층에 그리드가 설정되어 있지 않으면 실패합니다. gridCellIds는
+                    비어 있을 수 없고, 중복되거나 해당 층 소속이 아니거나 보행 불가능
+                    (walkable=false) 셀이 섞여 있으면 실패합니다.
+                    """
+    )
     @PutMapping("/{cctvId}/grid-cells")
     public ResponseEntity<ApiResponse<CctvResponse>> configureGridCells(
             @PathVariable UUID cctvId,
@@ -93,6 +172,16 @@ public class CctvController {
         ));
     }
 
+    @Operation(
+            summary = "CCTV 이름/위치 수정",
+            description = """
+                    CCTV의 이름과 도면상 좌표(x, y)를 수정합니다. code, 감시 GridCell,
+                    활성화 여부, 디바이스 토큰에는 영향을 주지 않습니다.
+
+                    x, y는 0.0~1.0 범위의 상대 좌표로, 도면 이미지 기준 비율 좌표입니다.
+                    소속 층은 이 API로 바꿀 수 없습니다.
+                    """
+    )
     @PatchMapping("/{cctvId}")
     public ResponseEntity<ApiResponse<CctvResponse>> updateCctv(
             @PathVariable UUID cctvId,
@@ -105,6 +194,17 @@ public class CctvController {
         ));
     }
 
+    @Operation(
+            summary = "CCTV 활성화",
+            description = """
+                    비활성화된 CCTV를 다시 활성화합니다. 이미 활성 상태여도 에러 없이
+                    그대로 성공 처리됩니다(멱등).
+
+                    비활성 상태에서는 해당 CCTV(Pi)가 유도등 명령 폴링(GET
+                    /api/v1/device/light-commands) 시 CCTV_DISABLED로 거부되므로,
+                    현장 점검이 끝난 CCTV를 다시 운영에 투입할 때 사용합니다.
+                    """
+    )
     @PatchMapping("/{cctvId}/enable")
     public ResponseEntity<ApiResponse<CctvResponse>> enableCctv(
             @PathVariable UUID cctvId,
@@ -115,6 +215,18 @@ public class CctvController {
         ));
     }
 
+    @Operation(
+            summary = "CCTV 비활성화",
+            description = """
+                    CCTV를 비활성화합니다. 이미 비활성 상태여도 에러 없이 그대로 성공 처리됩니다
+                    (멱등).
+
+                    비활성화되면 해당 CCTV(Pi)는 디바이스 토큰이 유효해도 유도등 명령 폴링(GET
+                    /api/v1/device/light-commands)이 CCTV_DISABLED로 거부됩니다 - 이 CCTV가
+                    담당하는 유도등들은 새 명령을 더 이상 받아가지 못하게 됩니다. 하드웨어
+                    점검/철거 시 사용합니다.
+                    """
+    )
     @PatchMapping("/{cctvId}/disable")
     public ResponseEntity<ApiResponse<CctvResponse>> disableCctv(
             @PathVariable UUID cctvId,

--- a/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/IoTLightController.java
@@ -11,6 +11,7 @@ import com.saferoute.domain.device.dto.response.LightDirectionResponse;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.IoTLightSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -36,6 +37,19 @@ public class IoTLightController {
 
     private final IoTLightService iotLightService;
 
+    @Operation(
+            summary = "IoT 유도등 등록",
+            description = """
+                    도면 위치(floorId, x, y)만으로 IoT 유도등을 새로 등록합니다. code는
+                    클라이언트가 보내지 않으며 서버가 LIGHT_001 형식으로 자동 채번합니다.
+
+                    등록 시점에는 분기 정보(decisionNode/leftEdge/rightEdge), piEndpoint,
+                    담당 CCTV가 모두 비어 있어 guidanceConfigured는 false, piEndpoint와
+                    cctvId는 null로 반환됩니다. 실제로 방향 전환 명령을 받으려면 경로 안내
+                    설정(PATCH /{lightId}/guidance)과 담당 CCTV 지정(PATCH /{lightId}/cctv)을
+                    별도로 완료해야 합니다.
+                    """
+    )
     @PostMapping
     public ResponseEntity<ApiResponse<IoTLightResponse>> createLight(
             @Valid @RequestBody CreateIoTLightRequest request,
@@ -46,6 +60,22 @@ public class IoTLightController {
                 .body(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_CREATED, response));
     }
 
+    @Operation(
+            summary = "IoT 유도등 목록 조회",
+            description = """
+                    요청자 소속 학교의 IoT 유도등 목록을 조회합니다. 활성/비활성 여부와
+                    관계없이 모두 포함되며, enabled 필드로 구분해야 합니다.
+
+                    floorId를 지정하면 해당 층의 유도등만 반환하고, 생략하면 학교 전체
+                    유도등을 반환합니다. 현재 점등 방향(LEFT/RIGHT/BOTH/OFF)은 훈련별로
+                    바뀌는 동적 상태라 이 응답에 포함되지 않습니다 - 서버 메모리에서만
+                    관리되며 별도 계약이 없어 이 API로는 조회할 수 없습니다.
+
+                    decisionNodeId/leftEdgeId/rightEdgeId, piEndpoint, cctvId는 아직
+                    설정되지 않았으면 null이며, guidanceConfigured가 true여야 방향 전환이
+                    가능합니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<List<IoTLightResponse>>> getLights(
             @RequestParam(required = false) UUID floorId,
@@ -56,6 +86,17 @@ public class IoTLightController {
                         iotLightService.getLights(floorId, authentication.getName())));
     }
 
+    @Operation(
+            summary = "IoT 유도등 상세 조회",
+            description = """
+                    IoT 유도등 한 건의 상세 정보를 조회합니다. 요청자와 다른 학교 소속
+                    유도등은 조회할 수 없고 찾을 수 없음으로 처리됩니다.
+
+                    현재 점등 방향은 훈련별 동적 상태(서버 메모리)라 이 응답에 포함되지
+                    않습니다. decisionNodeId/leftEdgeId/rightEdgeId, piEndpoint, cctvId는
+                    아직 설정되지 않았으면 null입니다.
+                    """
+    )
     @GetMapping("/{lightId}")
     public ResponseEntity<ApiResponse<IoTLightResponse>> getLight(
             @PathVariable UUID lightId,
@@ -65,6 +106,20 @@ public class IoTLightController {
                         iotLightService.getLight(lightId, authentication.getName())));
     }
 
+    @Operation(
+            summary = "IoT 유도등 경로 안내 설정",
+            description = """
+                    유도등이 방향을 판단하는 분기 노드(decisionNodeId)와 좌/우 점등 시
+                    안내되는 통로 엣지(leftEdgeId, rightEdgeId)를 설정합니다. 설정이 끝나면
+                    guidanceConfigured가 true가 되어야 OFF 이외의 방향(LEFT/RIGHT/BOTH)으로
+                    전환할 수 있습니다.
+
+                    leftEdgeId와 rightEdgeId는 서로 같을 수 없고, 둘 다 decisionNodeId에
+                    실제로 연결된 엣지여야 합니다 - 아니면 요청이 거부됩니다.
+
+                    이 API는 기존 설정을 완전히 새 값으로 덮어씁니다.
+                    """
+    )
     @PatchMapping("/{lightId}/guidance")
     public ResponseEntity<ApiResponse<IoTLightResponse>> configureGuidance(
             @PathVariable UUID lightId,
@@ -75,6 +130,15 @@ public class IoTLightController {
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_GUIDANCE_CONFIGURED, response));
     }
 
+    @Operation(
+            summary = "IoT 유도등 이름/위치 수정",
+            description = """
+                    유도등의 이름과 도면상 좌표(x, y)를 수정합니다. code, 경로 안내 설정,
+                    piEndpoint, 담당 CCTV, 활성화 여부에는 영향을 주지 않습니다.
+
+                    소속 층은 이 API로 바꿀 수 없습니다.
+                    """
+    )
     @PatchMapping("/{lightId}")
     public ResponseEntity<ApiResponse<IoTLightResponse>> updateLight(
             @PathVariable UUID lightId,
@@ -85,6 +149,32 @@ public class IoTLightController {
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_UPDATED, response));
     }
 
+    @Operation(
+            summary = "IoT 유도등 점등 방향 전환",
+            description = """
+                    유도등의 점등 방향을 전환합니다. EC2 서버가 사설망의 라즈베리파이를 직접
+                    호출할 수 없어, 이 API는 Pi를 즉시 부르지 않고 LightCommand를 PENDING
+                    상태로 큐에 적재하기만 합니다. 실제 릴레이 제어는 이 유도등을 담당하는
+                    CCTV(Pi)가 GET /api/v1/device/light-commands로 주기적으로 폴링해가서
+                    수행하고, 결과는 Pi가 PATCH /api/v1/device/light-commands/{commandId}/ack로
+                    비동기 보고합니다.
+
+                    응답의 direction/changedAt은 명령을 큐에 적재하는 시점에 낙관적으로
+                    확정되는 값입니다 - Pi가 실제로 명령을 폴링해가서 실행에 성공했는지,
+                    실패했는지, 아예 오프라인이라 15초 안에 ACK를 못 보내 타임아웃되는지는
+                    이 응답만으로는 알 수 없습니다. 실행 결과가 필요하면 유도등 명령 폴링/ACK
+                    조회 경로를 별도로 확인해야 합니다.
+
+                    같은 유도등에 이미 PENDING 상태로 쌓여 있던(아직 Pi가 가져가지 않은) 이전
+                    명령은 이번 요청으로 즉시 SUPERSEDED 처리되어 실행되지 않습니다 - Pi는
+                    폴링 시 유도등당 최신 PENDING 명령 하나만 가져가므로, 밀린 방향 전환이
+                    뒤늦게 실행되는 일은 없습니다.
+
+                    direction이 OFF가 아니면 유도등에 경로 안내(guidance)가 먼저 설정되어
+                    있어야 하고, 담당 CCTV(cctv)가 지정되어 있어야 합니다. 비활성화된
+                    유도등이거나 두 조건 중 하나라도 충족하지 못하면 요청이 거부됩니다.
+                    """
+    )
     @PatchMapping("/{lightId}/direction")
     public ResponseEntity<ApiResponse<LightDirectionResponse>> changeDirection(
             @PathVariable UUID lightId,
@@ -95,6 +185,18 @@ public class IoTLightController {
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_DIRECTION_CHANGED, response));
     }
 
+    @Operation(
+            summary = "IoT 유도등 Pi 엔드포인트 설정",
+            description = """
+                    유도등의 릴레이를 직접 제어하는 라즈베리파이 주소(piEndpoint, 예:
+                    http://192.168.0.50:5000)를 등록/수정합니다. 등록 시점에는 비어 있을 수
+                    있어, 하드웨어 배치가 끝난 뒤 별도로 설정하는 용도입니다.
+
+                    참고로 유도등 명령 폴링/ACK 인증은 이 piEndpoint가 아니라 담당 CCTV(PATCH
+                    /{lightId}/cctv로 지정)의 디바이스 토큰을 사용합니다 - piEndpoint는 현재
+                    참고용 메타데이터이며 실제 명령 전달 경로에는 사용되지 않습니다.
+                    """
+    )
     @PatchMapping("/{lightId}/pi-endpoint")
     public ResponseEntity<ApiResponse<IoTLightResponse>> updatePiEndpoint(
             @PathVariable UUID lightId,
@@ -105,6 +207,23 @@ public class IoTLightController {
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_PI_ENDPOINT_UPDATED, response));
     }
 
+    @Operation(
+            summary = "IoT 유도등 담당 CCTV 연결",
+            description = """
+                    유도등의 릴레이를 실제로 제어하는 라즈베리파이를 지정합니다. 릴레이 자체는
+                    별도 네트워크 장비이지만, 그 릴레이에 명령을 보내는 코드는 혼잡도 감지용
+                    Pi 프로세스 안에서 함께 돌기 때문에, 유도등을 직접 지정하지 않고 그 Pi가
+                    맡고 있는 CCTV를 통해 연결합니다.
+
+                    이 연결이 곧 유도등 명령 폴링(GET /api/v1/device/light-commands?cctvCode=...)
+                    의 인증/라우팅 기준입니다 - 지정된 CCTV(Pi)가 자신의 디바이스 토큰으로
+                    폴링해야만 이 유도등의 PENDING 명령을 가져갈 수 있습니다. 담당 CCTV가
+                    지정되지 않은 유도등은 점등 방향 전환 자체가 거부됩니다.
+
+                    이 API는 기존 연결을 새 CCTV로 완전히 교체합니다. 지정하는 CCTV는 요청자와
+                    같은 학교 소속이어야 합니다.
+                    """
+    )
     @PatchMapping("/{lightId}/cctv")
     public ResponseEntity<ApiResponse<IoTLightResponse>> assignCctv(
             @PathVariable UUID lightId,
@@ -115,6 +234,16 @@ public class IoTLightController {
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_CCTV_ASSIGNED, response));
     }
 
+    @Operation(
+            summary = "IoT 유도등 활성화",
+            description = """
+                    비활성화된 유도등을 다시 활성화합니다. 이미 활성 상태여도 에러 없이
+                    그대로 성공 처리됩니다(멱등).
+
+                    비활성 상태에서는 점등 방향 전환(PATCH /{lightId}/direction) 요청 자체가
+                    거부되므로, 현장 점검이 끝난 유도등을 다시 운영에 투입할 때 사용합니다.
+                    """
+    )
     @PatchMapping("/{lightId}/enable")
     public ResponseEntity<ApiResponse<IoTLightResponse>> enableLight(
             @PathVariable UUID lightId,
@@ -123,6 +252,17 @@ public class IoTLightController {
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_ENABLED, response));
     }
 
+    @Operation(
+            summary = "IoT 유도등 비활성화",
+            description = """
+                    유도등을 비활성화합니다. 이미 비활성 상태여도 에러 없이 그대로 성공
+                    처리됩니다(멱등).
+
+                    비활성화되면 점등 방향 전환(PATCH /{lightId}/direction) 요청이 거부되어
+                    새 명령이 큐에 적재되지 않습니다. 단, 이미 적재되어 Pi가 폴링해간 명령의
+                    실행이나 ACK 처리 자체를 막지는 않습니다. 하드웨어 점검/철거 시 사용합니다.
+                    """
+    )
     @PatchMapping("/{lightId}/disable")
     public ResponseEntity<ApiResponse<IoTLightResponse>> disableLight(
             @PathVariable UUID lightId,
@@ -131,6 +271,17 @@ public class IoTLightController {
         return ResponseEntity.ok(ApiResponse.success(IoTLightSuccessCode.IOT_LIGHT_DISABLED, response));
     }
 
+    @Operation(
+            summary = "IoT 유도등 삭제",
+            description = """
+                    IoT 유도등을 영구 삭제합니다. 유도등에 연결된 도면 노드(customNode)를
+                    지우는 방식으로 동작하며, DB의 ON DELETE CASCADE 설정에 의해 유도등
+                    레코드 자체도 함께 삭제됩니다.
+
+                    노드를 지우기 전에 그 노드와 연결된 통로 엣지(from/to 어느 쪽이든)를
+                    먼저 모두 삭제합니다. 복구할 수 없는 삭제이므로 되돌릴 수 없습니다.
+                    """
+    )
     @DeleteMapping("/{lightId}")
     public ResponseEntity<ApiResponse<Void>> deleteLight(
             @PathVariable UUID lightId,

--- a/src/main/java/com/saferoute/domain/device/controller/LightCommandController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/LightCommandController.java
@@ -7,6 +7,7 @@ import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.service.DeviceAuthorizationService;
 import com.saferoute.domain.device.service.LightCommandService;
 import com.saferoute.global.security.DevicePrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -33,6 +34,25 @@ public class LightCommandController {
     private final DeviceAuthorizationService deviceAuthorizationService;
     private final LightCommandService lightCommandService;
 
+    @Operation(
+            summary = "유도등 명령 폴링",
+            description = """
+                    Pi가 자신이 담당하는 CCTV(cctvCode)에 연결된 모든 유도등을 대상으로,
+                    아직 가져가지 않은 최신 명령을 가져갑니다. EC2 서버가 사설망의 Pi를 직접
+                    호출할 수 없어 만든 구조로, Pi가 이 API를 짧은 주기로 반복 호출(폴링)해
+                    실행할 명령이 있는지 확인해야 합니다.
+
+                    유도등 하나당 PENDING 상태의 최신 명령 1건만 반환하며, 반환과 동시에
+                    해당 명령은 SENT 상태로 전환됩니다 - 같은 명령이 다음 폴링에서 다시
+                    반환되지는 않습니다. 실행할 명령이 없는 유도등은 목록에 포함되지 않으므로,
+                    담당 유도등이 있어도 commands가 빈 배열일 수 있습니다.
+
+                    인증은 디바이스 토큰(Authorization)과 cctvCode가 그 토큰이 발급된 CCTV와
+                    일치해야 하며, 해당 CCTV가 비활성화(disabled) 상태면 거부됩니다. 명령을
+                    가져간 뒤에는 반드시 PATCH /{commandId}/ack로 실행 결과를 보고해야 합니다 -
+                    15초 안에 ACK가 없으면 서버가 TIMED_OUT으로 처리합니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<LightCommandListResponse> pollCommands(
             @AuthenticationPrincipal DevicePrincipal principal,
@@ -42,6 +62,23 @@ public class LightCommandController {
         return ResponseEntity.ok(lightCommandService.pollCommands(cctv));
     }
 
+    @Operation(
+            summary = "유도등 명령 실행 결과 보고(ACK)",
+            description = """
+                    Pi가 폴링해간 명령의 실행 결과를 보고합니다. success=true면 명령이 ACKED로,
+                    false면 FAILED로 전환되며 이때 failReason을 함께 남길 수 있습니다.
+
+                    이 API는 명령이 SENT 상태(폴링해가서 아직 결과 보고 전)일 때만 실제로
+                    상태를 바꿉니다. 이미 ACKED/FAILED/TIMED_OUT으로 처리된 명령에 다시
+                    호출해도 상태는 바뀌지 않고 현재 상태를 그대로 응답합니다 - Pi가 응답을
+                    받지 못해 같은 commandId로 재전송하더라도 중복 처리되지 않는 멱등 처리입니다.
+
+                    명령을 폴링해간 뒤 15초 안에 ACK를 보내지 않으면, 서버 스케줄러가 먼저
+                    TIMED_OUT으로 처리할 수 있습니다 - 이 경우 뒤늦게 도착한 ACK는 위와 같은
+                    이유로 무시됩니다. ACK를 보내는 Pi(디바이스 토큰의 소유 CCTV)는 해당
+                    명령이 속한 유도등의 담당 CCTV와 일치해야 합니다.
+                    """
+    )
     @PatchMapping("/{commandId}/ack")
     public ResponseEntity<LightCommandAckResponse> ack(
             @AuthenticationPrincipal DevicePrincipal principal,

--- a/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.evacuation.dto.response.EvacuationRouteResponse;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,21 @@ public class EvacuationRouteController {
     private final EvacuationRouteService evacuationRouteService;
 
     // 시작 노드에서 가장 가까운 EXIT까지의 추천 경로 (mock data 기준, congestion/danger 0 고정)
+    @Operation(
+            summary = "최단 대피 경로 조회",
+            description = """
+                    지정한 층에서 startNodeId부터 가장 가까운 EXIT 대상 노드까지 다익스트라로 계산한
+                    최단 경로를 노드 목록(출발 -> 도착 순서)과 총 가중치(totalWeight)로 반환합니다.
+
+                    가중치는 기본적으로 엣지의 실거리(distance) 합이며, 혼잡도/위험도 가중치는
+                    아직 DynamoDB 혼잡도·화재 확산 데이터 연동 전이라 항상 0으로 고정되어 있어
+                    현재는 사실상 최단 거리 경로와 동일합니다. 훈련 중 혼잡으로 트리거된 우회 경로는
+                    이 API가 아니라 재탐색 승인 API(RouteRecalculation)를 통해 반영됩니다.
+
+                    startNodeId는 대상 층에 실제로 존재하는 노드여야 하며, 해당 층에 EXIT 대상으로
+                    지정된 노드가 하나도 없거나 그래프상 도달 가능한 경로가 없으면 오류가 발생합니다.
+                    """
+    )
     @GetMapping("/routes")
     public ResponseEntity<ApiResponse<EvacuationRouteResponse>> getShortestRoute(
             @PathVariable UUID floorId,

--- a/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.evacuation.controller;
 import com.saferoute.domain.evacuation.graph.dto.response.FloorGraphResponse;
 import com.saferoute.domain.evacuation.graph.service.MapGraphService;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,22 @@ public class MapGraphController {
     private final MapGraphService mapGraphService;
 
     // 커스텀 편집 UI 캔버스 초기 로딩용 - 노드/엣지 전체 조회
+    @Operation(
+            summary = "층 맵 그래프 전체 조회",
+            description = """
+                    지정한 층에 등록된 모든 노드(STAIR/ROOM/HALLWAY/DOOR/EXIT/CUSTOM)와 엣지(통로)를
+                    한 번에 반환합니다. 커스텀 편집 UI 캔버스를 처음 열 때 도면 위에 그래프를 그리는
+                    용도로 사용됩니다.
+
+                    노드에는 정규화 좌표(0.0~1.0, x/y), 타입, EXIT 대상 여부가, 엣지에는 연결된
+                    fromNode/toNode, 실거리(distance), 양방향 여부(bidirectional)가 포함됩니다.
+                    CUSTOM 타입 노드는 CCTV/IoT 유도등 등 기기 설치 위치를 나타내며 경로 목적지가
+                    될 수 없습니다.
+
+                    아직 노드나 엣지가 하나도 등록되지 않은 층이면 nodes/edges가 빈 배열로 반환됩니다.
+                    노드/엣지의 개별 생성·수정·삭제는 이 API가 아니라 맵 그래프 편집 API를 사용합니다.
+                    """
+    )
     @GetMapping("/graph")
     public ResponseEntity<ApiResponse<FloorGraphResponse>> getGraph(
             @PathVariable UUID floorId,

--- a/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
@@ -8,6 +8,7 @@ import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
 import com.saferoute.domain.evacuation.graph.service.MapGraphService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.EvacuationSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -31,6 +32,20 @@ public class MapGraphEditController {
 
     private final MapGraphService mapGraphService;
 
+    @Operation(
+            summary = "맵 노드 생성",
+            description = """
+                    지정한 층에 새 노드(STAIR/ROOM/HALLWAY/DOOR/EXIT/CUSTOM)를 하나 추가합니다.
+                    커스텀 편집 UI에서 캔버스에 노드를 드롭했을 때 호출합니다.
+
+                    code는 같은 층 안에서 유일해야 하며(floor_id + code 유니크 제약), x/y는
+                    도면 가로/세로 기준 0.0~1.0 정규화 좌표입니다. isExitTarget을 true로 생성하면
+                    이 노드가 대피 경로 계산(다익스트라)의 목적지 후보에 포함됩니다.
+
+                    CCTV/IoT 유도등 같은 기기 위치 노드는 이 API가 아니라 각 기기 도메인의
+                    등록 API를 통해 CUSTOM 타입으로 생성됩니다.
+                    """
+    )
     @PostMapping("/floors/{floorId}/nodes")
     public ResponseEntity<ApiResponse<MapNodeResponse>> createNode(
             @PathVariable UUID floorId,
@@ -41,6 +56,19 @@ public class MapGraphEditController {
                 .body(ApiResponse.success(EvacuationSuccessCode.MAP_NODE_CREATED, response));
     }
 
+    @Operation(
+            summary = "맵 노드 위치/EXIT 대상 여부 수정",
+            description = """
+                    노드의 좌표(x, y)와 EXIT 대상(isExitTarget) 여부를 함께 수정합니다.
+                    커스텀 편집 UI에서 노드를 드래그로 이동하거나 EXIT 대상 지정을 토글할 때
+                    사용하며, 두 값을 부분 수정할 수는 없고 항상 함께 전달해야 합니다.
+
+                    isExitTarget을 false로 바꾸는 요청은, 그 노드가 속한 층에 남은 EXIT 대상
+                    노드가 이 노드 하나뿐이면 거부됩니다(마지막 출구는 해제할 수 없음). 이때
+                    같은 층에 대한 동시 수정 요청은 직렬화되어 처리되므로, 두 관리자가 동시에
+                    마지막 두 EXIT 노드를 각각 해제하려 해도 경쟁 상태 없이 하나만 성공합니다.
+                    """
+    )
     @PatchMapping("/nodes/{nodeId}")
     public ResponseEntity<ApiResponse<MapNodeResponse>> updateNodePosition(
             @PathVariable UUID nodeId,
@@ -49,12 +77,37 @@ public class MapGraphEditController {
         return ResponseEntity.ok(ApiResponse.success(mapGraphService.updateNodePosition(nodeId, request)));
     }
 
+    @Operation(
+            summary = "맵 노드 삭제",
+            description = """
+                    노드 하나를 삭제합니다. 해당 노드에 연결된 엣지(통로)도 DB FK CASCADE로
+                    함께 삭제되므로, 프론트는 삭제 후 그래프를 다시 조회해 연결이 끊어진 엣지가
+                    사라졌는지 반영해야 합니다.
+
+                    삭제 대상 노드가 EXIT 대상(isExitTarget=true)이고, 그 노드가 속한 층에 남은
+                    EXIT 대상 노드가 하나뿐이면 삭제가 거부됩니다(마지막 출구 보호). 동일 층에
+                    대한 동시 삭제 요청은 직렬화되어 처리됩니다.
+                    """
+    )
     @DeleteMapping("/nodes/{nodeId}")
     public ResponseEntity<ApiResponse<Void>> deleteNode(@PathVariable UUID nodeId) {
         mapGraphService.deleteNode(nodeId);
         return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.MAP_NODE_DELETED, null));
     }
 
+    @Operation(
+            summary = "맵 엣지(통로) 생성",
+            description = """
+                    fromNodeId와 toNodeId 두 노드를 잇는 엣지(통로)를 생성합니다. 엣지가 속한
+                    층은 별도 파라미터 없이 fromNode가 속한 floor를 그대로 사용하므로, 두 노드는
+                    같은 층에 속해야 합니다.
+
+                    distance는 실제 거리(미터)로 0보다 커야 하며 대피 경로 계산(다익스트라)의
+                    기본 가중치로 쓰입니다. bidirectional이 true면 양방향 통행으로, false면
+                    fromNode -> toNode 단방향으로만 경로 탐색 시 사용됩니다. room-hallway를
+                    직접 연결하는 등 허용되지 않는 조합은 저장 계층에서 검증됩니다.
+                    """
+    )
     @PostMapping("/edges")
     public ResponseEntity<ApiResponse<MapEdgeResponse>> createEdge(@Valid @RequestBody CreateMapEdgeRequest request) {
         MapEdgeResponse response = mapGraphService.createEdge(request);
@@ -62,6 +115,14 @@ public class MapGraphEditController {
                 .body(ApiResponse.success(EvacuationSuccessCode.MAP_EDGE_CREATED, response));
     }
 
+    @Operation(
+            summary = "맵 엣지(통로) 삭제",
+            description = """
+                    엣지(통로) 하나를 삭제합니다. 존재하지 않는 edgeId면 오류가 발생합니다.
+                    삭제 후 해당 통로를 지나던 최단 경로 계산은 더 이상 이 엣지를 후보로
+                    사용하지 않으므로, 프론트는 삭제 후 그래프를 다시 조회해 반영해야 합니다.
+                    """
+    )
     @DeleteMapping("/edges/{edgeId}")
     public ResponseEntity<ApiResponse<Void>> deleteEdge(@PathVariable UUID edgeId) {
         mapGraphService.deleteEdge(edgeId);

--- a/src/main/java/com/saferoute/domain/evacuation/controller/RouteRecalculationController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/RouteRecalculationController.java
@@ -8,6 +8,7 @@ import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.EvacuationSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
@@ -30,6 +31,19 @@ public class RouteRecalculationController {
 
     private final RouteRecalculationService routeRecalculationService;
 
+    @Operation(
+            summary = "재탐색 요청 목록 조회",
+            description = """
+                    지정한 훈련 세션에서 혼잡 감지로 트리거된 경로 재탐색 요청 목록을
+                    요청 시각(requestedAt) 내림차순(최신순)으로 반환합니다. 경로 상세(이전/후보
+                    노드 목록)는 포함되지 않으며, 필요하면 상세 조회 API를 따로 호출해야 합니다.
+
+                    status를 지정하면 해당 상태(PENDING/APPROVED/REJECTED/CANCELLED)의 요청만
+                    필터링해 반환하고, 생략하면 전체 상태를 반환합니다. 같은 세션+엣지라도 혼잡
+                    레벨이 오르내리며 PENDING이 CANCELLED로 무효화되고 새 PENDING이 다시 생성될
+                    수 있어, 한 엣지에 대해 여러 건의 이력이 쌓일 수 있습니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<List<RouteRecalculationSummaryResponse>>> getRecalculations(
             @RequestParam UUID trainingSessionId,
@@ -42,6 +56,20 @@ public class RouteRecalculationController {
         return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_LIST_FOUND, response));
     }
 
+    @Operation(
+            summary = "재탐색 요청 상세 조회",
+            description = """
+                    재탐색 요청 하나의 상세 정보를 반환합니다. 관리자가 승인/거절을 결정할 수
+                    있도록 트리거 시점의 기존 경로(previousRoute)와 새로 계산된 후보 경로
+                    (candidateRoute)를 노드 목록과 총 가중치로 나란히 제공합니다.
+
+                    previousRoute는 트리거 시점에 이미 승인된 우회 경로가 있으면 그 경로를,
+                    없으면 트리거 엣지를 그대로 포함한 정상(직행) 경로를 기준으로 삼습니다.
+                    status가 PENDING이 아니면(APPROVED/REJECTED/CANCELLED) resolvedAt,
+                    resolvedBy와 함께 rejectReason 또는 cancelReason이 채워지며, 시스템이
+                    자동으로 CANCELLED 처리한 경우 resolvedBy는 null입니다.
+                    """
+    )
     @GetMapping("/{recalculationId}")
     public ResponseEntity<ApiResponse<RouteRecalculationDetailResponse>> getRecalculationDetail(
             @PathVariable UUID recalculationId,
@@ -53,6 +81,19 @@ public class RouteRecalculationController {
         return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_DETAIL_FOUND, response));
     }
 
+    @Operation(
+            summary = "재탐색 후보 경로 승인",
+            description = """
+                    PENDING 상태인 재탐색 요청을 승인해 후보 경로(recalculatedNodeIds)를 실제
+                    대피 경로로 확정합니다. 승인 즉시 그 경로를 따라 안내하도록 관련 IoT 유도등에
+                    방향 반영이 트리거됩니다.
+
+                    이미 APPROVED/REJECTED/CANCELLED로 처리된 요청을 다시 승인하려 하면
+                    거부됩니다(PENDING만 승인 가능). 승인된 경로는 이후 같은 트리거 엣지에서
+                    혼잡이 종료될 때 정상 경로로의 복구 후보를 계산하는 기준(활성 경로)으로도
+                    사용됩니다.
+                    """
+    )
     @PatchMapping("/{recalculationId}/approve")
     public ResponseEntity<ApiResponse<RouteRecalculationResponse>> approve(
             @PathVariable UUID recalculationId,
@@ -63,6 +104,18 @@ public class RouteRecalculationController {
         return ResponseEntity.ok(ApiResponse.success(EvacuationSuccessCode.ROUTE_RECALCULATION_APPROVED, response));
     }
 
+    @Operation(
+            summary = "재탐색 후보 경로 거절",
+            description = """
+                    PENDING 상태인 재탐색 요청을 거절해 후보 경로를 반영하지 않고 기존 경로를
+                    유지합니다. reason은 선택 항목이며, 요청 본문을 아예 생략해도(body 없이
+                    호출해도) 거절 처리는 정상적으로 이루어집니다.
+
+                    이미 APPROVED/REJECTED/CANCELLED 상태인 요청은 다시 거절할 수 없습니다
+                    (PENDING만 거절 가능). 거절 사유는 상세 조회 API의 rejectReason으로 확인할
+                    수 있습니다.
+                    """
+    )
     @PatchMapping("/{recalculationId}/reject")
     public ResponseEntity<ApiResponse<RouteRecalculationResponse>> reject(
             @PathVariable UUID recalculationId,

--- a/src/main/java/com/saferoute/domain/evacuation/deviation/controller/RouteDeviationController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/deviation/controller/RouteDeviationController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.evacuation.deviation.controller;
 import com.saferoute.domain.evacuation.deviation.dto.RouteDeviationResponse;
 import com.saferoute.domain.evacuation.deviation.service.RouteDeviationService;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,27 @@ public class RouteDeviationController {
 
     private final RouteDeviationService routeDeviationService;
 
+    @Operation(
+            summary = "유도등 경로 이탈률 조회",
+            description = """
+                    지정한 IoT 유도등이 훈련 세션 동안 안내한 방향과, 같은 통로를 감시하는
+                    CCTV가 실제로 인원을 탐지한 위치를 시간 축으로 대조해 경로 이탈률을
+                    계산합니다. totalObservedWindows는 유도등이 좌/우 중 한쪽을 가리키고 있던
+                    5초 관측 구간 수, deviatedWindows는 그중 안내 방향의 반대쪽 CCTV에서도
+                    인원이 탐지되어 이탈로 집계된 구간 수이며, deviationRate는 그 비율입니다.
+
+                    CCTV는 headcount/밀집도만 보고할 뿐 개별 인원의 이동 경로를 알 수 없으므로,
+                    "좌/우 통로를 각각 감시하는 CCTV가 분리되어 있다"는 전제 하에 어느 쪽
+                    CCTV에서 인원이 탐지됐는지를 실제 이동 방향의 대리 지표로 사용합니다. 유도등이
+                    OFF이거나 BOTH(평상시 양방향 안내)를 가리키던 구간은 이탈 여부를 판단할
+                    기준이 없어 집계에서 제외됩니다.
+
+                    대상 유도등에 좌/우 안내 경로(guidance)가 아직 설정되지 않았거나, 좌/우 통로를
+                    구분해 감시하는 CCTV 매핑을 찾을 수 없으면 오류가 발생합니다. 관측 구간이
+                    하나도 없으면 totalObservedWindows/deviatedWindows는 0, deviationRate는
+                    0.0으로 반환됩니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<RouteDeviationResponse>> getDeviationRate(
             @PathVariable UUID lightId,

--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
@@ -5,6 +5,7 @@ import com.saferoute.domain.evacuation.grid.dto.response.FloorGridCellPageRespon
 import com.saferoute.domain.evacuation.grid.dto.response.FloorGridResponse;
 import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -22,6 +23,22 @@ public class FloorGridController {
 
     private final FloorGridService floorGridService;
 
+    @Operation(
+            summary = "층 그리드 셀 목록 조회",
+            description = """
+                    지정한 층에 생성된 그리드 셀을 행(rowIndex) 오름차순, 같은 행에서는
+                    열(columnIndex) 오름차순으로 페이지네이션 조회합니다. 셀 수가 수만 개 이상일
+                    수 있어 전체를 한 번에 반환하지 않고 page/size로 나눠서 제공합니다.
+
+                    각 셀은 walkable(보행 가능 여부), isFired(현재 화재 여부), 중심 정규화 좌표,
+                    그리고 지정된 사용자 구역(UserZone)이 있으면 그 정보를 포함합니다. isFired는
+                    훈련 중 화재 확산 시뮬레이션에 따라 동적으로 바뀌고 훈련 종료 시 초기화되므로,
+                    실시간 상태가 필요하면 화면에서 주기적으로 다시 조회해야 합니다.
+
+                    아직 그리드가 생성되지 않은 층을 조회하면 content가 빈 배열로 반환됩니다.
+                    size는 최대 2000까지 허용됩니다.
+                    """
+    )
     @GetMapping("/cells")
     public ApiResponse<FloorGridCellPageResponse> getGridCells(
             @PathVariable UUID floorId,
@@ -33,6 +50,25 @@ public class FloorGridController {
                 floorId, page, size, authentication.getName()));
     }
 
+    @Operation(
+            summary = "층 그리드 생성/재생성",
+            description = """
+                    지정한 층에 cellSizeMeter(미터 단위 셀 한 변 길이) 기준으로 격자 그리드를
+                    새로 생성합니다. 이미 그리드가 존재하는 층에 다시 호출하면 최초 생성과 동일한
+                    로직으로 전체를 재생성합니다(부분 수정 불가).
+
+                    재생성 시 기존 그리드 셀은 모두 삭제되고(연결된 NodeGridCell/MapEdgeGridCell도
+                    함께 삭제), 그 층의 사용자 지정 구역(UserZone)도 함께 삭제됩니다 - 셀 좌표
+                    체계가 바뀌므로 구역 지정을 그대로 옮길 수 없기 때문입니다. CCTV 위치 노드도
+                    삭제 후 재계산 대상이며(유도등 노드는 유지), 살아남은 노드/엣지는 새 그리드
+                    좌표로 다시 매핑됩니다.
+
+                    도면 세그멘테이션이 완료(DONE) 상태이고 실측 가로/세로 값(realWidth/
+                    realHeight)이 설정되어 있어야 하며, 그렇지 않으면 오류가 발생합니다. 계산된
+                    셀 개수가 너무 많거나(rows × columns 상한 초과) cellSizeMeter로 계산한
+                    행/열 수가 0 이하이면(비정상적으로 큰 셀 크기) 오류가 발생합니다.
+                    """
+    )
     @PutMapping
     public ApiResponse<FloorGridResponse> createOrRegenerateGrid(
             @PathVariable UUID floorId,

--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/UserZoneController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/UserZoneController.java
@@ -6,6 +6,7 @@ import com.saferoute.domain.evacuation.grid.dto.response.UserZoneCellsResponse;
 import com.saferoute.domain.evacuation.grid.dto.response.UserZoneResponse;
 import com.saferoute.domain.evacuation.grid.service.UserZoneService;
 import com.saferoute.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,19 @@ public class UserZoneController {
 
     private final UserZoneService userZoneService;
 
+    @Operation(
+            summary = "사용자 구역 생성",
+            description = """
+                    지정한 층의 그리드 셀 여러 개를 name으로 묶어 사람이 읽을 수 있는 구역
+                    (예: "301호 앞 복도", "3층 왼쪽 계단")으로 등록합니다. cellIds로 넘긴
+                    FloorGridCell들이 이 구역에 일괄 편입됩니다.
+
+                    name은 같은 층 안에서 유일해야 하며 이미 존재하면 오류가 발생합니다.
+                    cellIds에 존재하지 않는 셀 id가 섞여 있거나, 다른 층의 셀 id가 섞여 있으면
+                    요청 전체가 거부됩니다(부분 성공 없음). 이미 다른 구역에 속한 셀을 다시
+                    지정하면 소속 구역이 이 구역으로 덮어써집니다.
+                    """
+    )
     @PostMapping
     public ApiResponse<UserZoneResponse> createUserZone(
             @PathVariable UUID floorId,
@@ -30,6 +44,16 @@ public class UserZoneController {
         return ApiResponse.success(userZoneService.create(floorId, request));
     }
     
+    @Operation(
+            summary = "사용자 구역 삭제",
+            description = """
+                    사용자 구역을 삭제합니다. 삭제해도 구역에 편입되어 있던 그리드 셀 자체는
+                    지워지지 않고 구역 미지정(userZone=null) 상태로 남습니다(SET NULL).
+
+                    userZoneId가 존재하지 않거나, 존재하더라도 요청한 floorId가 속한 층의
+                    구역이 아니면 찾을 수 없음 오류가 발생합니다.
+                    """
+    )
     @DeleteMapping("/{userZoneId}")
     public ResponseEntity<Void> deleteUserZone(
             @PathVariable UUID floorId,
@@ -39,6 +63,16 @@ public class UserZoneController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(
+            summary = "층 사용자 구역 목록 조회",
+            description = """
+                    지정한 층에 등록된 모든 사용자 구역의 id/이름 목록을 반환합니다. 개별 구역에
+                    속한 셀 목록은 포함하지 않으며, 필요하면 구역 단건 조회 API를 따로 호출해야
+                    합니다.
+
+                    아직 구역이 하나도 등록되지 않은 층이면 userzones가 빈 배열로 반환됩니다.
+                    """
+    )
     @GetMapping
     public ApiResponse<AllUserZoneResponse> findAllUserZone(
             @PathVariable UUID floorId
@@ -46,6 +80,17 @@ public class UserZoneController {
         return ApiResponse.success(userZoneService.findAll(floorId));
     }
 
+    @Operation(
+            summary = "사용자 구역 단건 조회",
+            description = """
+                    사용자 구역 하나의 정보와, 그 구역에 편입된 그리드 셀 전체 목록을 함께
+                    반환합니다. 도면 위에 구역 범위를 하이라이트해서 보여줄 때 사용합니다.
+
+                    userZoneId가 존재하지 않거나, 존재하더라도 요청한 floorId가 속한 층의
+                    구역이 아니면 찾을 수 없음 오류가 발생합니다. 구역에 편입된 셀이 없으면
+                    cells가 빈 배열로 반환됩니다.
+                    """
+    )
     @GetMapping("/{userZoneId}")
     public ApiResponse<UserZoneCellsResponse> findUserZone(
             @PathVariable UUID floorId,

--- a/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
+++ b/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
@@ -8,6 +8,7 @@ import com.saferoute.domain.floor.dto.response.FloorResponse;
 import com.saferoute.domain.floor.service.FloorService;
 import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.FloorSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -28,6 +29,21 @@ public class FloorController {
     private final FloorService floorService;
 
     // 건물별 도면 목록 조회
+    @Operation(
+            summary = "건물별 도면 목록 조회",
+            description = """
+                    지정한 건물(buildingId)에 등록된 모든 층(Floor)을 floorNum 오름차순으로
+                    반환합니다. 지하층은 floorNum이 음수이므로 지하층 → 지상층 순으로 정렬됩니다.
+
+                    아직 도면 이미지를 업로드하지 않은 층(mapImageKey가 null, segmentationStatus가
+                    PENDING)도 목록에 함께 포함됩니다. 응답의 mapImageKey는 S3 원본 키일 뿐 바로
+                    렌더링 가능한 URL이 아니므로, 이미지를 화면에 표시하려면 각 층에 대해
+                    도면 이미지 조회용 Presigned URL 발급 API를 별도로 호출해야 합니다.
+
+                    buildingId가 존재하지 않거나 요청자와 다른 학교 소속 건물이면 404가
+                    반환됩니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<ApiResponse<List<FloorResponse>>> getFloors(
             @PathVariable UUID buildingId,
@@ -37,6 +53,22 @@ public class FloorController {
     }
 
     // 층 등록
+    @Operation(
+            summary = "층 등록 (도면 이미지 없이)",
+            description = """
+                    도면 이미지 없이 층 번호(floorNum)만으로 층을 먼저 등록합니다. 생성된 층은
+                    mapImageKey가 null이고 segmentationStatus는 PENDING 상태이며, 실제 도면
+                    이미지는 이후 도면 등록(업로드) API로 같은 floorNum에 대해 별도로 올려야 합니다.
+
+                    같은 건물 안에서 floorNum은 중복될 수 없습니다(uk_floor_building_floornum).
+                    이미 존재하는 floorNum으로 요청하면 실패합니다.
+
+                    floorNum이 음수이면 지하층, 0 이상이면 지상층으로 취급되며, 등록에 성공하면
+                    건물(Building)의 groundFloorCount/basementFloorCount/totalFloors가 자동으로
+                    1씩 증가합니다. 이 값들은 클라이언트가 직접 수정할 수 없고 오직 층 등록/삭제로만
+                    변경됩니다.
+                    """
+    )
     @PostMapping
     public ResponseEntity<ApiResponse<FloorResponse>> createFloor(
             @PathVariable UUID buildingId,
@@ -50,6 +82,22 @@ public class FloorController {
     }
 
     // 도면 등록
+    @Operation(
+            summary = "도면 이미지 업로드",
+            description = """
+                    이미 등록되어 있는 층에 도면 이미지 파일과 실제 크기(realWidth, realHeight,
+                    미터 단위)를 업로드합니다. 대상 층은 floorId가 아니라 floorNum으로 지정하며,
+                    해당 buildingId 안에 그 floorNum을 가진 층이 없으면 실패하므로 반드시 층 등록
+                    API로 층을 먼저 만든 뒤 호출해야 합니다.
+
+                    업로드에 성공하면 mapImageKey/realWidth/realHeight가 채워지고
+                    segmentationStatus가 DONE으로 바뀝니다. 이미 이미지가 있는 층에 다시
+                    호출하면 기존 값을 덮어쓰며, 이전 S3 객체는 별도로 삭제되지 않습니다.
+
+                    realWidth/realHeight는 도면 픽셀 좌표를 실제 거리로 환산하는 데 쓰이므로
+                    반드시 양수여야 합니다.
+                    """
+    )
     @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<FloorResponse>> uploadFloor(
         @PathVariable UUID buildingId,
@@ -63,6 +111,17 @@ public class FloorController {
     }
 
     // 도면 상세 조회
+    @Operation(
+            summary = "도면(층) 상세 조회",
+            description = """
+                    buildingId에 속한 특정 floorId의 층 정보를 단건 조회합니다. 층이 없거나
+                    지정한 buildingId 소속이 아니면(다른 건물/다른 학교) 404가 반환됩니다.
+
+                    응답의 mapImageKey는 S3 원본 키이며 바로 렌더링 가능한 URL이 아닙니다.
+                    이미지를 화면에 표시하려면 도면 이미지 조회용 Presigned URL 발급 API를
+                    추가로 호출해야 합니다.
+                    """
+    )
     @GetMapping("/{floorId}")
     public ResponseEntity<ApiResponse<FloorResponse>> getFloor(
             @PathVariable UUID buildingId,
@@ -74,6 +133,21 @@ public class FloorController {
     }
 
     // 도면 이미지 조회용 Presigned GET URL 발급
+    @Operation(
+            summary = "도면 이미지 조회용 Presigned URL 발급",
+            description = """
+                    해당 층의 도면 이미지를 화면에 렌더링할 수 있도록 만료 시간이 있는 S3
+                    presigned GET URL(imageUrl)과 만료 시각(expiresAt)을 발급합니다.
+
+                    아직 도면 이미지를 업로드하지 않은 층(mapImageKey가 null)에 대해 호출하면
+                    404가 반환되므로, 프론트는 층 조회 응답의 mapImageKey가 null이 아닐 때만
+                    이 API를 호출해야 합니다.
+
+                    imageUrl은 영구 URL이 아니라 expiresAt 시점에 만료되므로, 화면에 값을 오래
+                    캐싱하지 말고 만료 시점이 가까워지면 이 API를 다시 호출해 새 URL을 받아야
+                    합니다.
+                    """
+    )
     @GetMapping("/{floorId}/image-url")
     public ResponseEntity<ApiResponse<FloorImageUrlResponse>> getFloorImageUrl(
             @PathVariable UUID buildingId,
@@ -85,6 +159,21 @@ public class FloorController {
     }
 
     // 층 정보 수정
+    @Operation(
+            summary = "층 번호 수정",
+            description = """
+                    지정한 floorId의 floorNum만 수정합니다. 도면 이미지·실제 크기 등은 이 API로
+                    변경할 수 없으며, 이미지를 새로 반영하려면 도면 등록(업로드) API를 다시
+                    호출해야 합니다.
+
+                    새 floorNum이 기존 값과 다르면 같은 건물 안에서 중복 여부를 다시 검사하며,
+                    이미 다른 층이 그 floorNum을 쓰고 있으면 실패합니다. 검사를 통과하면
+                    건물(Building)의 groundFloorCount/basementFloorCount/totalFloors가
+                    기존 floorNum 기준으로 1 감소, 새 floorNum 기준으로 1 증가하도록 재계산됩니다.
+                    즉 지상층(0 이상)과 지하층(음수) 사이를 오가도록 floorNum을 바꾸면 지상/지하
+                    층수 구성이 함께 바뀝니다.
+                    """
+    )
     @PatchMapping("/{floorId}")
     public ResponseEntity<ApiResponse<FloorResponse>> updateFloor(
             @PathVariable UUID buildingId,
@@ -98,6 +187,20 @@ public class FloorController {
     }
 
     // 도면 삭제
+    @Operation(
+            summary = "도면(층) 삭제",
+            description = """
+                    해당 층(Floor row) 자체를 완전히 삭제합니다. 이미지만 지우고 층은 남기는
+                    도면 초기화 API와 달리, 이 API를 호출하면 층이 목록에서 완전히 사라집니다.
+
+                    DB의 ON DELETE CASCADE 설정으로 인해 이 층에 속한 대피 경로 그래프의
+                    노드(MapNode)와 엣지(MapEdge)도 함께 삭제됩니다. 되돌릴 수 없는 작업이므로
+                    프론트에서는 삭제 전 사용자 확인을 받는 것을 권장합니다.
+
+                    삭제에 성공하면 건물(Building)의 groundFloorCount/basementFloorCount/
+                    totalFloors가 해당 층의 floorNum 기준으로 1씩 감소합니다.
+                    """
+    )
     @DeleteMapping("/{floorId}")
     public ResponseEntity<ApiResponse<Void>> deleteFloor(
             @PathVariable UUID buildingId,
@@ -109,6 +212,23 @@ public class FloorController {
     }
 
     // 도면 초기화 (이미지·노드·엣지만 삭제, 층은 유지)
+    @Operation(
+            summary = "도면 초기화 (이미지만 삭제, 층은 유지)",
+            description = """
+                    층(Floor) row 자체는 삭제하지 않고, 도면 이미지(mapImageKey)·실제 크기
+                    (realWidth/realHeight)·그리드 정보·처리 시각(processedAt)만 초기화하고
+                    segmentationStatus를 PENDING으로 되돌립니다. floorNum과 floorId는 그대로
+                    유지되므로 층 목록에서는 사라지지 않습니다.
+
+                    이 층에 속한 대피 경로 그래프의 노드(MapNode)와 엣지(MapEdge)도 함께
+                    삭제되어 도면과 관련된 경로 데이터가 모두 초기화됩니다.
+
+                    segmentationStatus가 PROCESSING(AI 세그멘테이션 진행 중)인 층에는 호출할 수
+                    없으며 409로 실패하므로, 프론트는 분석이 끝난 뒤 다시 시도해야 합니다.
+                    초기화 후 같은 floorNum으로 도면 등록(업로드) API를 다시 호출해 새 이미지를
+                    올릴 수 있습니다.
+                    """
+    )
     @DeleteMapping("/{floorId}/map")
     public ResponseEntity<ApiResponse<FloorResponse>> clearFloorMap(
             @PathVariable UUID buildingId,

--- a/src/main/java/com/saferoute/domain/report/controller/ReportController.java
+++ b/src/main/java/com/saferoute/domain/report/controller/ReportController.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.report.controller;
 
 import com.saferoute.domain.report.dto.ReportResponse;
 import com.saferoute.domain.report.service.TrainingReportService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ContentDisposition;
@@ -23,6 +24,23 @@ public class ReportController {
   private final TrainingReportService trainingReportService;
 
   // reportId는 TrainingReport.shortId (URL 노출용 짧은 id)
+  @Operation(
+      summary = "훈련 리포트 단건 조회",
+      description = """
+          리포트 생성 시점에 계산·저장된 훈련 리포트 상세를 조회합니다. 등급, 종합 점수와
+          함께 대피시간/생존률/병목/경로준수율 4개 항목의 개별 값·점수, 서술형 요약, 개선
+          권고 목록, 그리고 누적 대피 인원 추이·구역별 밀집도·최근 대피 시간 차트 데이터를
+          함께 반환합니다.
+
+          reportId는 리포트의 UUID가 아니라 URL 노출용으로 별도 발급되는 10자리 shortId입니다.
+
+          riskIndex와 pdfUrl은 아직 계산·생성 로직이 없어 항상 null로 반환되므로, 프론트엔드는
+          해당 필드가 채워지지 않은 것을 정상 상태로 처리해야 합니다.
+
+          요청자가 속한 학교의 리포트만 조회할 수 있으며, 다른 학교 소속이거나 존재하지 않는
+          reportId는 404로 처리됩니다.
+          """
+  )
   @GetMapping("/{reportId}")
   public ResponseEntity<ReportResponse> getReport(
       @PathVariable String reportId,
@@ -30,6 +48,21 @@ public class ReportController {
     return ResponseEntity.ok(trainingReportService.getReport(reportId, authentication.getName()));
   }
 
+  @Operation(
+      summary = "훈련 리포트 PDF 다운로드",
+      description = """
+          지정한 훈련 리포트를 PDF 파일로 변환해 반환합니다. 리포트는 생성된 이후 값이
+          바뀌지 않으므로 PDF를 S3 등에 미리 저장해두지 않고, 매 요청마다 DB에 저장된 리포트
+          값으로 그 자리에서 새로 생성합니다.
+
+          응답은 Content-Type: application/pdf이며, Content-Disposition 헤더로
+          "report-{reportId}.pdf" 파일명이 함께 내려가므로 프론트엔드는 별도 파일명 지정 없이
+          그대로 다운로드에 사용할 수 있습니다.
+
+          요청자가 속한 학교의 리포트만 다운로드할 수 있으며, 다른 학교 소속이거나 존재하지
+          않는 reportId는 404로 처리됩니다.
+          """
+  )
   @GetMapping("/{reportId}/pdf")
   public ResponseEntity<byte[]> downloadReportPdf(
       @PathVariable String reportId,

--- a/src/main/java/com/saferoute/domain/report/controller/TrainingReportController.java
+++ b/src/main/java/com/saferoute/domain/report/controller/TrainingReportController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.report.controller;
 import com.saferoute.domain.report.dto.GenerateReportRequest;
 import com.saferoute.domain.report.dto.ReportResponse;
 import com.saferoute.domain.report.service.TrainingReportService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -24,6 +25,25 @@ public class TrainingReportController {
   private final TrainingReportService trainingReportService;
 
   // 훈련 종료 후 관리자가 참여/생존 인원을 입력하면, 나머지 평가 항목은 BE가 직접 계산해 리포트를 생성한다.
+  @Operation(
+      summary = "훈련 세션 리포트 생성",
+      description = """
+          종료된 훈련 세션에 대해 관리자가 참여 인원(participantCount)과 생존 인원
+          (survivorCount)만 입력하면, 나머지 평가 항목(대피시간/병목/경로준수율)은 세션 동안
+          이미 수집된 데이터로 서버가 직접 계산해 리포트를 생성합니다.
+
+          대피시간은 세션의 시작~종료 시각 차이(개인별이 아닌 세션 전체 소요 시간)를 시나리오의
+          목표 대피시간과 비교해 점수화하고, 병목 횟수는 세션 기간 동안 감지된 혼잡 이벤트 수,
+          경로준수율은 유도등 안내 방향과 실제 이동 방향이 어긋난 관측 구간의 비율로 계산됩니다.
+          최종 종합 점수는 대피시간 35% · 생존률 30% · 병목 20% · 경로준수율 15% 가중합이며,
+          이 점수로 등급(Grade)이 정해집니다. 응답에 포함된 reportId(shortId)로 리포트 단건
+          조회/PDF 다운로드 API를 호출할 수 있습니다.
+
+          세션이 아직 종료되지 않았거나(endedAt이 null), 이미 해당 세션에 대한 리포트가
+          생성되어 있거나, survivorCount가 participantCount보다 크면 오류가 발생하며 리포트는
+          세션당 한 번만 생성할 수 있습니다.
+          """
+  )
   @PostMapping("/{sessionId}")
   public ResponseEntity<ReportResponse> generateReport(
       @PathVariable UUID sessionId,

--- a/src/main/java/com/saferoute/domain/training/controller/FireZoneController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/FireZoneController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.training.controller;
 import com.saferoute.domain.training.dto.CreateFireZoneRequest;
 import com.saferoute.domain.training.dto.FireZoneResponse;
 import com.saferoute.domain.training.service.FireZoneService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -24,6 +25,26 @@ public class FireZoneController {
 
     private final FireZoneService fireZoneService;
 
+    @Operation(
+            summary = "발화점 지정",
+            description = """
+                    지정한 격자 셀(gridCellId)을 해당 시나리오의 최초 발화점으로 등록합니다.
+                    등록과 동시에 그 셀은 FloorGridCell.isFired = true로 표시되며, 생성되는
+                    FireZone은 isManualAdd = true, spreadGeneration = 0으로 저장됩니다.
+
+                    이 API는 시나리오 설정(READY) 단계에서 관리자가 화면에서 발화점을 클릭해
+                    지정할 때 사용합니다. 이후 훈련이 시작되면 화재 확산 시뮬레이션이 이 발화점을
+                    시작 세대(generation 0)로 삼아 BFS 방식으로 인접 셀에 옮겨붙으며,
+                    isManualAdd = false인 FireZone들을 spreadGeneration을 늘려가며 추가로
+                    생성합니다.
+
+                    gridCellId로 지정한 셀이 속한 층의 건물이 시나리오의 건물과 다르면 요청이
+                    거부됩니다. 같은 시나리오에 여러 번 호출해 발화점을 추가로 지정할 수 있습니다.
+
+                    훈련 세션이 종료(정상 종료/강제 종료/타임아웃)되면 이 시나리오의 화재 셀은
+                    일괄적으로 isFired = false로 초기화됩니다.
+                    """
+    )
     @PostMapping
     public ResponseEntity<FireZoneResponse> designateOrigin(
             @PathVariable UUID scenarioId,

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
@@ -4,6 +4,7 @@ import com.saferoute.domain.training.dto.CreateScenarioRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
 import com.saferoute.domain.training.service.TrainingScenarioService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -30,12 +31,39 @@ public class TrainingScenarioController {
     private final TrainingScenarioService scenarioService;
 
     // GET /api/v1/scenarios
+    @Operation(
+            summary = "훈련 시나리오 목록 조회",
+            description = """
+                    요청자 학교 소속의 모든 훈련 시나리오를 생성일 최신순으로 반환합니다.
+
+                    각 시나리오의 deletable은 해당 시나리오에 연결된 훈련 세션이 하나도 없을 때만
+                    true입니다. 세션이 하나라도 있으면 과거 훈련 기록 보존을 위해 삭제가
+                    막히므로, 프론트는 deletable = false인 시나리오에서는 삭제 버튼을 비활성화해야
+                    합니다. reportId는 해당 시나리오의 훈련 리포트가 이미 생성되어 있으면 그
+                    id를, 아직 없으면 null을 반환합니다.
+
+                    status 필드는 연결된 세션의 생명주기에 따라 서버가 자동으로 갱신하는 값으로,
+                    이 API로 직접 변경할 수 없습니다.
+                    """
+    )
     @GetMapping
     public ResponseEntity<List<ScenarioResponse>> getScenarios(Authentication authentication) {
         return ResponseEntity.ok(scenarioService.getScenarios(authentication.getName()));
     }
 
     // GET /api/v1/scenarios/{scenarioId}
+    @Operation(
+            summary = "훈련 시나리오 단건 조회",
+            description = """
+                    요청자 학교 소속 시나리오 중 scenarioId에 해당하는 시나리오 상세 정보를
+                    반환합니다.
+
+                    목록 조회와 달리 deletable, reportId 필드는 항상 null로 반환되므로 이 값은
+                    목록 조회(GET /api/v1/scenarios) 결과를 사용해야 합니다.
+
+                    다른 학교 소속이거나 존재하지 않는 scenarioId를 요청하면 조회에 실패합니다.
+                    """
+    )
     @GetMapping("/{scenarioId}")
     public ResponseEntity<ScenarioResponse> getScenario(
             @PathVariable UUID scenarioId,
@@ -44,6 +72,25 @@ public class TrainingScenarioController {
     }
 
     // POST /api/v1/scenarios
+    @Operation(
+            summary = "훈련 시나리오 생성",
+            description = """
+                    새 훈련 시나리오를 생성합니다. buildingId, adminId는 모두 요청자와 같은
+                    학교 소속이어야 하며, startNodeId는 buildingId로 지정한 건물에 속한
+                    MapNode여야 합니다. 셋 중 하나라도 조건을 만족하지 못하면 생성에 실패합니다.
+
+                    fireSpreadSpeed를 지정하지 않으면 MEDIUM으로 기본 처리됩니다. 이 값은
+                    시나리오 전체에 하나로 적용되며(발화점별 개별 지정 불가), 훈련 시작 후 화재
+                    확산 시뮬레이션의 tick 간격을 결정합니다(FAST가 가장 빠르게 확산).
+
+                    startNodeId는 훈련 시작(POST /api/v1/sessions/{sessionId}/start) 시
+                    최초 대피 경로를 계산하는 출발 노드로 사용되며, 이 필드가 비어 있으면 훈련을
+                    시작할 수 없습니다.
+
+                    생성 직후 시나리오는 바로 실행 가능한 READY 상태로 시작합니다. 초안(DRAFT)
+                    저장 플로우는 아직 지원하지 않습니다.
+                    """
+    )
     @PostMapping
     public ResponseEntity<ScenarioResponse> createScenario(
             @Valid @RequestBody CreateScenarioRequest request,
@@ -53,6 +100,22 @@ public class TrainingScenarioController {
     }
 
     // PATCH /api/v1/scenarios/{scenarioId}
+    @Operation(
+            summary = "훈련 시나리오 수정",
+            description = """
+                    요청 바디에 값이 채워진 필드만 부분 수정합니다. null인 필드는 기존 값을
+                    그대로 유지하므로, 값을 지우고 싶다고 해서 null을 보내면 변경되지 않습니다.
+
+                    startNodeId를 지정하면 해당 노드가 시나리오가 속한 건물 소속인지 다시
+                    검증하며, 다른 건물의 노드면 수정이 거부됩니다. buildingId, adminId,
+                    status는 이 API로 변경할 수 없습니다.
+
+                    시나리오의 status(READY/IN_PROGRESS/COMPLETED/ERROR)는 연결된 훈련
+                    세션의 생명주기에 따라 서버가 자동으로 전이시키는 값이라 이 API로는 건드릴
+                    수 없습니다. 이미 훈련 세션이 시작된 시나리오를 수정할 때의 부작용(예: 진행
+                    중인 세션과의 정합성) 검증은 이 API에 포함되어 있지 않습니다.
+                    """
+    )
     @PatchMapping("/{scenarioId}")
     public ResponseEntity<ScenarioResponse> updateScenario(
             @PathVariable UUID scenarioId,
@@ -62,6 +125,16 @@ public class TrainingScenarioController {
     }
 
     // DELETE /api/v1/scenarios/{scenarioId}
+    @Operation(
+            summary = "훈련 시나리오 삭제",
+            description = """
+                    시나리오를 삭제합니다. 연결된 훈련 세션이 단 하나라도 존재하면(과거에 종료된
+                    세션 포함) 과거 훈련 기록 보존을 위해 삭제가 거부되므로, 프론트는 목록
+                    조회 응답의 deletable 필드로 삭제 가능 여부를 먼저 확인해야 합니다.
+
+                    성공 시 본문 없이 204 No Content를 반환합니다.
+                    """
+    )
     @DeleteMapping("/{scenarioId}")
     public ResponseEntity<Void> deleteScenario(
             @PathVariable UUID scenarioId,

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -133,6 +133,21 @@ public class TrainingSessionController {
     return ResponseEntity.ok(ApiResponse.success(TrainingSuccessCode.TRAINING_SESSION_LIST_FOUND, response));
   }
 
+  @Operation(
+      summary = "훈련 세션 생성",
+      description = """
+          scenarioId 시나리오에 대한 훈련 세션을 생성합니다. 시나리오당 세션은 1개만 존재할
+          수 있어, 이미 해당 시나리오에 세션이 있으면(과거에 종료된 세션 포함) 생성이 거부됩니다.
+          재훈련이 필요하면 세션이 아니라 시나리오를 새로 만들어야 합니다.
+
+          adminId는 요청자와 같은 학교 소속이면서 MANAGER 권한을 가진 사용자여야 합니다.
+
+          status를 RUNNING으로 생성하려면 startedAt을 함께 지정해야 합니다. status를
+          SCHEDULED로 생성하는 경우가 일반적인 흐름이며, 이때는 실제 시작 시각이 아직 없으므로
+          이후 시작 API(POST /api/v1/sessions/{sessionId}/start) 호출 시 서버가 시작
+          시각을 다시 기록합니다.
+          """
+  )
   @PostMapping("/{scenarioId}")
   public ResponseEntity<TrainingSessionResponse> createTrainingSession(
       @RequestBody CreateSessionRequest request,
@@ -141,6 +156,21 @@ public class TrainingSessionController {
     return ResponseEntity.ok(trainingSessionService.create(request, scenarioId, authentication.getName()));
   }
 
+  @Operation(
+      summary = "훈련 세션 시작",
+      description = """
+          SCHEDULED 상태의 세션을 RUNNING으로 전이시키고, 시작 시각을 현재 시각으로
+          기록합니다. RUNNING이 아닌 다른 상태(SCHEDULED가 아닌 세션)에는 호출할 수 없습니다.
+
+          시작 전에 시나리오의 startNodeId를 기준으로 최초 대피 경로를 계산하며, 시나리오에
+          startNodeId가 설정되어 있지 않거나 경로를 찾을 수 없으면 세션 상태를 바꾸지 않고
+          요청이 실패합니다. 계산에 성공하면 시나리오 status도 IN_PROGRESS로 함께 전이되고,
+          계산된 경로를 따라 건물의 유도등에 대피 방향 안내 명령이 내려갑니다.
+
+          성공 시 웹소켓으로 훈련 상태 변경 이벤트가 발행되므로, 모니터링 화면은 이 이벤트로도
+          상태 갱신을 감지할 수 있습니다.
+          """
+  )
   @PostMapping("/{sessionId}/start")
   public ResponseEntity<ApiResponse<TrainingSessionResponse>> startTrainingSession(
       @PathVariable("sessionId") UUID sessionId,
@@ -149,6 +179,20 @@ public class TrainingSessionController {
     return ResponseEntity.ok(ApiResponse.success(TrainingSuccessCode.TRAINING_STARTED, response));
   }
 
+  @Operation(
+      summary = "훈련 세션 정상 종료",
+      description = """
+          RUNNING 상태의 세션을 COMPLETED로 전이시키고 종료 시각을 현재 시각으로 기록합니다.
+          RUNNING이 아닌 세션에는 호출할 수 없습니다.
+
+          종료 처리와 함께 시나리오 status는 COMPLETED로 전이되고, 이 시나리오의 화재 셀은
+          모두 꺼진 상태로 초기화되며, 이 세션에 대해 대기 중이던 경로 재탐색 요청은 모두
+          무효화되고, 건물의 유도등은 평상시 상태로 복구됩니다.
+
+          정상 종료 여부는 관리자가 직접 끝내는 강제 종료(force-end)와 구분됩니다. 정상
+          종료는 시나리오를 COMPLETED로, 강제 종료는 ERROR로 남긴다는 점이 다릅니다.
+          """
+  )
   @PostMapping("/{sessionId}/end")
   public ResponseEntity<ApiResponse<TrainingSessionResponse>> endTrainingSession(
       @PathVariable("sessionId") UUID sessionId,
@@ -157,6 +201,18 @@ public class TrainingSessionController {
     return ResponseEntity.ok(ApiResponse.success(TrainingSuccessCode.TRAINING_ENDED, response));
   }
 
+  @Operation(
+      summary = "훈련 세션 강제 종료",
+      description = """
+          관리자가 훈련을 중간에 강제로 중단할 때 사용합니다. RUNNING 상태의 세션을
+          STOPPED로 전이시키고 종료 시각을 현재 시각으로 기록합니다. RUNNING이 아닌 세션에는
+          호출할 수 없습니다.
+
+          정상 종료(end)와 동일하게 시나리오의 화재 셀 초기화, 대기 중인 경로 재탐색 요청
+          무효화, 유도등 평상시 복구가 함께 일어나지만, 시나리오 status는 COMPLETED가 아니라
+          ERROR로 표시되어 정상 종료와 구분됩니다.
+          """
+  )
   @PostMapping("/{sessionId}/force-end")
   public ResponseEntity<ApiResponse<TrainingSessionResponse>> forceEndTrainingSession(
       @PathVariable("sessionId") UUID sessionId,

--- a/src/main/java/com/saferoute/domain/user/controller/UserController.java
+++ b/src/main/java/com/saferoute/domain/user/controller/UserController.java
@@ -14,6 +14,7 @@ import com.saferoute.global.api.response.UserSuccessCode;
 import com.saferoute.global.security.AccessTokenRevocationService;
 import com.saferoute.global.security.JwtTokenProvider;
 import com.saferoute.global.security.RefreshTokenService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,24 @@ public class UserController {
     private final JwtTokenProvider jwtTokenProvider;
 
     // 회원가입
+    @Operation(
+            summary = "회원가입",
+            description = """
+                    새 계정을 생성하고 생성된 사용자 정보를 201 Created로 반환합니다.
+                    비밀번호는 해시되어 저장되며 응답에는 포함되지 않습니다.
+
+                    인증 없이 호출할 수 있는 공개 API입니다.
+
+                    role을 생략하면 기본값 NORMAL로 가입되며, MANAGER로 가입하려면
+                    role 필드에 "MANAGER"를 명시해야 합니다. email과 username은 각각
+                    전체 사용자 중 유일해야 하고, 이미 사용 중이면 각각
+                    DUPLICATE_EMAIL / DUPLICATE_USERNAME 오류가 발생합니다.
+
+                    schoolName은 5~20자 필수값이며, 가입 이후에는 다른 학교 이름으로
+                    변경할 수 없습니다(내 프로필 수정 API 설명 참고). phoneNumber는
+                    선택값이며 숫자와 '-'만 허용됩니다.
+                    """
+    )
     @PostMapping("/auth/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
         SignupResponse response = userService.signup(request);
@@ -49,12 +68,38 @@ public class UserController {
     }
 
     // 로그인: JWT 없이 자격 증명만 확인 후 사용자 정보를 반환
+    @Operation(
+            summary = "로그인",
+            description = """
+                    email/password로 자격 증명을 확인한 뒤 사용자 프로필 정보와 함께
+                    access token, refresh token을 발급합니다.
+
+                    인증 없이 호출할 수 있는 공개 API입니다. 존재하지 않는 이메일과
+                    비밀번호 불일치는 구분되지 않고 동일하게 INVALID_CREDENTIAL 오류로
+                    응답해, 어떤 이메일이 가입되어 있는지 노출하지 않습니다.
+
+                    accessToken은 tokenType="Bearer"와 함께 반환되며 expiresIn(초) 이후
+                    만료됩니다. 이후 요청은 Authorization: Bearer {accessToken} 헤더로
+                    인증합니다. refreshToken은 accessToken 만료 시 /api/v1/auth/reissue로
+                    재발급받는 데 사용하므로 클라이언트가 안전하게 보관해야 합니다.
+                    """
+    )
     @PostMapping("/auth/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = userService.login(request);
         return ResponseEntity.ok(ApiResponse.success(UserSuccessCode.LOGIN_COMPLETED, response));
     }
 
+    @Operation(
+            summary = "내 프로필 조회",
+            description = """
+                    Authorization 헤더의 access token으로 식별한 현재 로그인 사용자의
+                    프로필 정보를 반환합니다.
+
+                    MANAGER, NORMAL 권한을 가진 로그인 사용자만 호출할 수 있습니다.
+                    비밀번호 등 민감 정보는 응답에 포함되지 않습니다.
+                    """
+    )
     @GetMapping("/users/me")
     public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile(
             Authentication authentication
@@ -63,6 +108,23 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(UserSuccessCode.PROFILE_RETRIEVED, response));
     }
 
+    @Operation(
+            summary = "내 프로필 수정",
+            description = """
+                    현재 로그인 사용자의 프로필을 부분 수정합니다. 요청 바디에서 값이
+                    채워진 필드만 변경되고, null인 필드는 기존 값이 유지됩니다.
+
+                    username, email은 다른 사용자와 중복될 수 없으며, 중복 시 각각
+                    DUPLICATE_USERNAME / DUPLICATE_EMAIL 오류가 발생합니다.
+
+                    schoolName은 현재 소속 학교와 동일한 값을 다시 보내는 경우에만
+                    허용됩니다. 다른 값으로 바꾸려고 하면 403 FORBIDDEN이 발생하므로,
+                    이 API로는 소속 학교를 변경할 수 없습니다. 비밀번호는 이 API의
+                    요청 필드에 없어 변경할 수 없습니다.
+
+                    성공 시 수정이 반영된 최신 프로필 전체를 반환합니다.
+                    """
+    )
     @PatchMapping("/users/me")
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateMyProfile(
             Authentication authentication,
@@ -73,6 +135,22 @@ public class UserController {
     }
 
     // 토큰 재발급: refresh token을 검증하고 새 access/refresh token을 발급한다.
+    @Operation(
+            summary = "토큰 재발급",
+            description = """
+                    refreshToken을 검증하고 새 access token, refresh token 쌍을
+                    발급합니다.
+
+                    refresh token은 재발급마다 회전(rotate)됩니다. 요청에 사용한
+                    refreshToken은 성공 즉시 서버에서 소비되어 다시 사용할 수 없으므로,
+                    응답으로 받은 새 refreshToken으로 반드시 교체해서 저장해야 합니다.
+                    같은 토큰으로 다시 요청하면 INVALID_REFRESH_TOKEN 오류가 발생합니다.
+
+                    토큰이 만료되었거나 서명이 유효하지 않거나 이미 소비된 경우 모두
+                    동일하게 INVALID_REFRESH_TOKEN으로 응답합니다. Authorization
+                    헤더 없이 호출할 수 있는 공개 API입니다.
+                    """
+    )
     @PostMapping("/auth/reissue")
     public ResponseEntity<ApiResponse<ReissueResponse>> reissue(@Valid @RequestBody ReissueRequest request) {
         RefreshTokenService.ReissuedTokens tokens = refreshTokenService.reissue(request.refreshToken());
@@ -84,6 +162,21 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(UserSuccessCode.REISSUE_COMPLETED, response));
     }
 
+    @Operation(
+            summary = "로그아웃",
+            description = """
+                    Authorization 헤더의 access token을 서버 측 폐기(revocation)
+                    목록에 등록해, 원래 만료 시각까지 더 이상 사용할 수 없게 만듭니다.
+
+                    이미 만료된 access token은 폐기 목록에 추가하지 않고 그대로
+                    성공으로 처리합니다.
+
+                    refreshToken은 이 API로 무효화되지 않으므로, 완전히 로그아웃하려면
+                    클라이언트가 보관 중인 refreshToken도 함께 폐기(삭제)해야 합니다.
+
+                    MANAGER, NORMAL 권한을 가진 로그인 사용자만 호출할 수 있습니다.
+                    """
+    )
     @PostMapping("/auth/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization

--- a/src/main/java/com/saferoute/infrastructure/s3/controller/S3Controller.java
+++ b/src/main/java/com/saferoute/infrastructure/s3/controller/S3Controller.java
@@ -4,6 +4,7 @@ import com.saferoute.global.api.response.ApiResponse;
 import com.saferoute.global.api.response.S3SuccessCode;
 import com.saferoute.infrastructure.s3.dto.S3UploadResponse;
 import com.saferoute.infrastructure.s3.service.S3Service;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,30 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
+    @Operation(
+            summary = "파일 업로드",
+            description = """
+                    multipart/form-data로 전달된 파일을 S3의 "floor-plans/" 경로 하위에
+                    원본 그대로 업로드하고, 저장된 bucket, key, S3 URI 등을 반환합니다.
+
+                    이 API는 파일을 영구 저장하는 업로드 전용 API이며 presigned URL을
+                    발급하지 않습니다. 응답의 s3Uri("s3://...")는 브라우저에서 직접 접근할
+                    수 없으므로, 업로드한 이미지를 화면에 표시하려면 key를 이용해 별도의
+                    조회(presigned GET URL 발급) API를 호출해야 합니다.
+
+                    key는 원본 파일명에서 경로를 제거하고 영숫자 및 일부 특수문자 외의
+                    문자를 '_'로 치환한 뒤 "floor-plans/{UUID}-파일명" 형태로 생성되므로,
+                    같은 파일명을 여러 번 업로드해도 서로 다른 key가 생성되어 기존 파일을
+                    덮어쓰지 않습니다.
+
+                    빈 파일을 업로드하면 400 EMPTY_FILE 오류가 발생합니다. 파일 크기나
+                    확장자 제한은 서버에서 별도로 검사하지 않으므로, 필요한 제약은
+                    프론트에서 업로드 전에 확인해야 합니다. content-type을 지정하지
+                    않으면 application/octet-stream으로 저장됩니다.
+
+                    로그인 사용자 중 MANAGER 권한을 가진 사용자만 호출할 수 있습니다.
+                    """
+    )
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<S3UploadResponse>> upload(
             @RequestPart("file") MultipartFile file


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #161
- Branch: feature/161-swagger-api-docs

## 주요 내용

- 전체 컨트롤러(26개 파일, 약 90개 엔드포인트)에 Swagger `@Operation` summary/description 추가
- 단순 API 스펙 설명을 넘어, 코드만 봐서는 알기 어려운 도메인 규칙과 프론트가 알아야 할 사항 위주로 작성
  - 상태 전이/사이드 이펙트 (예: 유도등 명령 큐 PENDING→SENT→ACK/TIMEOUT 흐름, 훈련 세션 상태)
  - 파라미터가 결과에 미치는 영향
  - 아직 미구현/미지원인 부분, presigned URL 만료 등 클라이언트가 유의할 점
- 도메인 단위로 커밋 분리 (device / evacuation / congestion / floor·building / report·dashboard / training / user·s3)
- 컨트롤러/`@ApiResponses`/로직 코드는 변경하지 않음 (Swagger 어노테이션만 추가)

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?