### PR TITLE
[feat] #165: CCTV 혼잡도 연동용 훈련 상태 흐름 및 비활성 응답 개선

### DIFF
--- a/src/main/java/com/saferoute/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/saferoute/domain/building/repository/BuildingRepository.java
@@ -1,14 +1,23 @@
 package com.saferoute.domain.building.repository;
 
 import com.saferoute.domain.building.entity.Building;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BuildingRepository
         extends JpaRepository<Building, UUID> {
     List<Building> findAllBySchoolNameOrderByCreatedAtDesc(String schoolName);
 
     Optional<Building> findByIdAndSchoolName(UUID id, String schoolName);
+
+    // 같은 건물의 서로 다른 세션이 동시에 시작되는 경쟁을 건물 행 하나로 직렬화한다.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select b from Building b where b.id = :buildingId")
+    Optional<Building> findByIdForUpdate(@Param("buildingId") UUID buildingId);
 }

--- a/src/main/java/com/saferoute/domain/congestion/dto/response/CongestionConfigQueryResponse.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/response/CongestionConfigQueryResponse.java
@@ -1,7 +1,9 @@
 package com.saferoute.domain.congestion.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.saferoute.domain.congestion.entity.CongestionConfig;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record CongestionConfigQueryResponse(
         boolean trainingActive,
         String trainingSessionId,

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -28,10 +28,12 @@ public interface TrainingSessionRepository extends JpaRepository<TrainingSession
       UUID id, TrainingStatus status, UUID buildingId);
 
   // Pi의 설정 조회 요청엔 세션 id가 없어 건물만으로 현재 RUNNING 세션을 찾는다.
-  // 건물당 동시 RUNNING 세션은 1개라고 가정하되(TrainingSession에 세션-층 직접 연결이 없어 건물 단위로 조회),
-  // 이 가정이 DB 제약으로 강제되진 않으므로 예외적으로 여러 개가 있어도 결과가 흔들리지 않도록 시작 시각 기준으로 정렬한다.
+  // 건물당 동시 RUNNING 세션은 TrainingSessionService가 건물 행 잠금 후 강제한다.
+  // 레거시/직접 SQL로 중복 데이터가 생겨도 결과가 흔들리지 않도록 시작 시각 기준으로 정렬한다.
   Optional<TrainingSession> findFirstByStatusAndScenario_Building_IdOrderByStartedAtAsc(
       TrainingStatus status, UUID buildingId);
+
+  boolean existsByStatusAndScenario_Building_Id(TrainingStatus status, UUID buildingId);
 
   Optional<TrainingSession> findByIdAndScenario_Building_SchoolName(UUID id, String schoolName);
 

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.training.service;
 
 import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.service.EvacuationRoute;
