### PR TITLE
grid 조회 response 수정 및 firezone 조회 api 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/grid/dto/response/FloorGridCellPageResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/dto/response/FloorGridCellPageResponse.java
@@ -1,5 +1,6 @@
 package com.saferoute.domain.evacuation.grid.dto.response;
 
+import com.saferoute.domain.floor.entity.Floor;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
@@ -10,9 +11,14 @@ public record FloorGridCellPageResponse(
         long totalElements,
         int totalPages,
         boolean first,
-        boolean last
+        boolean last,
+        Double realWidth,
+        Double realHeight,
+        Integer rows,
+        Integer columns,
+        Double cellSizeMeter
 ) {
-    public static FloorGridCellPageResponse from(Page<FloorGridCellResponse> result) {
+    public static FloorGridCellPageResponse from(Page<FloorGridCellResponse> result, Floor floor) {
         return new FloorGridCellPageResponse(
                 result.getContent(),
                 result.getNumber(),
@@ -20,7 +26,12 @@ public record FloorGridCellPageResponse(
                 result.getTotalElements(),
                 result.getTotalPages(),
                 result.isFirst(),
-                result.isLast()
+                result.isLast(),
+                floor.getRealWidth(),
+                floor.getRealHeight(),
+                floor.getGridRows(),
+                floor.getGridColumns(),
+                floor.getGridCellSizeMeter()
         );
     }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
@@ -49,9 +49,8 @@ public class FloorGridService {
     private final SchoolContextService schoolContextService;
 
     public FloorGridCellPageResponse getGridCells(UUID floorId, int page, int size) {
-        if (!floorRepository.existsById(floorId)) {
-            throw new ApiException(FloorErrorCode.FLOOR_NOT_FOUND);
-        }
+        Floor floor = floorRepository.findById(floorId)
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
         PageRequest pageable = PageRequest.of(
                 page,
                 size,
@@ -59,7 +58,8 @@ public class FloorGridService {
         );
         return FloorGridCellPageResponse.from(
                 floorGridCellRepository.findAllByFloor_Id(floorId, pageable)
-                        .map(FloorGridCellResponse::from)
+                        .map(FloorGridCellResponse::from),
+                floor
         );
     }
 

--- a/src/main/java/com/saferoute/domain/training/controller/FireZoneController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/FireZoneController.java
@@ -6,11 +6,13 @@ import com.saferoute.domain.training.service.FireZoneService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -52,5 +54,27 @@ public class FireZoneController {
             Authentication authentication) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(fireZoneService.designateOrigin(scenarioId, request, authentication.getName()));
+    }
+
+    @Operation(
+            summary = "화재구역 전체 조회",
+            description = """
+                    해당 시나리오에 등록된 FireZone 전체를 반환합니다. 관리자가 수동 지정한
+                    최초 발화점(isManualAdd = true, spreadGeneration = 0)과, 훈련 시작 후 화재
+                    확산 시뮬레이션이 BFS로 옮겨붙인 셀(isManualAdd = false)이 모두 포함됩니다.
+
+                    spreadGeneration 오름차순, 같은 세대 안에서는 addedAt 오름차순으로
+                    정렬되므로 그대로 화면에 그리면 시간순 확산 순서가 됩니다.
+
+                    아직 발화점을 하나도 지정하지 않았다면 빈 배열을 반환합니다. 훈련 세션이
+                    종료되면 화재 셀은 초기화되지만 FireZone 레코드 자체는 삭제되지 않으므로,
+                    지난 훈련의 확산 기록 조회에도 사용할 수 있습니다.
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<List<FireZoneResponse>> getFireZones(
+            @PathVariable UUID scenarioId,
+            Authentication authentication) {
+        return ResponseEntity.ok(fireZoneService.getFireZones(scenarioId, authentication.getName()));
     }
 }

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
@@ -1,8 +1,10 @@
 package com.saferoute.domain.training.controller;
 
 import com.saferoute.domain.training.dto.CreateScenarioRequest;
+import com.saferoute.domain.training.dto.FireZoneResponse;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
+import com.saferoute.domain.training.service.FireZoneService;
 import com.saferoute.domain.training.service.TrainingScenarioService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TrainingScenarioController {
 
     private final TrainingScenarioService scenarioService;
+    private final FireZoneService fireZoneService;
 
     // GET /api/v1/scenarios
     @Operation(
@@ -141,5 +144,25 @@ public class TrainingScenarioController {
             Authentication authentication) {
         scenarioService.deleteScenario(scenarioId, authentication.getName());
         return ResponseEntity.noContent().build();
+    }
+
+    // GET /api/v1/scenarios/{scenarioId}/fire-origin
+    @Operation(
+            summary = "최초 발화점 목록 조회",
+            description = """
+                    관리자가 POST /api/v1/scenarios/{scenarioId}/fire-zones로 수동 지정한
+                    최초 발화점(FireZone.isManualAdd = true) 목록을 반환합니다.
+
+                    화재 확산 시뮬레이션이 생성한 FireZone(isManualAdd = false)은 포함되지
+                    않으며, 아직 발화점을 하나도 지정하지 않았다면 빈 배열을 반환합니다.
+
+                    다른 학교 소속이거나 존재하지 않는 scenarioId를 요청하면 조회에 실패합니다.
+                    """
+    )
+    @GetMapping("/{scenarioId}/fire-origin")
+    public ResponseEntity<List<FireZoneResponse>> getFireOrigin(
+            @PathVariable UUID scenarioId,
+            Authentication authentication) {
+        return ResponseEntity.ok(fireZoneService.getFireOrigins(scenarioId, authentication.getName()));
     }
 }

--- a/src/main/java/com/saferoute/domain/training/repository/FireZoneRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/FireZoneRepository.java
@@ -18,6 +18,9 @@ public interface FireZoneRepository extends JpaRepository<FireZone, UUID> {
     // 관리자가 수동 지정한 최초 발화점만 조회 (확산 시뮬레이션이 생성한 FireZone은 제외)
     List<FireZone> findByScenario_IdAndIsManualAddTrue(UUID scenarioId);
 
+    // 시나리오의 전체 FireZone(수동 발화점 + 확산으로 옮겨붙은 셀) 조회 - 세대 오름차순, 같은 세대는 등록 시각 오름차순
+    List<FireZone> findByScenario_IdOrderBySpreadGenerationAscAddedAtAsc(UUID scenarioId);
+
     // 세션 종료 시 해당 시나리오의 화재 셀들 isFired = false로 일괄 초기화
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/saferoute/domain/training/repository/FireZoneRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/FireZoneRepository.java
@@ -15,6 +15,9 @@ public interface FireZoneRepository extends JpaRepository<FireZone, UUID> {
     // 현재 세대(frontier)에 속한 FireZone 조회 - 다음 확산의 시작점.
     List<FireZone> findByScenario_IdAndSpreadGeneration(UUID scenarioId, int spreadGeneration);
 
+    // 관리자가 수동 지정한 최초 발화점만 조회 (확산 시뮬레이션이 생성한 FireZone은 제외)
+    List<FireZone> findByScenario_IdAndIsManualAddTrue(UUID scenarioId);
+
     // 세션 종료 시 해당 시나리오의 화재 셀들 isFired = false로 일괄 초기화
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/saferoute/domain/training/service/FireZoneService.java
+++ b/src/main/java/com/saferoute/domain/training/service/FireZoneService.java
@@ -12,6 +12,7 @@ import com.saferoute.domain.user.service.SchoolContextService;
 import com.saferoute.global.api.error.GridErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,5 +46,18 @@ public class FireZoneService {
         fireZoneRepository.save(origin);
 
         return FireZoneResponse.from(origin);
+    }
+
+    // 관리자가 수동 지정한 최초 발화점 목록 조회 (확산 시뮬레이션으로 생성된 FireZone은 제외)
+    @Transactional(readOnly = true)
+    public List<FireZoneResponse> getFireOrigins(UUID scenarioId, String email) {
+        String schoolName = schoolContextService.getSchoolName(email);
+        if (scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, schoolName).isEmpty()) {
+            throw new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND);
+        }
+
+        return fireZoneRepository.findByScenario_IdAndIsManualAddTrue(scenarioId).stream()
+                .map(FireZoneResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/saferoute/domain/training/service/FireZoneService.java
+++ b/src/main/java/com/saferoute/domain/training/service/FireZoneService.java
@@ -51,13 +51,25 @@ public class FireZoneService {
     // 관리자가 수동 지정한 최초 발화점 목록 조회 (확산 시뮬레이션으로 생성된 FireZone은 제외)
     @Transactional(readOnly = true)
     public List<FireZoneResponse> getFireOrigins(UUID scenarioId, String email) {
+        validateScenarioForSchool(scenarioId, email);
+        return fireZoneRepository.findByScenario_IdAndIsManualAddTrue(scenarioId).stream()
+                .map(FireZoneResponse::from)
+                .toList();
+    }
+
+    // 시나리오의 전체 FireZone(수동 발화점 + 확산으로 옮겨붙은 셀) 조회 - 세대 오름차순 정렬
+    @Transactional(readOnly = true)
+    public List<FireZoneResponse> getFireZones(UUID scenarioId, String email) {
+        validateScenarioForSchool(scenarioId, email);
+        return fireZoneRepository.findByScenario_IdOrderBySpreadGenerationAscAddedAtAsc(scenarioId).stream()
+                .map(FireZoneResponse::from)
+                .toList();
+    }
+
+    private void validateScenarioForSchool(UUID scenarioId, String email) {
         String schoolName = schoolContextService.getSchoolName(email);
         if (scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, schoolName).isEmpty()) {
             throw new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND);
         }
-
-        return fireZoneRepository.findByScenario_IdAndIsManualAddTrue(scenarioId).stream()
-                .map(FireZoneResponse::from)
-                .toList();
     }
 }

--- a/src/test/java/com/saferoute/domain/evacuation/grid/controller/FloorGridControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/grid/controller/FloorGridControllerTest.java
@@ -46,7 +46,8 @@ class FloorGridControllerTest {
                 UUID.randomUUID(), 0, 0, true, false, 0.1, 0.1);
         given(floorGridService.getGridCells(floorId, 0, 500, EMAIL))
                 .willReturn(new FloorGridCellPageResponse(
-                        List.of(cell), 0, 500, 1, 1, true, true));
+                        List.of(cell), 0, 500, 1, 1, true, true,
+                        10.0, 8.0, 1, 1, 0.5));
 
         mockMvc.perform(get("/api/v1/floors/{floorId}/grid/cells", floorId)
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #168 
- Branch:

## 주요 내용

-

## ✅ Check List

- [ ] 테스트 통과
- [ ] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 시나리오별 전체 화재 구역을 조회할 수 있습니다.
  * 관리자가 수동 지정한 최초 발화점 목록을 별도로 조회할 수 있습니다.
  * 층별 격자 조회 결과에 실제 층 크기, 행·열 수, 셀 크기 정보가 포함됩니다.
* **개선**
  * 화재 구역 목록이 확산 단계와 등록 순서에 따라 정렬되어 제공됩니다.
  * 격자 조회 시 층 정보를 함께 확인하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->