### PR TITLE
[FEAT] #167: 훈련 세션 생성 및 경로 미리보기 정책 변경

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -296,7 +296,7 @@ public class RouteRecalculationService {
                 CurrentRouteResponse.RouteSource.INITIAL,
                 path,
                 directRoute.totalWeight(),
-                session.getStartedAt());
+                session.getCreatedAt());
     }
 
     // RouteRecalculation은 노드 id만 저장하므로(@ElementCollection), 도면에 그릴 이름/타입/좌표를

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
@@ -142,16 +143,14 @@ public class TrainingSessionController {
           재훈련이 필요하면 세션이 아니라 시나리오를 새로 만들어야 합니다.
 
           adminId는 요청자와 같은 학교 소속이면서 MANAGER 권한을 가진 사용자여야 합니다.
-
-          status를 RUNNING으로 생성하려면 startedAt을 함께 지정해야 합니다. status를
-          SCHEDULED로 생성하는 경우가 일반적인 흐름이며, 이때는 실제 시작 시각이 아직 없으므로
-          이후 시작 API(POST /api/v1/sessions/{sessionId}/start) 호출 시 서버가 시작
-          시각을 다시 기록합니다.
+          신규 세션은 항상 SCHEDULED 상태와 startedAt=null로 생성됩니다. RUNNING 상태와
+          실제 시작 시각은 시작 API(POST /api/v1/sessions/{sessionId}/start)를 호출할 때만
+          서버가 설정합니다.
           """
   )
   @PostMapping("/{scenarioId}")
   public ResponseEntity<TrainingSessionResponse> createTrainingSession(
-      @RequestBody CreateSessionRequest request,
+      @Valid @RequestBody CreateSessionRequest request,
       @PathVariable("scenarioId") UUID scenarioId,
       Authentication authentication) {
     return ResponseEntity.ok(trainingSessionService.create(request, scenarioId, authentication.getName()));

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -68,11 +68,12 @@ public class TrainingSessionController {
                               "sessions": [
                                 {
                                   "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                  "scenarioId": "746d0249-c6c2-4a61-a233-44f35c04dc49",
                                   "scenarioName": "3학년 A동 화재 대피 훈련",
                                   "buildingId": "b5a6e5b0-1e3a-4b8a-9b8a-6a2b6b1f5a11",
                                   "buildingName": "A동",
-                                  "status": "RUNNING",
-                                  "startedAt": "2026-08-26T05:26:00Z"
+                                  "status": "SCHEDULED",
+                                  "startedAt": null
                                 }
                               ]
                             }

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -236,6 +236,11 @@ public class TrainingSessionController {
           승인된 재탐색이 있을 수 없으므로 자연히 최단 경로가 반환되고, 이미 종료된
           (COMPLETED/ERROR) 세션은 종료 시점까지의 마지막 승인 경로가 그대로 반환됩니다.
 
+          시나리오 작성 완료 후 SCHEDULED 세션을 생성하고, 생성 응답의 sessionId로 이 API를
+          호출하면 훈련 시작 전에도 경로 미리보기를 표시할 수 있습니다. 시나리오 미리보기와
+          훈련 진행 화면은 일반 최단 경로 API에 startNodeId를 직접 전달하지 않고 이 세션 기준
+          API를 사용합니다.
+
           시나리오에 발화층의 START 노드가 연결되어 있지 않으면 실패합니다.
           """
   )

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -40,7 +40,8 @@ public class TrainingSessionController {
   @Operation(
       summary = "상태별 훈련 세션 목록 조회",
       description = """
-              요청자 학교 소속 훈련 세션을 상태로 필터링해 최신 시작 순으로 반환합니다.
+              요청자 학교 소속 훈련 세션을 상태로 필터링해 반환합니다. SCHEDULED 세션은
+              생성 시각 최신순으로, 그 외 상태는 실제 훈련 시작 시각 최신순으로 정렬합니다.
 
               모니터링 화면에 진입할 sessionId를 얻는 용도로 사용합니다.
               예: GET /api/v1/sessions?status=RUNNING

--- a/src/main/java/com/saferoute/domain/training/dto/CreateSessionRequest.java
+++ b/src/main/java/com/saferoute/domain/training/dto/CreateSessionRequest.java
@@ -1,8 +1,7 @@
 package com.saferoute.domain.training.dto;
 
-import com.saferoute.domain.training.entity.TrainingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,12 +12,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateSessionRequest {
 
-  @NotNull
-  private TrainingStatus status;
-
-  @NotNull
-  private Instant startedAt;
-
+  @Schema(
+      description = "세션을 생성할 관리자 ID",
+      example = "8d40b5e1-40f8-4dd4-a11c-f1ed418b73d1",
+      requiredMode = Schema.RequiredMode.REQUIRED
+  )
   @NotNull
   private UUID adminId;
 }

--- a/src/main/java/com/saferoute/domain/training/dto/TrainingSessionSummaryResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/TrainingSessionSummaryResponse.java
@@ -11,6 +11,9 @@ public record TrainingSessionSummaryResponse(
         @Schema(description = "훈련 세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
         UUID sessionId,
 
+        @Schema(description = "훈련 시나리오 ID", example = "746d0249-c6c2-4a61-a233-44f35c04dc49")
+        UUID scenarioId,
+
         @Schema(description = "훈련 시나리오 이름", example = "3학년 A동 화재 대피 훈련")
         String scenarioName,
 
@@ -30,6 +33,7 @@ public record TrainingSessionSummaryResponse(
     public static TrainingSessionSummaryResponse from(TrainingSession session) {
         return new TrainingSessionSummaryResponse(
                 session.getId(),
+                session.getScenario().getId(),
                 session.getScenario().getName(),
                 session.getScenario().getBuilding().getId(),
                 session.getScenario().getBuilding().getName(),

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingSession.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingSession.java
@@ -36,7 +36,7 @@ public class TrainingSession {
     @Column(name = "training_status", nullable = false, length = 20)
     private TrainingStatus status;
 
-    @Column(name = "started_at", nullable = false)
+    @Column(name = "started_at")
     private Instant startedAt;
 
     @Column(name = "ended_at")
@@ -88,6 +88,10 @@ public class TrainingSession {
     // 훈련 세션 생성용 정적 팩토리 메서드
     public static TrainingSession create(TrainingStatus status, Instant startedAt, User admin, TrainingScenario scenario) {
         return new TrainingSession(status, startedAt, admin, scenario);
+    }
+
+    public static TrainingSession schedule(User admin, TrainingScenario scenario) {
+        return new TrainingSession(TrainingStatus.SCHEDULED, null, admin, scenario);
     }
 
     // 관리자가 훈련 시작 버튼을 누른 시각으로 실제 시작 시각을 갱신하며 RUNNING으로 전이한다.

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -18,7 +18,13 @@ public interface TrainingSessionRepository extends JpaRepository<TrainingSession
   List<TrainingSession> findByStatusAndStartedAtBefore(TrainingStatus status, Instant threshold);
 
   List<TrainingSession> findAllByStatus(TrainingStatus status);
-  // 모니터링 화면 진입점: 요청자 학교 소속 세션 중 상태로 필터링해 최신 시작 순으로 반환한다.
+
+  // 시작 전 세션은 startedAt이 null이므로 생성 시각을 기준으로 최신순 정렬한다.
+  @EntityGraph(attributePaths = {"scenario", "scenario.building"})
+  List<TrainingSession> findAllByStatusAndScenario_Building_SchoolNameOrderByCreatedAtDesc(
+      TrainingStatus status, String schoolName);
+
+  // 시작된 세션은 실제 훈련 시작 시각을 기준으로 최신순 정렬한다.
   @EntityGraph(attributePaths = {"scenario", "scenario.building"})
   List<TrainingSession> findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(
       TrainingStatus status, String schoolName);

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -93,8 +93,12 @@ public class TrainingSessionService {
   @Transactional(readOnly = true)
   public TrainingSessionListResponse getSessions(TrainingStatus status, String email) {
     String schoolName = schoolContextService.getSchoolName(email);
-    List<TrainingSessionSummaryResponse> sessions = trainingSessionRepository
-        .findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(status, schoolName)
+    List<TrainingSession> trainingSessions = status == TrainingStatus.SCHEDULED
+        ? trainingSessionRepository
+            .findAllByStatusAndScenario_Building_SchoolNameOrderByCreatedAtDesc(status, schoolName)
+        : trainingSessionRepository
+            .findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(status, schoolName);
+    List<TrainingSessionSummaryResponse> sessions = trainingSessions
         .stream()
         .map(TrainingSessionSummaryResponse::from)
         .toList();

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -77,21 +77,7 @@ public class TrainingSessionService {
       throw new ApiException(TrainingErrorCode.SESSION_ALREADY_EXISTS);
     }
 
-    if (request.getStatus() == TrainingStatus.RUNNING && request.getStartedAt() == null) {
-      throw new ApiException(ErrorCode.INVALID_INPUT);
-    }
-
-    if (request.getStatus() == TrainingStatus.RUNNING
-        && hasRunningSession(scenario.getBuildingId())) {
-      throw new ApiException(TrainingErrorCode.RUNNING_SESSION_ALREADY_EXISTS);
-    }
-
-    TrainingSession trainingSession = TrainingSession.create(
-        request.getStatus(),
-        request.getStartedAt(),
-        user,
-        scenario
-    );
+    TrainingSession trainingSession = TrainingSession.schedule(user, scenario);
 
     // existsByScenario_Id 체크와 save는 원자적이지 않아 동시 요청이 둘 다 통과할 수 있다.
     // 이 경우 뒤늦게 실패하는 쪽은 UNIQUE 제약 위반으로 걸러지므로, saveAndFlush로 INSERT를

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -27,6 +27,7 @@ import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
+import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.entity.User;
 import com.saferoute.domain.user.repository.UserRepository;
@@ -513,13 +514,17 @@ class RouteRecalculationServiceTest {
     }
 
     @Test
-    @DisplayName("승인된 재탐색이 없으면 시나리오의 대표 startNode 기준 최단 경로를 반환한다")
-    void getCurrentRoute_withoutApprovedRecalculation_returnsShortestRoute() {
-        UUID recSessionId = session.getId();
+    @DisplayName("SCHEDULED 세션에 승인된 재탐색이 없으면 대표 START 기준 INITIAL 경로를 반환한다")
+    void getCurrentRoute_scheduledWithoutApprovedRecalculation_returnsInitialRoute() {
+        UUID recSessionId = UUID.randomUUID();
         UUID scenarioId = UUID.randomUUID();
         UUID buildingId = UUID.randomUUID();
+        Instant createdAt = Instant.now();
+        TrainingSession scheduledSession = TrainingSession.schedule(mock(User.class), scenario);
+        ReflectionTestUtils.setField(scheduledSession, "id", recSessionId);
+        ReflectionTestUtils.setField(scheduledSession, "createdAt", createdAt);
         given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(recSessionId, SCHOOL_NAME))
-                .willReturn(Optional.of(session));
+                .willReturn(Optional.of(scheduledSession));
         given(routeRecalculationRepository.findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
                 recSessionId, RecalculationStatus.APPROVED))
                 .willReturn(Optional.empty());
@@ -534,8 +539,6 @@ class RouteRecalculationServiceTest {
         given(exitNode.getX()).willReturn(0.8);
         given(exitNode.getY()).willReturn(0.3);
 
-        Instant startedAt = Instant.now();
-        given(session.getStartedAt()).willReturn(startedAt);
         given(evacuationRouteService.findShortestRoute(floorId, startNodeId))
                 .willReturn(new EvacuationRoute(List.of(representativeStart, exitNode), 9.5));
 
@@ -550,7 +553,9 @@ class RouteRecalculationServiceTest {
         assertThat(response.path()).extracting(CurrentRouteResponse.NodePoint::nodeId)
                 .containsExactly(startNodeId, exitNodeId);
         assertThat(response.totalWeight()).isEqualTo(9.5);
-        assertThat(response.updatedAt()).isEqualTo(startedAt);
+        assertThat(response.updatedAt()).isEqualTo(createdAt);
+        assertThat(scheduledSession.getStatus()).isEqualTo(TrainingStatus.SCHEDULED);
+        assertThat(scheduledSession.getStartedAt()).isNull();
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.training.controller;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -26,6 +27,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -119,6 +121,53 @@ class TrainingSessionControllerTest {
     void getSessions_invalidStatus_returnsBadRequest() throws Exception {
         mockMvc.perform(get("/api/v1/sessions")
                         .param("status", "NOT_A_STATUS")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON400"));
+    }
+
+    // === create ===
+
+    @Test
+    @DisplayName("POST /sessions/{scenarioId} - 이전 status와 startedAt을 보내도 SCHEDULED 세션을 생성한다")
+    void createTrainingSession_ignoresLegacyStatusAndStartedAt() throws Exception {
+        UUID scenarioId = UUID.randomUUID();
+        UUID adminId = UUID.randomUUID();
+        TrainingSessionResponse response = TrainingSessionResponse.builder()
+                .id(sessionId)
+                .status(TrainingStatus.SCHEDULED)
+                .startedAt(null)
+                .adminName("박현지")
+                .scenarioName("정기 훈련")
+                .build();
+        given(trainingSessionService.create(
+                argThat(request -> adminId.equals(request.getAdminId())),
+                eq(scenarioId),
+                eq(EMAIL)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/v1/sessions/{scenarioId}", scenarioId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "adminId": "%s",
+                                  "status": "RUNNING",
+                                  "startedAt": "2026-09-03T10:00:00Z"
+                                }
+                                """.formatted(adminId))
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(sessionId.toString()))
+                .andExpect(jsonPath("$.status").value("SCHEDULED"))
+                .andExpect(jsonPath("$.startedAt").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("POST /sessions/{scenarioId} - adminId가 없으면 400을 반환한다")
+    void createTrainingSession_missingAdminId_returnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/sessions/{scenarioId}", UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("COMMON400"));

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
@@ -1,7 +1,8 @@
 package com.saferoute.domain.training.controller;
 
-import static org.mockito.ArgumentMatchers.eq;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -95,7 +96,9 @@ class TrainingSessionControllerTest {
                 .andExpect(jsonPath("$.result.sessions[0].buildingId").value(buildingId.toString()))
                 .andExpect(jsonPath("$.result.sessions[0].buildingName").value("A동"))
                 .andExpect(jsonPath("$.result.sessions[0].status").value("SCHEDULED"))
-                .andExpect(jsonPath("$.result.sessions[0].startedAt").doesNotExist());
+                .andExpect(jsonPath("$.result.sessions[0].startedAt").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content()
+                        .string(containsString("\"startedAt\":null")));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
@@ -67,31 +67,35 @@ class TrainingSessionControllerTest {
     // === getSessions ===
 
     @Test
-    @DisplayName("GET /sessions?status=RUNNING - 세션 목록을 공통 응답으로 반환한다")
+    @DisplayName("GET /sessions?status=SCHEDULED - 세션 목록에 scenarioId를 포함한다")
     void getSessions_success() throws Exception {
+        UUID scenarioId = UUID.randomUUID();
         UUID buildingId = UUID.randomUUID();
         TrainingSessionSummaryResponse summary = new TrainingSessionSummaryResponse(
                 sessionId,
+                scenarioId,
                 "3학년 A동 화재 대피 훈련",
                 buildingId,
                 "A동",
-                TrainingStatus.RUNNING,
-                Instant.parse("2026-08-26T05:26:00Z")
+                TrainingStatus.SCHEDULED,
+                null
         );
-        given(trainingSessionService.getSessions(TrainingStatus.RUNNING, EMAIL))
+        given(trainingSessionService.getSessions(TrainingStatus.SCHEDULED, EMAIL))
                 .willReturn(new TrainingSessionListResponse(List.of(summary)));
 
         mockMvc.perform(get("/api/v1/sessions")
-                        .param("status", "RUNNING")
+                        .param("status", "SCHEDULED")
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.code").value("TRAINING_SUCCESS_008"))
                 .andExpect(jsonPath("$.result.sessions[0].sessionId").value(sessionId.toString()))
+                .andExpect(jsonPath("$.result.sessions[0].scenarioId").value(scenarioId.toString()))
                 .andExpect(jsonPath("$.result.sessions[0].scenarioName").value("3학년 A동 화재 대피 훈련"))
                 .andExpect(jsonPath("$.result.sessions[0].buildingId").value(buildingId.toString()))
                 .andExpect(jsonPath("$.result.sessions[0].buildingName").value("A동"))
-                .andExpect(jsonPath("$.result.sessions[0].status").value("RUNNING"));
+                .andExpect(jsonPath("$.result.sessions[0].status").value("SCHEDULED"))
+                .andExpect(jsonPath("$.result.sessions[0].startedAt").doesNotExist());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -123,34 +123,36 @@ class TrainingSessionServiceTest {
     // === getSessions ===
 
     @Test
-    @DisplayName("요청자 학교의 상태별 세션 목록을 최신순으로 반환한다")
-    void getSessions_returnsSummariesForRequesterSchool() {
+    @DisplayName("요청자 학교의 SCHEDULED 세션 목록에 실제 시나리오 ID를 포함한다")
+    void getSessions_scheduledIncludesScenarioId() {
         UUID buildingId = UUID.randomUUID();
+        UUID scenarioId = UUID.randomUUID();
         Building building = mock(Building.class);
         given(building.getId()).willReturn(buildingId);
         given(building.getName()).willReturn("A동");
         TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getId()).willReturn(scenarioId);
         given(scenario.getName()).willReturn("3학년 A동 화재 대피 훈련");
         given(scenario.getBuilding()).willReturn(building);
-        Instant startedAt = Instant.parse("2026-08-26T05:26:00Z");
         TrainingSession session =
-                TrainingSession.create(TrainingStatus.RUNNING, startedAt, mock(User.class), scenario);
+                TrainingSession.schedule(mock(User.class), scenario);
         ReflectionTestUtils.setField(session, "id", sessionId);
         given(trainingSessionRepository
                 .findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(
-                        TrainingStatus.RUNNING, SCHOOL_NAME))
+                        TrainingStatus.SCHEDULED, SCHOOL_NAME))
                 .willReturn(List.of(session));
 
-        TrainingSessionListResponse response = trainingSessionService.getSessions(TrainingStatus.RUNNING, EMAIL);
+        TrainingSessionListResponse response = trainingSessionService.getSessions(TrainingStatus.SCHEDULED, EMAIL);
 
         assertThat(response.sessions()).hasSize(1);
         TrainingSessionSummaryResponse summary = response.sessions().get(0);
         assertThat(summary.sessionId()).isEqualTo(sessionId);
+        assertThat(summary.scenarioId()).isEqualTo(scenarioId);
         assertThat(summary.scenarioName()).isEqualTo("3학년 A동 화재 대피 훈련");
         assertThat(summary.buildingId()).isEqualTo(buildingId);
         assertThat(summary.buildingName()).isEqualTo("A동");
-        assertThat(summary.status()).isEqualTo(TrainingStatus.RUNNING);
-        assertThat(summary.startedAt()).isEqualTo(startedAt);
+        assertThat(summary.status()).isEqualTo(TrainingStatus.SCHEDULED);
+        assertThat(summary.startedAt()).isNull();
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -123,36 +123,47 @@ class TrainingSessionServiceTest {
     // === getSessions ===
 
     @Test
-    @DisplayName("요청자 학교의 SCHEDULED 세션 목록에 실제 시나리오 ID를 포함한다")
-    void getSessions_scheduledIncludesScenarioId() {
+    @DisplayName("SCHEDULED 세션 목록을 생성 시각 기준 최신순으로 반환한다")
+    void getSessions_scheduledOrdersByCreatedAtDescending() {
         UUID buildingId = UUID.randomUUID();
-        UUID scenarioId = UUID.randomUUID();
+        UUID newestScenarioId = UUID.randomUUID();
+        UUID olderScenarioId = UUID.randomUUID();
         Building building = mock(Building.class);
         given(building.getId()).willReturn(buildingId);
         given(building.getName()).willReturn("A동");
-        TrainingScenario scenario = mock(TrainingScenario.class);
-        given(scenario.getId()).willReturn(scenarioId);
-        given(scenario.getName()).willReturn("3학년 A동 화재 대피 훈련");
-        given(scenario.getBuilding()).willReturn(building);
-        TrainingSession session =
-                TrainingSession.schedule(mock(User.class), scenario);
-        ReflectionTestUtils.setField(session, "id", sessionId);
+
+        TrainingScenario newestScenario = mock(TrainingScenario.class);
+        given(newestScenario.getId()).willReturn(newestScenarioId);
+        given(newestScenario.getName()).willReturn("최신 훈련");
+        given(newestScenario.getBuilding()).willReturn(building);
+        TrainingSession newestSession = TrainingSession.schedule(mock(User.class), newestScenario);
+        ReflectionTestUtils.setField(newestSession, "id", sessionId);
+        ReflectionTestUtils.setField(newestSession, "createdAt", Instant.parse("2026-09-03T10:00:00Z"));
+
+        TrainingScenario olderScenario = mock(TrainingScenario.class);
+        given(olderScenario.getId()).willReturn(olderScenarioId);
+        given(olderScenario.getName()).willReturn("이전 훈련");
+        given(olderScenario.getBuilding()).willReturn(building);
+        TrainingSession olderSession = TrainingSession.schedule(mock(User.class), olderScenario);
+        ReflectionTestUtils.setField(olderSession, "id", UUID.randomUUID());
+        ReflectionTestUtils.setField(olderSession, "createdAt", Instant.parse("2026-09-02T10:00:00Z"));
+
         given(trainingSessionRepository
-                .findAllByStatusAndScenario_Building_SchoolNameOrderByStartedAtDesc(
+                .findAllByStatusAndScenario_Building_SchoolNameOrderByCreatedAtDesc(
                         TrainingStatus.SCHEDULED, SCHOOL_NAME))
-                .willReturn(List.of(session));
+                .willReturn(List.of(newestSession, olderSession));
 
         TrainingSessionListResponse response = trainingSessionService.getSessions(TrainingStatus.SCHEDULED, EMAIL);
 
-        assertThat(response.sessions()).hasSize(1);
-        TrainingSessionSummaryResponse summary = response.sessions().get(0);
-        assertThat(summary.sessionId()).isEqualTo(sessionId);
-        assertThat(summary.scenarioId()).isEqualTo(scenarioId);
-        assertThat(summary.scenarioName()).isEqualTo("3학년 A동 화재 대피 훈련");
-        assertThat(summary.buildingId()).isEqualTo(buildingId);
-        assertThat(summary.buildingName()).isEqualTo("A동");
-        assertThat(summary.status()).isEqualTo(TrainingStatus.SCHEDULED);
-        assertThat(summary.startedAt()).isNull();
+        assertThat(response.sessions())
+                .extracting(TrainingSessionSummaryResponse::scenarioId)
+                .containsExactly(newestScenarioId, olderScenarioId);
+        assertThat(response.sessions())
+                .extracting(TrainingSessionSummaryResponse::startedAt)
+                .containsOnlyNulls();
+        verify(trainingSessionRepository)
+                .findAllByStatusAndScenario_Building_SchoolNameOrderByCreatedAtDesc(
+                        TrainingStatus.SCHEDULED, SCHOOL_NAME);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -33,7 +33,6 @@ import com.saferoute.domain.user.entity.User;
 import com.saferoute.domain.user.entity.UserRole;
 import com.saferoute.domain.user.repository.UserRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
-import com.saferoute.global.api.code.ErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
@@ -170,23 +169,28 @@ class TrainingSessionServiceTest {
     // === create ===
 
     @Test
-    @DisplayName("RUNNING 상태로 세션을 생성할 때 시작 시각이 없으면 예외가 발생한다")
-    void create_runningWithoutStartedAt_throwsException() {
+    @DisplayName("세션을 생성하면 항상 SCHEDULED 상태이고 시작 시각은 비어 있다")
+    void create_alwaysCreatesScheduledSessionWithoutStartedAt() {
         UUID adminId = UUID.randomUUID();
         UUID scenarioId = UUID.randomUUID();
 
         User manager = mock(User.class);
         given(manager.getRole()).willReturn(UserRole.MANAGER);
         given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
+        TrainingScenario scenario = mock(TrainingScenario.class);
         given(trainingScenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
-                .willReturn(Optional.of(mock(TrainingScenario.class)));
+                .willReturn(Optional.of(scenario));
+        given(trainingSessionRepository.saveAndFlush(any(TrainingSession.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
-        CreateSessionRequest request = new CreateSessionRequest(TrainingStatus.RUNNING, null, adminId);
+        CreateSessionRequest request = new CreateSessionRequest(adminId);
 
-        assertThatThrownBy(() -> trainingSessionService.create(request, scenarioId, EMAIL))
-                .isInstanceOf(ApiException.class)
-                .extracting(exception -> ((ApiException) exception).getErrorCode())
-                .isEqualTo(ErrorCode.INVALID_INPUT);
+        trainingSessionService.create(request, scenarioId, EMAIL);
+
+        var sessionCaptor = org.mockito.ArgumentCaptor.forClass(TrainingSession.class);
+        verify(trainingSessionRepository).saveAndFlush(sessionCaptor.capture());
+        assertThat(sessionCaptor.getValue().getStatus()).isEqualTo(TrainingStatus.SCHEDULED);
+        assertThat(sessionCaptor.getValue().getStartedAt()).isNull();
     }
 
     @Test
@@ -201,7 +205,7 @@ class TrainingSessionServiceTest {
                 .willReturn(Optional.of(mock(TrainingScenario.class)));
         given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(true);
 
-        CreateSessionRequest request = new CreateSessionRequest(TrainingStatus.SCHEDULED, null, adminId);
+        CreateSessionRequest request = new CreateSessionRequest(adminId);
 
         assertThatThrownBy(() -> trainingSessionService.create(request, scenarioId, EMAIL))
                 .isInstanceOf(ApiException.class)
@@ -224,7 +228,7 @@ class TrainingSessionServiceTest {
         given(trainingSessionRepository.saveAndFlush(any()))
                 .willThrow(new org.springframework.dao.DataIntegrityViolationException("unique constraint"));
 
-        CreateSessionRequest request = new CreateSessionRequest(TrainingStatus.SCHEDULED, null, adminId);
+        CreateSessionRequest request = new CreateSessionRequest(adminId);
 
         assertThatThrownBy(() -> trainingSessionService.create(request, scenarioId, EMAIL))
                 .isInstanceOf(ApiException.class)
@@ -244,8 +248,7 @@ class TrainingSessionServiceTest {
         given(trainingScenarioRepository
                 .findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.empty());
-        CreateSessionRequest request =
-                new CreateSessionRequest(TrainingStatus.SCHEDULED, null, adminId);
+        CreateSessionRequest request = new CreateSessionRequest(adminId);
 
         assertThatThrownBy(() -> trainingSessionService.create(request, scenarioId, EMAIL))
                 .isInstanceOf(ApiException.class)


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #167
- Branch: feat/#167

## 주요 내용

- 세션 생성 요청에서 `status`, `startedAt` 필드를 제거했습니다.
- 신규 세션이 항상 `SCHEDULED`, `startedAt=null`로 생성되도록 변경했습니다.
- `RUNNING` 상태와 실제 시작 시각은 세션 시작 API에서만 설정되도록 분리했습니다.
- `training_sessions.started_at` 컬럼이 null을 허용하도록 수정했습니다.
- 세션 목록 응답에 `scenarioId`를 추가했습니다.
- SCHEDULED 세션에서도 대표 START 노드 기준 `INITIAL` 경로를 조회할 수 있도록 테스트를 보완했습니다.
- 초기 경로의 `updatedAt`이 세션 생성 시각을 사용하도록 변경했습니다.
- 세션 생성 및 경로 미리보기 Swagger 설명과 예시를 수정했습니다.

## ✅ Check List

- [x] 테스트 통과
- [x] `./gradlew build` 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **주요 변경사항**
  * 훈련 세션 생성 시 상태와 시작 시각을 입력하지 않으며, 모든 세션이 `SCHEDULED` 상태와 시작 시각 없음으로 생성됩니다.
  * 관리자 ID 필수 검증이 적용되어 잘못된 요청은 거부됩니다.
  * 세션 목록 응답에 시나리오 ID가 포함됩니다.
  * 예약된 세션의 초기 경로 시간 정보가 생성 시각을 기준으로 제공됩니다.
  * 관련 API 문서와 예시가 새로운 세션 생성 및 경로 미리보기 방식에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->