### PR TITLE
feat(recalculation): 재탐색 API 수정

### DIFF
--- a/docs/fixtures/route-recalculations/detail.json
+++ b/docs/fixtures/route-recalculations/detail.json
@@ -1,0 +1,40 @@
+{
+  "isSuccess": true,
+  "code": "COMMON_SUCCESS_001",
+  "message": "요청에 성공했습니다.",
+  "result": {
+    "recalculationId": "5f3c1a2e-2b7a-4c9e-9d3e-8a1b2c3d4e5f",
+    "trainingSessionId": "3a2b1c0d-9e8f-4a5b-8c7d-6e5f4a3b2c1d",
+    "floorId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+    "floorNum": 1,
+    "locationName": "1층",
+    "cctvCode": "CCTV_001",
+    "triggerEdgeId": "9f8e7d6c-5b4a-3928-1706-f5e4d3c2b1a0",
+    "triggerType": "STARTED",
+    "congestionLevel": "VERY_CROWDED",
+    "density": 5.2,
+    "densityUnit": "PERSON_PER_SQUARE_METER",
+    "previousRoute": {
+      "nodeIds": [
+        "aaaaaaaa-1111-2222-3333-444444444444",
+        "bbbbbbbb-1111-2222-3333-444444444444",
+        "cccccccc-1111-2222-3333-444444444444"
+      ],
+      "totalWeight": 12.5
+    },
+    "candidateRoute": {
+      "nodeIds": [
+        "aaaaaaaa-1111-2222-3333-444444444444",
+        "dddddddd-1111-2222-3333-444444444444",
+        "cccccccc-1111-2222-3333-444444444444"
+      ],
+      "totalWeight": 18.3
+    },
+    "status": "PENDING",
+    "requestedAt": "2026-09-01T09:12:34.567Z",
+    "resolvedAt": null,
+    "resolvedBy": null,
+    "rejectReason": null,
+    "cancelReason": null
+  }
+}

--- a/docs/fixtures/route-recalculations/list-empty.json
+++ b/docs/fixtures/route-recalculations/list-empty.json
@@ -1,0 +1,6 @@
+{
+  "isSuccess": true,
+  "code": "COMMON_SUCCESS_001",
+  "message": "요청에 성공했습니다.",
+  "result": []
+}

--- a/docs/fixtures/route-recalculations/list-pending.json
+++ b/docs/fixtures/route-recalculations/list-pending.json
@@ -1,0 +1,22 @@
+{
+  "isSuccess": true,
+  "code": "COMMON_SUCCESS_001",
+  "message": "요청에 성공했습니다.",
+  "result": [
+    {
+      "recalculationId": "5f3c1a2e-2b7a-4c9e-9d3e-8a1b2c3d4e5f",
+      "trainingSessionId": "3a2b1c0d-9e8f-4a5b-8c7d-6e5f4a3b2c1d",
+      "floorId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+      "floorNum": 1,
+      "locationName": "1층",
+      "cctvCode": "CCTV_001",
+      "triggerEdgeId": "9f8e7d6c-5b4a-3928-1706-f5e4d3c2b1a0",
+      "triggerType": "STARTED",
+      "congestionLevel": "VERY_CROWDED",
+      "density": 5.2,
+      "densityUnit": "PERSON_PER_SQUARE_METER",
+      "status": "PENDING",
+      "requestedAt": "2026-09-01T09:12:34.567Z"
+    }
+  ]
+}

