### PR TITLE
feat(evacuation): 훈련 세션 현재 유효 대피 경로 조회 API 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/CurrentRouteResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/dto/response/CurrentRouteResponse.java
@@ -1,0 +1,34 @@
+package com.saferoute.domain.evacuation.recalculation.dto.response;
+
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+// 훈련 세션에 대해 "지금 안내되고 있는" 대피 경로 하나를 도면에 바로 그릴 수 있는 형태로
+// 반환한다. 가장 최근 승인된 재탐색이 있으면 그 경로(source=RECALCULATED), 없으면 시나리오의
+// 대표 startNode 기준 최단 경로(source=INITIAL)다.
+public record CurrentRouteResponse(
+        UUID sessionId,
+        UUID scenarioId,
+        UUID buildingId,
+        UUID floorId,
+        UUID startNodeId,
+        RouteSource source,
+        List<NodePoint> path,
+        double totalWeight,
+        Instant updatedAt
+) {
+
+    public enum RouteSource {
+        INITIAL,
+        RECALCULATED
+    }
+
+    public record NodePoint(UUID nodeId, String name, NodeType type, double x, double y) {
+        public static NodePoint from(MapNode node) {
+            return new NodePoint(node.getId(), node.getName(), node.getType(), node.getX(), node.getY());
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
@@ -19,6 +19,12 @@ public interface RouteRecalculationRepository extends JpaRepository<RouteRecalcu
     Optional<RouteRecalculation> findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
             UUID trainingSessionId, UUID triggerEdgeId, RecalculationStatus status);
 
+    // 세션 전체에서(트리거 엣지 무관) 가장 최근에 승인된 경로 - "지금 안내 중인 경로" 조회(GET
+    // /api/v1/sessions/{sessionId}/current-route)에서 사용. 없으면 호출부가 시나리오의
+    // startNodeId 기준 최단 경로로 대체한다.
+    Optional<RouteRecalculation> findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+            UUID trainingSessionId, RecalculationStatus status);
+
     List<RouteRecalculation> findAllByTrainingSession_IdOrderByRequestedAtDesc(UUID trainingSessionId);
 
     List<RouteRecalculation>

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -3,6 +3,9 @@ package com.saferoute.domain.evacuation.recalculation.service;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.recalculation.dto.response.CurrentRouteResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationDetailResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationSummaryResponse;
@@ -12,6 +15,7 @@ import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
 import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
+import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.entity.User;
@@ -27,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -52,6 +57,7 @@ public class RouteRecalculationService {
     private final TrainingEventPublisher trainingEventPublisher;
     private final SchoolContextService schoolContextService;
     private final TrainingSessionRepository trainingSessionRepository;
+    private final MapNodeJpaRepository mapNodeJpaRepository;
 
     // 혼잡 감지로 트리거되는 우회 경로 재탐색.
     // - 같은 세션+엣지에 이미 PENDING이 있고 레벨이 그대로면 반복 트리거를 무시한다.
@@ -79,9 +85,15 @@ public class RouteRecalculationService {
         }
 
         UUID floorId = triggerEdge.getFloor().getId();
-        // TODO: 양방향 엣지에서는 실제로 반대편(toNode) 기준 우회도 필요할 수 있다 - 지금은
-        // fromNode 기준으로 고정한다
-        UUID startNodeId = triggerEdge.getFromNode().getId();
+        // 현재 유효 경로는 항상 "시나리오 대표 startNode -> EXIT" 완전한 한 경로여야 하므로,
+        // 혼잡 엣지의 fromNode가 아니라 시나리오의 대표 startNode에서 다시 계산한다.
+        MapNode representativeStart = session.getScenario().getStartNode();
+        if (representativeStart == null) {
+            log.warn("시나리오에 대표 startNode가 없어 재탐색 승인 대기 항목을 생성하지 않음: sessionId={}",
+                    session.getId());
+            return;
+        }
+        UUID startNodeId = representativeStart.getId();
 
         RouteSnapshot previous = resolveActiveRoute(session, triggerEdge, floorId, startNodeId);
 
@@ -128,7 +140,13 @@ public class RouteRecalculationService {
         RouteRecalculation activeDetour = latestApproved.get();
 
         UUID floorId = triggerEdge.getFloor().getId();
-        UUID startNodeId = triggerEdge.getFromNode().getId();
+        MapNode representativeStart = session.getScenario().getStartNode();
+        if (representativeStart == null) {
+            log.warn("시나리오에 대표 startNode가 없어 재탐색 승인 대기 항목을 생성하지 않음: sessionId={}",
+                    session.getId());
+            return;
+        }
+        UUID startNodeId = representativeStart.getId();
 
         EvacuationRoute recovery;
         try {
@@ -225,6 +243,72 @@ public class RouteRecalculationService {
     @Transactional(readOnly = true)
     public RouteRecalculationDetailResponse getRecalculationDetail(UUID recalculationId, String email) {
         return RouteRecalculationDetailResponse.from(findOrThrow(recalculationId, email));
+    }
+
+    // "지금 안내되고 있는 경로"를 세션 단위로 한 번에, 도면에 바로 그릴 수 있는 노드 상세
+    // 목록으로 반환한다. resolveActiveRoute()와 동일한 우선순위(가장 최근 승인된 재탐색 >
+    // 시나리오 대표 startNode 기준 최단 경로)를 쓰지만, 특정 triggerEdge에 종속되지 않고
+    // 세션 전체에서 가장 최근 승인 건을 찾는다는 점이 다르다.
+    // 세션 상태(RUNNING 여부)는 검증하지 않는다 - SCHEDULED 세션은 아직 재탐색이 없으므로
+    // 자연히 최단 경로로, COMPLETED/ERROR 세션은 종료 시점까지의 마지막 승인 경로로 응답된다.
+    @Transactional(readOnly = true)
+    public CurrentRouteResponse getCurrentRoute(UUID sessionId, String email) {
+        String schoolName = schoolContextService.getSchoolName(email);
+        TrainingSession session = trainingSessionRepository
+                .findByIdAndScenario_Building_SchoolName(sessionId, schoolName)
+                .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+        TrainingScenario scenario = session.getScenario();
+
+        Optional<RouteRecalculation> latestApproved = routeRecalculationRepository
+                .findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(sessionId, RecalculationStatus.APPROVED);
+        if (latestApproved.isPresent()) {
+            RouteRecalculation approved = latestApproved.get();
+            List<CurrentRouteResponse.NodePoint> path = toNodePoints(approved.getRecalculatedNodeIds());
+            UUID startNodeId = path.isEmpty() ? null : path.get(0).nodeId();
+            return new CurrentRouteResponse(
+                    sessionId,
+                    scenario.getId(),
+                    scenario.getBuildingId(),
+                    approved.getTriggerEdge().getFloor().getId(),
+                    startNodeId,
+                    CurrentRouteResponse.RouteSource.RECALCULATED,
+                    path,
+                    approved.getTotalWeight(),
+                    approved.getResolvedAt());
+        }
+
+        MapNode representativeStart = scenario.getStartNode();
+        if (representativeStart == null) {
+            throw new ApiException(TrainingErrorCode.START_NODE_NOT_CONFIGURED);
+        }
+        UUID floorId = representativeStart.getFloor().getId();
+        EvacuationRoute directRoute =
+                evacuationRouteService.findShortestRoute(floorId, representativeStart.getId());
+        List<CurrentRouteResponse.NodePoint> path = directRoute.path().stream()
+                .map(CurrentRouteResponse.NodePoint::from)
+                .toList();
+        return new CurrentRouteResponse(
+                sessionId,
+                scenario.getId(),
+                scenario.getBuildingId(),
+                floorId,
+                representativeStart.getId(),
+                CurrentRouteResponse.RouteSource.INITIAL,
+                path,
+                directRoute.totalWeight(),
+                session.getStartedAt());
+    }
+
+    // RouteRecalculation은 노드 id만 저장하므로(@ElementCollection), 도면에 그릴 이름/타입/좌표를
+    // 채우려면 MapNode를 다시 조회해야 한다. findAllById는 순서를 보장하지 않으므로 원래
+    // 저장된 순서(출발 -> 도착)대로 재정렬한다.
+    private List<CurrentRouteResponse.NodePoint> toNodePoints(List<UUID> nodeIds) {
+        Map<UUID, MapNode> nodesById = mapNodeJpaRepository.findAllById(nodeIds).stream()
+                .collect(Collectors.toMap(MapNode::getId, node -> node));
+        return nodeIds.stream()
+                .map(nodesById::get)
+                .map(CurrentRouteResponse.NodePoint::from)
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -1,5 +1,6 @@
 package com.saferoute.domain.training.controller;
 
+import com.saferoute.domain.evacuation.recalculation.dto.response.CurrentRouteResponse;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
 import com.saferoute.domain.training.dto.TrainingSessionListApiResponse;
 import com.saferoute.domain.training.dto.TrainingSessionListResponse;
@@ -219,5 +220,28 @@ public class TrainingSessionController {
       Authentication authentication) {
     TrainingSessionResponse response = trainingSessionService.forceEnd(sessionId, authentication.getName());
     return ResponseEntity.ok(ApiResponse.success(TrainingSuccessCode.TRAINING_FORCE_ENDED, response));
+  }
+
+  @Operation(
+      summary = "훈련 세션의 현재 유효 대피 경로 조회",
+      description = """
+          이 세션에 대해 "지금 안내되고 있는" 대피 경로 하나를 노드 목록과 총 가중치로
+          반환합니다. 가장 최근 승인된 경로 재탐색이 있으면 그 경로(fromApprovedRecalculation
+          =true)를, 없으면 시나리오의 startNodeId를 기준으로 새로 계산한 최단 경로
+          (fromApprovedRecalculation=false)를 반환합니다.
+
+          세션 상태(RUNNING 여부)는 검증하지 않습니다. 아직 시작 전(SCHEDULED)인 세션은
+          승인된 재탐색이 있을 수 없으므로 자연히 최단 경로가 반환되고, 이미 종료된
+          (COMPLETED/ERROR) 세션은 종료 시점까지의 마지막 승인 경로가 그대로 반환됩니다.
+
+          시나리오에 startNodeId가 설정되어 있지 않으면 실패합니다.
+          """
+  )
+  @GetMapping("/{sessionId}/current-route")
+  public ResponseEntity<ApiResponse<CurrentRouteResponse>> getCurrentRoute(
+      @PathVariable("sessionId") UUID sessionId,
+      Authentication authentication) {
+    CurrentRouteResponse response = trainingSessionService.getCurrentRoute(sessionId, authentication.getName());
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.training.service;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.recalculation.dto.response.CurrentRouteResponse;
 import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
@@ -217,6 +218,14 @@ public class TrainingSessionService {
       trainingEventPublisher.publishTrainingStatusUpdatedAfterCommit(session);
       log.info("훈련 세션 타임아웃 처리: sessionId={}", session.getId());
     }
+  }
+
+  // "지금 안내되고 있는 경로" 조회는 재탐색 승인 이력까지 함께 봐야 해서 실제 로직은
+  // RouteRecalculationService가 갖고 있다 - 이 메서드는 /api/v1/sessions 하위 URL 컨벤션에
+  // 맞추기 위한 위임일 뿐이다.
+  @Transactional(readOnly = true)
+  public CurrentRouteResponse getCurrentRoute(UUID sessionId, String email) {
+    return routeRecalculationService.getCurrentRoute(sessionId, email);
   }
 
   private TrainingSession findSession(UUID sessionId, String email) {

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -15,6 +15,8 @@ import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.recalculation.dto.response.CurrentRouteResponse;
 import com.saferoute.domain.evacuation.recalculation.dto.response.RouteRecalculationResponse;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
@@ -23,6 +25,7 @@ import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculati
 import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.entity.User;
@@ -78,8 +81,13 @@ class RouteRecalculationServiceTest {
     @Mock
     private TrainingSessionRepository trainingSessionRepository;
 
+    @Mock
+    private MapNodeJpaRepository mapNodeJpaRepository;
+
     private TrainingSession session;
+    private TrainingScenario scenario;
     private MapEdge triggerEdge;
+    private MapNode representativeStart;
     private UUID floorId;
     private UUID startNodeId;
 
@@ -94,11 +102,16 @@ class RouteRecalculationServiceTest {
         floorId = UUID.randomUUID();
         org.mockito.Mockito.lenient().when(floor.getId()).thenReturn(floorId);
 
-        MapNode fromNode = MapNode.create(floor, "HALLWAY1", NodeType.HALLWAY, "HALLWAY1", 0, 0, false);
+        // 시나리오의 대표 startNode. 재탐색 계산은 이제 이 노드를 출발점으로 쓴다.
+        representativeStart = MapNode.create(floor, "HALLWAY1", NodeType.HALLWAY, "HALLWAY1", 0, 0, false);
         startNodeId = UUID.randomUUID();
-        ReflectionTestUtils.setField(fromNode, "id", startNodeId);
+        ReflectionTestUtils.setField(representativeStart, "id", startNodeId);
 
-        triggerEdge = MapEdge.create(floor, fromNode, mock(MapNode.class), 5.0, true);
+        scenario = mock(TrainingScenario.class);
+        org.mockito.Mockito.lenient().when(scenario.getStartNode()).thenReturn(representativeStart);
+        org.mockito.Mockito.lenient().when(session.getScenario()).thenReturn(scenario);
+
+        triggerEdge = MapEdge.create(floor, mock(MapNode.class), mock(MapNode.class), 5.0, true);
         ReflectionTestUtils.setField(triggerEdge, "id", UUID.randomUUID());
         ReflectionTestUtils.setField(triggerEdge, "floor", floor);
     }
@@ -430,5 +443,143 @@ class RouteRecalculationServiceTest {
         verify(trainingEventPublisher, never()).publishEvacuationRouteUpdatedAfterCommit(any());
         verify(trainingEventPublisher, times(1)).publishRouteRecalculationRejectedAfterCommit(recalculation);
         verify(ioTLightService, never()).applyRouteGuidance(any());
+    }
+
+    // === getCurrentRoute ===
+
+    @Test
+    @DisplayName("다른 기관의 훈련 세션으로 현재 경로를 조회하면 세션 not-found를 반환한다")
+    void getCurrentRoute_otherSchool_throwsTrainingSessionNotFound() {
+        UUID otherSessionId = UUID.randomUUID();
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(otherSessionId, SCHOOL_NAME))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> routeRecalculationService.getCurrentRoute(otherSessionId, MANAGER_EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("승인된 재탐색이 있으면 그 경로를 노드 상세와 함께 현재 경로로 반환한다")
+    void getCurrentRoute_withApprovedRecalculation_returnsApprovedRoute() {
+        UUID recSessionId = session.getId();
+        UUID scenarioId = UUID.randomUUID();
+        UUID buildingId = UUID.randomUUID();
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(recSessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+        given(scenario.getId()).willReturn(scenarioId);
+        given(scenario.getBuildingId()).willReturn(buildingId);
+
+        MapNode stairNode = mock(MapNode.class);
+        UUID stairNodeId = UUID.randomUUID();
+        given(stairNode.getId()).willReturn(stairNodeId);
+        given(stairNode.getName()).willReturn("서측 계단");
+        given(stairNode.getType()).willReturn(NodeType.STAIR);
+        given(stairNode.getX()).willReturn(0.5);
+        given(stairNode.getY()).willReturn(0.4);
+
+        MapNode exitNode = mock(MapNode.class);
+        UUID exitNodeId = UUID.randomUUID();
+        given(exitNode.getId()).willReturn(exitNodeId);
+        given(exitNode.getName()).willReturn("1층 출입구");
+        given(exitNode.getType()).willReturn(NodeType.EXIT);
+        given(exitNode.getX()).willReturn(0.8);
+        given(exitNode.getY()).willReturn(0.3);
+
+        List<UUID> recalculatedIds = List.of(startNodeId, stairNodeId, exitNodeId);
+        RouteRecalculation approved = approvedRecalculation(recalculatedIds, 18.3);
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                recSessionId, RecalculationStatus.APPROVED))
+                .willReturn(Optional.of(approved));
+        // findAllById가 저장 순서를 보장하지 않는다는 걸 검증하기 위해 일부러 뒤섞어 반환한다.
+        given(mapNodeJpaRepository.findAllById(recalculatedIds))
+                .willReturn(List.of(exitNode, representativeStart, stairNode));
+
+        CurrentRouteResponse response = routeRecalculationService.getCurrentRoute(recSessionId, MANAGER_EMAIL);
+
+        assertThat(response.sessionId()).isEqualTo(recSessionId);
+        assertThat(response.scenarioId()).isEqualTo(scenarioId);
+        assertThat(response.buildingId()).isEqualTo(buildingId);
+        assertThat(response.floorId()).isEqualTo(floorId);
+        assertThat(response.startNodeId()).isEqualTo(startNodeId);
+        assertThat(response.source()).isEqualTo(CurrentRouteResponse.RouteSource.RECALCULATED);
+        assertThat(response.path()).extracting(CurrentRouteResponse.NodePoint::nodeId)
+                .containsExactly(startNodeId, stairNodeId, exitNodeId);
+        assertThat(response.path().get(1).name()).isEqualTo("서측 계단");
+        assertThat(response.path().get(2).type()).isEqualTo(NodeType.EXIT);
+        assertThat(response.totalWeight()).isEqualTo(18.3);
+        assertThat(response.updatedAt()).isEqualTo(approved.getResolvedAt());
+    }
+
+    @Test
+    @DisplayName("승인된 재탐색이 없으면 시나리오의 대표 startNode 기준 최단 경로를 반환한다")
+    void getCurrentRoute_withoutApprovedRecalculation_returnsShortestRoute() {
+        UUID recSessionId = session.getId();
+        UUID scenarioId = UUID.randomUUID();
+        UUID buildingId = UUID.randomUUID();
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(recSessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                recSessionId, RecalculationStatus.APPROVED))
+                .willReturn(Optional.empty());
+        given(scenario.getId()).willReturn(scenarioId);
+        given(scenario.getBuildingId()).willReturn(buildingId);
+
+        MapNode exitNode = mock(MapNode.class);
+        UUID exitNodeId = UUID.randomUUID();
+        given(exitNode.getId()).willReturn(exitNodeId);
+        given(exitNode.getName()).willReturn("1층 출입구");
+        given(exitNode.getType()).willReturn(NodeType.EXIT);
+        given(exitNode.getX()).willReturn(0.8);
+        given(exitNode.getY()).willReturn(0.3);
+
+        Instant startedAt = Instant.now();
+        given(session.getStartedAt()).willReturn(startedAt);
+        given(evacuationRouteService.findShortestRoute(floorId, startNodeId))
+                .willReturn(new EvacuationRoute(List.of(representativeStart, exitNode), 9.5));
+
+        CurrentRouteResponse response = routeRecalculationService.getCurrentRoute(recSessionId, MANAGER_EMAIL);
+
+        assertThat(response.sessionId()).isEqualTo(recSessionId);
+        assertThat(response.scenarioId()).isEqualTo(scenarioId);
+        assertThat(response.buildingId()).isEqualTo(buildingId);
+        assertThat(response.floorId()).isEqualTo(floorId);
+        assertThat(response.startNodeId()).isEqualTo(startNodeId);
+        assertThat(response.source()).isEqualTo(CurrentRouteResponse.RouteSource.INITIAL);
+        assertThat(response.path()).extracting(CurrentRouteResponse.NodePoint::nodeId)
+                .containsExactly(startNodeId, exitNodeId);
+        assertThat(response.totalWeight()).isEqualTo(9.5);
+        assertThat(response.updatedAt()).isEqualTo(startedAt);
+    }
+
+    @Test
+    @DisplayName("승인된 재탐색도 없고 대표 startNode도 없으면 START_NODE_NOT_CONFIGURED를 던진다")
+    void getCurrentRoute_noApprovedAndNoStartNode_throws() {
+        UUID recSessionId = session.getId();
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(recSessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                recSessionId, RecalculationStatus.APPROVED))
+                .willReturn(Optional.empty());
+        given(scenario.getStartNode()).willReturn(null);
+
+        assertThatThrownBy(() -> routeRecalculationService.getCurrentRoute(recSessionId, MANAGER_EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.START_NODE_NOT_CONFIGURED);
+    }
+
+    @Test
+    @DisplayName("시나리오에 대표 startNode가 없으면 재탐색 승인 대기 항목을 만들지 않는다")
+    void trigger_noRepresentativeStartNode_doesNothing() {
+        givenNoExistingPending();
+        given(scenario.getStartNode()).willReturn(null);
+
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+                RecalculationTriggerType.STARTED, "CCTV_001", 3.5);
+
+        verify(routeRecalculationRepository, never()).save(any());
+        verify(evacuationRouteService, never()).findShortestRoute(any(), any(), anySet(), any());
     }
 }

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.device.service.IoTLightService;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.recalculation.dto.response.CurrentRouteResponse;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.evacuation.service.EvacuationRoute;
 import com.saferoute.domain.evacuation.service.EvacuationRouteService;
@@ -471,5 +472,20 @@ class TrainingSessionServiceTest {
         trainingSessionService.failTimedOutSessions();
 
         verify(trainingEventPublisher, never()).publishTrainingStatusUpdatedAfterCommit(any());
+    }
+
+    // === getCurrentRoute ===
+
+    @Test
+    @DisplayName("현재 유효 경로 조회는 RouteRecalculationService에 위임한다")
+    void getCurrentRoute_delegatesToRouteRecalculationService() {
+        CurrentRouteResponse expected = new CurrentRouteResponse(
+                sessionId, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                CurrentRouteResponse.RouteSource.RECALCULATED, List.of(), 10.0, Instant.now());
+        given(routeRecalculationService.getCurrentRoute(sessionId, EMAIL)).willReturn(expected);
+
+        CurrentRouteResponse response = trainingSessionService.getCurrentRoute(sessionId, EMAIL);
+
+        assertThat(response).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #173 
- Branch: feat/#173

## 주요 내용

- GET /api/v1/sessions/{sessionId}/current-route를 신규 추가한다. 세션의 가장 최근 APPROVED 재탐색이 있으면 그 경로를, 없으면 시나리오 대표 startNode 기준 최단 경로를 노드 상세(name/type/x/y)와 함께 반환한다.

- 재탐색 트리거(trigger/triggerRecovery)가 혼잡 엣지의 fromNode가 아니라 시나리오 대표 startNode부터 전체 경로를 다시 계산하도록 함께 수정해, 승인된 우회 경로도 항상 대표 START ~ EXIT의 완결된 한 경로가 되도록 보장한다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?