### PR TITLE
[docs] #172: 시나리오 발화점 Swagger 정책 정리 

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/EvacuationRouteController.java
@@ -39,6 +39,10 @@ public class EvacuationRouteController {
 
                     startNodeId는 대상 층에 실제로 존재하는 노드여야 하며, 해당 층에 EXIT 대상으로
                     지정된 노드가 하나도 없거나 그래프상 도달 가능한 경로가 없으면 오류가 발생합니다.
+
+                    이 API는 도면 관리에서 임의의 노드를 기준으로 경로를 확인할 때 사용합니다.
+                    시나리오·훈련 화면은 startNodeId를 직접 선택하지 않고, 세션의
+                    GET /api/v1/sessions/{sessionId}/current-route 응답을 조회해 표시합니다.
                     """
     )
     @GetMapping("/routes")

--- a/src/main/java/com/saferoute/domain/training/controller/FireZoneController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/FireZoneController.java
@@ -19,7 +19,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "화재구역", description = "훈련 시나리오 발화점 등록·조회 API")
+@Tag(
+        name = "화재구역",
+        description = "도면 관리의 시나리오별 최초 발화점 등록 및 시나리오·훈련 화면의 화재구역 조회 API"
+)
 @RestController
 @RequestMapping("/api/v1/scenarios/{scenarioId}/fire-zones")
 @RequiredArgsConstructor
@@ -28,14 +31,15 @@ public class FireZoneController {
     private final FireZoneService fireZoneService;
 
     @Operation(
-            summary = "발화점 지정",
+            summary = "최초 발화점 등록(도면 관리용)",
             description = """
                     지정한 격자 셀(gridCellId)을 해당 시나리오의 최초 발화점으로 등록합니다.
                     등록과 동시에 그 셀은 FloorGridCell.isFired = true로 표시되며, 생성되는
                     FireZone은 isManualAdd = true, spreadGeneration = 0으로 저장됩니다.
 
-                    이 API는 도면 관리 화면에서 READY 시나리오의 발화점을 격자 셀로
-                    지정할 때 1회만 사용합니다. 시나리오당 최초 발화점은 하나만 허용되며,
+                    이 API는 도면 관리 프론트에서 READY 시나리오의 발화점을 격자 셀로
+                    지정할 때 1회만 사용합니다. 시나리오 설정 프론트에서는 이 API를
+                    호출하지 않습니다. 시나리오당 최초 발화점은 하나만 허용되며,
                     이미 등록된 시나리오에 다시 요청하면 거부됩니다. 수정·삭제 API는 제공하지
                     않습니다. 시나리오 화면에서는 등록 API를 호출하지 않고 조회만 수행합니다.
 
@@ -62,7 +66,7 @@ public class FireZoneController {
     }
 
     @Operation(
-            summary = "화재구역 전체 조회",
+            summary = "화재구역 전체 조회(훈련 표시용)",
             description = """
                     해당 시나리오에 등록된 FireZone 전체를 반환합니다. 관리자가 수동 지정한
                     최초 발화점(isManualAdd = true, spreadGeneration = 0)과, 훈련 시작 후 화재
@@ -75,7 +79,8 @@ public class FireZoneController {
                     종료되면 화재 셀은 초기화되지만 FireZone 레코드 자체는 삭제되지 않으므로,
                     지난 훈련의 확산 기록 조회에도 사용할 수 있습니다.
 
-                    시나리오 프론트는 최초 발화점만 필요한 경우
+                    훈련 진행 화면에서 최초 발화점과 확산된 화재 셀을 함께
+                    표시할 때 사용합니다. 시나리오 설정 화면에서 최초 발화점만 필요하면
                     GET /api/v1/scenarios/{scenarioId}/fire-origin을 사용합니다.
                     """
     )

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
@@ -85,11 +85,13 @@ public class TrainingScenarioController {
                     시나리오 전체에 하나로 적용되며(발화점별 개별 지정 불가), 훈련 시작 후 화재
                     확산 시뮬레이션의 tick 간격을 결정합니다(FAST가 가장 빠르게 확산).
 
-                    startNodeId는 요청으로 받지 않습니다. 발화점을 등록하면 서버가 같은 층의
-                    START 노드를 찾아 시나리오에 연결합니다. targetEvacuationSec도 선택값입니다.
+                    startNodeId는 요청으로 받지 않습니다. 도면 관리에서 최초 발화점을
+                    등록하면 서버가 발화층의 대표 START 노드를 찾아 시나리오에
+                    자동으로 연결합니다. targetEvacuationSec도 선택값입니다.
 
-                    생성 직후 시나리오의 상태는 READY이지만, 훈련을 시작하려면 발화점을
-                    등록하고 같은 층의 START 노드가 시나리오에 연결되어야 합니다.
+                    생성 직후 시나리오의 상태는 READY이지만 바로 실행할 수는 없습니다.
+                    도면 관리에서 최초 발화점이 등록되고 같은 층의 START 노드가
+                    시나리오에 연결되어야 훈련을 시작할 수 있습니다.
                     초안(DRAFT) 저장 플로우는 아직 지원하지 않습니다.
                     """
     )
@@ -108,8 +110,9 @@ public class TrainingScenarioController {
                     요청 바디에 값이 채워진 필드만 부분 수정합니다. null인 필드는 기존 값을
                     그대로 유지하므로, 값을 지우고 싶다고 해서 null을 보내면 변경되지 않습니다.
 
-                    startNodeId는 이 API로 변경하지 않습니다. 발화점 층의 START 노드를 서버가
-                    자동으로 연결합니다. buildingId, adminId, status는 이 API로 변경할 수 없습니다.
+                    startNodeId는 이 API로 변경하지 않습니다. 도면 관리에서 등록한
+                    발화점 층의 START 노드를 서버가 자동으로 연결합니다.
+                    buildingId, adminId, status는 이 API로 변경할 수 없습니다.
 
                     시나리오의 status(READY/IN_PROGRESS/COMPLETED/ERROR)는 연결된 훈련
                     세션의 생명주기에 따라 서버가 자동으로 전이시키는 값이라 이 API로는 건드릴
@@ -146,7 +149,7 @@ public class TrainingScenarioController {
 
     // GET /api/v1/scenarios/{scenarioId}/fire-origin
     @Operation(
-            summary = "최초 발화점 목록 조회",
+            summary = "시나리오 최초 발화점 조회(표시용)",
             description = """
                     도면 관리에서 POST /api/v1/scenarios/{scenarioId}/fire-zones로 등록한
                     최초 발화점(FireZone.isManualAdd = true) 목록을 반환합니다.

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -228,14 +228,15 @@ public class TrainingSessionController {
       description = """
           이 세션에 대해 "지금 안내되고 있는" 대피 경로 하나를 노드 목록과 총 가중치로
           반환합니다. 가장 최근 승인된 경로 재탐색이 있으면 그 경로(fromApprovedRecalculation
-          =true)를, 없으면 시나리오의 startNodeId를 기준으로 새로 계산한 최단 경로
+          =true)를, 없으면 도면 관리에서 발화층에 지정한 대표 START 노드를
+          기준으로 새로 계산한 최단 경로
           (fromApprovedRecalculation=false)를 반환합니다.
 
           세션 상태(RUNNING 여부)는 검증하지 않습니다. 아직 시작 전(SCHEDULED)인 세션은
           승인된 재탐색이 있을 수 없으므로 자연히 최단 경로가 반환되고, 이미 종료된
           (COMPLETED/ERROR) 세션은 종료 시점까지의 마지막 승인 경로가 그대로 반환됩니다.
 
-          시나리오에 startNodeId가 설정되어 있지 않으면 실패합니다.
+          시나리오에 발화층의 START 노드가 연결되어 있지 않으면 실패합니다.
           """
   )
   @GetMapping("/{sessionId}/current-route")

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -112,8 +112,8 @@ public class TrainingScenario {
         scenario.building = building;
         scenario.admin = admin;
         scenario.startNode = startNode;
-        // 생성 시점엔 필수 필드가 모두 채워져 있어 바로 실행 가능한 상태로 시작한다.
-        // 초안 저장(DRAFT) 플로우는 별도 엔드포인트가 생기면 그때 지정한다.
+        // 생성 직후 READY로 시작하지만, 도면 관리에서 발화점을 등록해 START 노드가
+        // 연결되기 전에는 훈련을 시작할 수 없다. DRAFT 저장 플로우는 아직 지원하지 않는다.
         scenario.status = ScenarioStatus.READY;
         return scenario;
     }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #172 
- Branch: feat/#172

## 주요 내용

-최신 내용 스웨거 반영

## ✅ Check List

- [ ] 테스트 통과
- [ ] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * Swagger API 설명을 업데이트해 도면 관리, 최초 발화점 등록, 화재구역 표시 및 훈련 경로 조회의 사용 방식과 조건을 명확히 했습니다.
  * 시나리오 생성·수정 및 최초 발화점 조회 API의 동작 기준과 표시 목적을 구체적으로 안내합니다.
  * 훈련 시나리오의 초기 상태와 START 노드 연결 필요 조건에 대한 설명을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->