--- a/src/main/java/com/saferoute/domain/congestion/entity/DensityUnit.java
+++ b/src/main/java/com/saferoute/domain/congestion/entity/DensityUnit.java
@@ -1,0 +1,5 @@
+package com.saferoute.domain.congestion.entity;
+
+public enum DensityUnit {
+    PERSON_PER_SQUARE_METER
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationDetailResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationDetailResponse.java
@@ -1,9 +1,11 @@
 package com.saferoute.domain.evacuation.recalculation.dto.response;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.congestion.entity.DensityUnit;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import com.saferoute.domain.floor.entity.Floor;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -12,11 +14,15 @@ import java.util.UUID;
 public record RouteRecalculationDetailResponse(
         UUID recalculationId,
         UUID trainingSessionId,
+        UUID floorId,
+        Integer floorNum,
+        String locationName,
         String cctvCode,
         UUID triggerEdgeId,
         RecalculationTriggerType triggerType,
         CongestionLevel congestionLevel,
         double density,
+        DensityUnit densityUnit,
         RouteSegment previousRoute,
         RouteSegment candidateRoute,
         RecalculationStatus status,
@@ -31,14 +37,19 @@ public record RouteRecalculationDetailResponse(
     }
 
     public static RouteRecalculationDetailResponse from(RouteRecalculation recalculation) {
+        Floor floor = recalculation.getTriggerEdge().getFloor();
         return new RouteRecalculationDetailResponse(
                 recalculation.getId(),
                 recalculation.getTrainingSession().getId(),
+                floor.getId(),
+                floor.getFloorNum(),
+                floor.getFloorNum() + "층",
                 recalculation.getCctvCode(),
                 recalculation.getTriggerEdge().getId(),
                 recalculation.getTriggerType(),
                 recalculation.getCongestionLevel(),
                 recalculation.getDensity(),
+                DensityUnit.PERSON_PER_SQUARE_METER,
                 // @ElementCollection(LAZY) - 트랜잭션이 살아있는 지금 List.copyOf로 즉시 초기화한다
                 // (open-in-view: false 환경에서 직렬화 시점의 LazyInitializationException 방지, RouteRecalculationResponse 참고).
                 new RouteSegment(List.copyOf(recalculation.getPreviousNodeIds()), recalculation.getPreviousTotalWeight()),

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationSummaryResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/RouteRecalculationSummaryResponse.java
@@ -1,9 +1,11 @@
 package com.saferoute.domain.evacuation.recalculation.dto.response;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.congestion.entity.DensityUnit;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
+import com.saferoute.domain.floor.entity.Floor;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -11,24 +13,33 @@ import java.util.UUID;
 public record RouteRecalculationSummaryResponse(
         UUID recalculationId,
         UUID trainingSessionId,
+        UUID floorId,
+        Integer floorNum,
+        String locationName,
         String cctvCode,
         UUID triggerEdgeId,
         RecalculationTriggerType triggerType,
         CongestionLevel congestionLevel,
         double density,
+        DensityUnit densityUnit,
         RecalculationStatus status,
         Instant requestedAt
 ) {
 
     public static RouteRecalculationSummaryResponse from(RouteRecalculation recalculation) {
+        Floor floor = recalculation.getTriggerEdge().getFloor();
         return new RouteRecalculationSummaryResponse(
                 recalculation.getId(),
                 recalculation.getTrainingSession().getId(),
+                floor.getId(),
+                floor.getFloorNum(),
+                floor.getFloorNum() + "층",
                 recalculation.getCctvCode(),
                 recalculation.getTriggerEdge().getId(),
                 recalculation.getTriggerType(),
                 recalculation.getCongestionLevel(),
                 recalculation.getDensity(),
+                DensityUnit.PERSON_PER_SQUARE_METER,
                 recalculation.getStatus(),
                 recalculation.getRequestedAt()
         );

--- a/src/test/java/com/saferoute/domain/evacuation/controller/RouteRecalculationControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/controller/RouteRecalculationControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.congestion.entity.DensityUnit;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationDetailResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationSummaryResponse;
@@ -71,14 +72,16 @@ class RouteRecalculationControllerTest {
 
     private RouteRecalculationSummaryResponse summary(RecalculationStatus status) {
         return new RouteRecalculationSummaryResponse(
-                recalculationId, sessionId, "CCTV_001", UUID.randomUUID(),
-                RecalculationTriggerType.STARTED, CongestionLevel.CROWDED, 3.5, status, Instant.now());
+                recalculationId, sessionId, UUID.randomUUID(), 1, "1층", "CCTV_001", UUID.randomUUID(),
+                RecalculationTriggerType.STARTED, CongestionLevel.CROWDED, 3.5,
+                DensityUnit.PERSON_PER_SQUARE_METER, status, Instant.now());
     }
 
     private RouteRecalculationDetailResponse detail(RecalculationStatus status) {
         return new RouteRecalculationDetailResponse(
-                recalculationId, sessionId, "CCTV_001", UUID.randomUUID(),
+                recalculationId, sessionId, UUID.randomUUID(), 1, "1층", "CCTV_001", UUID.randomUUID(),
                 RecalculationTriggerType.STARTED, CongestionLevel.CROWDED, 3.5,
+                DensityUnit.PERSON_PER_SQUARE_METER,
                 new RouteRecalculationDetailResponse.RouteSegment(List.of(UUID.randomUUID()), 15.0),
                 new RouteRecalculationDetailResponse.RouteSegment(List.of(UUID.randomUUID()), 22.0),
                 status, Instant.now(), null, null, null, null);


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #170 
- Branch: feature/170-recalculation-response-fields

## 주요 내용

- 목록·상세 응답에 트리거 엣지가 속한 층 정보(floorId, floorNum, locationName)와 density 단위(densityUnit)를 추가하고, 프론트 목킹용 fixture JSON을 제공한다.
  - DensityUnit.java : PERSON_PER_SQUARE_METER 값의 신규 enum
  - RouteRecalculationSummaryResponse.java, RouteRecalculationDetailResponse.java : floorId, floorNum, locationName({floorNum}층"), densityUnit 필드 추가, triggerEdge.getFloor()로 매핑
  - RouteRecalculationControllerTest.java : record 생성자 시그니처 변경에 맞춰 테스트 헬퍼 수정
  - docs/fixtures/route-recalculations/{list-pending,list-empty,detail}.json : FE MSW 목킹용 fixture 3종 (ApiResponse 봉투 포함 실제 응답 구조 그대로)

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?