@@ -56,7 +57,9 @@ public class TrainingSessionService {
   private final IoTLightService ioTLightService;
   private final TrainingEventPublisher trainingEventPublisher;
   private final SchoolContextService schoolContextService;
+  private final BuildingRepository buildingRepository;
 
+  @Transactional
   public TrainingSessionResponse create(CreateSessionRequest request, UUID scenarioId, String email) {
     String schoolName = schoolContextService.getSchoolName(email);
     User user = userRepository.findByIdAndSchoolName(request.getAdminId(), schoolName)
@@ -73,6 +76,11 @@ public class TrainingSessionService {
 
     if (request.getStatus() == TrainingStatus.RUNNING && request.getStartedAt() == null) {
       throw new ApiException(ErrorCode.INVALID_INPUT);
+    }
+
+    if (request.getStatus() == TrainingStatus.RUNNING
+        && hasRunningSession(scenario.getBuildingId())) {
+      throw new ApiException(TrainingErrorCode.RUNNING_SESSION_ALREADY_EXISTS);
     }
 
     TrainingSession trainingSession = TrainingSession.create(
@@ -139,6 +147,10 @@ public class TrainingSessionService {
 
     if (session.getStatus() != TrainingStatus.SCHEDULED) {
       throw new ApiException(TrainingErrorCode.INVALID_STATUS_TRANSITION);
+    }
+
+    if (hasRunningSession(session.getScenario().getBuildingId())) {
+      throw new ApiException(TrainingErrorCode.RUNNING_SESSION_ALREADY_EXISTS);
     }
 
     // 유도등 반영 전 최초 경로부터 계산해, EXIT 미지정/도달 불가 시 세션 상태를 바꾸지 않고 막는다.
@@ -223,5 +235,12 @@ public class TrainingSessionService {
     String schoolName = schoolContextService.getSchoolName(email);
     return trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, schoolName)
         .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+  }
+
+  private boolean hasRunningSession(UUID buildingId) {
+    // 건물 행 잠금 이후 RUNNING 여부를 검사해야 동시 시작 요청도 하나만 성공한다.
+    buildingRepository.findByIdForUpdate(buildingId);
+    return trainingSessionRepository.existsByStatusAndScenario_Building_Id(
+        TrainingStatus.RUNNING, buildingId);
   }
 }

--- a/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
@@ -18,7 +18,8 @@ public enum TrainingErrorCode implements BaseErrorCode {
     SCENARIO_DELETE_NOT_ALLOWED(HttpStatus.CONFLICT, "TRAINING007", "훈련 세션이 존재하는 시나리오는 삭제할 수 없습니다."),
     SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "TRAINING008", "이미 훈련 세션이 존재하는 시나리오입니다."),
     START_NODE_BUILDING_MISMATCH(HttpStatus.BAD_REQUEST, "TRAINING009", "시작 노드가 해당 시나리오의 건물에 속하지 않습니다."),
-    START_NODE_NOT_CONFIGURED(HttpStatus.CONFLICT, "TRAINING010", "출발 노드가 지정되지 않은 시나리오는 훈련을 시작할 수 없습니다.");
+    START_NODE_NOT_CONFIGURED(HttpStatus.CONFLICT, "TRAINING010", "출발 노드가 지정되지 않은 시나리오는 훈련을 시작할 수 없습니다."),
+    RUNNING_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "TRAINING011", "해당 건물에서 이미 훈련이 진행 중입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionConfigControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionConfigControllerTest.java
@@ -95,6 +95,12 @@ class CongestionConfigControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.trainingActive").value(false))
                 .andExpect(jsonPath("$.trainingSessionId").doesNotExist())
+                .andExpect(jsonPath("$.monitoredAreaM2").doesNotExist())
+                .andExpect(jsonPath("$.snapshotIntervalSec").doesNotExist())
+                .andExpect(jsonPath("$.targetInferenceFps").doesNotExist())
+                .andExpect(jsonPath("$.congestionThresholds").doesNotExist())
+                .andExpect(jsonPath("$.eventDetection").doesNotExist())
+                .andExpect(jsonPath("$.cctvCode").value("CCTV_001"))
                 .andExpect(jsonPath("$.configVersion").value(1));
     }
 }

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
@@ -82,6 +83,9 @@ class TrainingSessionServiceTest {
 
     @Mock
     private SchoolContextService schoolContextService;
+
+    @Mock
+    private BuildingRepository buildingRepository;
 
     private final UUID sessionId = UUID.randomUUID();
     private final UUID buildingId = UUID.randomUUID();
@@ -278,6 +282,29 @@ class TrainingSessionServiceTest {
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
         verify(scenario, times(1)).markInProgress();
         verify(ioTLightService).applyRouteGuidance(List.of(startNodeId, exitNodeId));
+    }
+
+    @Test
+    @DisplayName("같은 건물에 RUNNING 세션이 있으면 SCHEDULED 세션을 시작할 수 없다")
+    void start_buildingAlreadyHasRunningSession_throwsConflict() {
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getBuildingId()).willReturn(buildingId);
+        TrainingSession session =
+                TrainingSession.create(TrainingStatus.SCHEDULED, Instant.now(), mock(User.class), scenario);
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+        given(trainingSessionRepository.existsByStatusAndScenario_Building_Id(
+                TrainingStatus.RUNNING, buildingId)).willReturn(true);
+
+        assertThatThrownBy(() -> trainingSessionService.start(sessionId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.RUNNING_SESSION_ALREADY_EXISTS);
+
+        assertThat(session.getStatus()).isEqualTo(TrainingStatus.SCHEDULED);
+        verify(evacuationRouteService, never()).findShortestRoute(any(), any());
+        verify(trainingEventPublisher, never()).publishTrainingStatusUpdatedAfterCommit(any());
     }
 
     @Test

--- a/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
@@ -231,6 +231,10 @@ class WebSocketIntegrationTest {
     @Test
     @DisplayName("훈련을 시작하면 구독자가 TRAINING_STATUS_UPDATED(RUNNING) 이벤트를 수신한다")
     void startingTrainingPublishesRunningEvent() throws Exception {
+        // 공통 픽스처의 RUNNING 세션을 종료해 건물당 RUNNING 세션 1개 제약을 충족시킨다.
+        trainingSession.stop(Instant.now());
+        trainingSessionRepository.saveAndFlush(trainingSession);
+
         TrainingScenario scenario = newScenario();
         TrainingSession scheduledSession = TrainingSession.create(
                 TrainingStatus.SCHEDULED, Instant.now(), managerUser, scenario);


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #165 
- Branch: feat/#165

## 주요 내용

- 혼잡도 설정 비활성 응답에서 값이 `null`인 필드를 JSON에서 제외했습니다.
  - `CongestionConfigQueryResponse`에 `@JsonInclude(JsonInclude.Include.NON_NULL)` 적용
  - Pi에서 숫자 필드를 처리할 때 발생하던 `float(None)` 오류 방지
- 동일 건물에서 RUNNING 훈련 세션이 중복으로 생성되지 않도록 제한했습니다.
  - 세션 생성 및 시작 시 동일 건물의 RUNNING 세션 존재 여부 확인
  - 중복 실행 시 `TRAINING011`과 `409 Conflict` 반환
- 동시 시작 요청에서도 건물당 하나의 RUNNING 세션만 허용되도록 건물 행에 비관적 쓰기 잠금을 적용했습니다.
- inactive 응답의 null 필드 제외 여부와 동일 건물 중복 시작 차단 테스트를 추가했습니다.

### inactive 응답

```json
{
  "trainingActive": false,
  "cctvCode": "CCTV_001",
  "configVersion": 1
}
```

active 응답은 기존과 동일하게 다음 설정을 모두 반환합니다.
- trainingSessionId
- monitoredAreaM2
- snapshotIntervalSec
- targetInferenceFps
- congestionThresholds
- eventDetection

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 요약

* **새 기능**
  * 동일한 건물에서 여러 훈련이 동시에 진행되지 않도록 제어합니다.
  * 이미 진행 중인 훈련이 있는 경우 충돌 오류와 안내 메시지를 제공합니다.

* **개선**
  * 훈련이 비활성화된 경우 불필요한 설정 항목을 응답에서 제외해 더 간결한 정보를 제공합니다.
  * 비활성 상태에서도 CCTV 식별 정보와 훈련 상태 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->