### PR TITLE
fix(floor): 도면 재업로드 시 기존 노드/엣지 cascade 삭제

### DIFF
--- a/src/main/java/com/saferoute/domain/floor/service/FloorService.java
+++ b/src/main/java/com/saferoute/domain/floor/service/FloorService.java
@@ -75,6 +75,10 @@ public class FloorService {
                 new ApiException(FloorErrorCode.FLOOR_NOT_FOUND)
             );
 
+        // 재업로드는 기존 도면에 딸린 그래프를 무효화한다 (프론트 재업로드 확인 문구와 동일한 동작 보장)
+        mapEdgeRepository.deleteAllByFloor(floor);
+        mapNodeRepository.deleteAllByFloor(floor);
+
         S3UploadResponse uploadResult =
             s3Service.upload(request.file());
 

--- a/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
+++ b/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
@@ -13,6 +13,7 @@ import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.floor.dto.request.UploadFloorRequest;
 import com.saferoute.domain.floor.dto.response.FloorImageUrlResponse;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.entity.SegmentationStatus;
@@ -23,11 +24,13 @@ import com.saferoute.global.api.error.BuildingErrorCode;
 import com.saferoute.global.api.error.FloorErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
+import com.saferoute.infrastructure.s3.dto.S3UploadResponse;
 import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
 import com.saferoute.infrastructure.s3.service.S3Service;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.mock.web.MockMultipartFile;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -194,5 +197,31 @@ class FloorServiceTest {
 
         then(mapEdgeRepository).should(never()).deleteAllByFloor(floor);
         then(mapNodeRepository).should(never()).deleteAllByFloor(floor);
+    }
+
+    @Test
+    void cascadesExistingGraphDeletionOnReupload() {
+        UUID buildingId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        Floor floor = Floor.create(building, 1);
+        UploadFloorRequest request = new UploadFloorRequest(
+                1, 4.0, 3.0,
+                new MockMultipartFile("file", "plan.png", "image/png", new byte[]{1, 2, 3}));
+
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(buildingRepository.findByIdAndSchoolName(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(building));
+        given(building.getId()).willReturn(buildingId);
+        given(floorRepository.findByBuilding_IdAndFloorNum(buildingId, 1))
+                .willReturn(Optional.of(floor));
+        given(s3Service.upload(request.file()))
+                .willReturn(new S3UploadResponse("bucket", "floors/new-plan.png", "s3://bucket/floors/new-plan.png",
+                        3L, "image/png"));
+
+        floorService.uploadFloor(buildingId, request, EMAIL);
+
+        then(mapEdgeRepository).should().deleteAllByFloor(floor);
+        then(mapNodeRepository).should().deleteAllByFloor(floor);
+        assertThat(floor.getMapImageKey()).isEqualTo("floors/new-plan.png");
     }
 }


### PR DESCRIPTION

## 관련 이슈 및 작업 브랜치

- Closes #163 
- Branch: fix/#163

## 주요 내용

- uploadFloor()가 이미지만 교체하고 기존 노드/엣지를 지우지 않는 버그 수정
- clearFloorMap()과 동일하게 MapEdgeJpaRepository/MapNodeJpaRepository의 deleteAllByFloor()를 재사용해 엣지 먼저, 노드 나중 순으로 cascade 삭제하도록 수정

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?