### PR TITLE
[Feat] #182: 도면 관리 - START 후보 노드 다중 등록 정책으로 전환

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
@@ -43,6 +43,11 @@ public class MapGraphEditController {
                     이 노드가 대피 경로 계산(다익스트라)의 목적지 후보에 포함됩니다.
                     단, START 노드는 요청값과 관계없이 isExitTarget=false로 저장됩니다.
 
+                    START 노드는 특정 시나리오에 귀속되지 않는, 시나리오 설정 화면에서 선택
+                    가능한 훈련 시작점 후보입니다. 한 층에 여러 개 등록할 수 있으며, 실제로
+                    어떤 START를 사용할지는 시나리오 설정 단계에서 선택합니다. 이 API는 후보를
+                    등록할 뿐 특정 시나리오의 발화점이나 훈련 시작점을 저장하지 않습니다.
+
                     CCTV/IoT 유도등 같은 기기 위치 노드는 이 API가 아니라 각 기기 도메인의
                     등록 API를 통해 CUSTOM 타입으로 생성됩니다.
                     """
@@ -64,7 +69,8 @@ public class MapGraphEditController {
                     커스텀 편집 UI에서 노드를 드래그로 이동하거나 EXIT 대상 지정을 토글할 때
                     사용합니다. type을 생략하면 기존 유형을 유지합니다.
 
-                    한 층에는 START 노드를 하나만 지정할 수 있습니다. START는 항상
+                    한 층에 START 후보 노드를 여러 개 둘 수 있으므로, 다른 노드를 START로
+                    변경할 때 같은 층에 이미 START가 있어도 거부되지 않습니다. START는 항상
                     isExitTarget=false, EXIT는 항상 isExitTarget=true로 저장됩니다.
 
                     isExitTarget을 false로 바꾸는 요청은, 그 노드가 속한 층에 남은 EXIT 대상

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
@@ -29,8 +29,6 @@ public interface MapGraphRepository {
     // 해당 층의 EXIT 대상(isExitTarget=true) 노드 개수 - 마지막 EXIT 삭제 방지 체크용
     long countExitTargetNodesByFloor(UUID floorId);
 
-    boolean existsNodeByFloorAndType(UUID floorId, NodeType type);
-
     // 엣지 단건 조회 (삭제 시 참조용)
     Optional<MapEdge> findEdgeById(UUID edgeId);
 

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
@@ -77,11 +77,6 @@ public class MapGraphRepositoryImpl implements MapGraphRepository {
     }
 
     @Override
-    public boolean existsNodeByFloorAndType(UUID floorId, NodeType type) {
-        return mapNodeJpaRepository.existsByFloor_IdAndType(floorId, type);
-    }
-
-    @Override
     public Optional<MapEdge> findEdgeById(UUID edgeId) {
         return mapEdgeJpaRepository.findById(edgeId);
     }

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapNodeJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapNodeJpaRepository.java
@@ -28,8 +28,6 @@ public interface MapNodeJpaRepository extends JpaRepository<MapNode, UUID> {
 
     boolean existsByFloor_IdAndCode(UUID floorId, String code);
 
-    boolean existsByFloor_IdAndType(UUID floorId, NodeType type);
-
     void deleteAllByFloor_Id(UUID floorId);
 
     void deleteAllByFloor(Floor floor);

--- a/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
@@ -58,11 +58,6 @@ public class MapGraphService {
     public MapNodeResponse createNode(UUID floorId, CreateMapNodeRequest request) {
         Floor floor = floorRepository.findById(floorId)
                 .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
-        if (request.type() == NodeType.START) {
-            floorRepository.findByIdForUpdate(floorId)
-                    .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
-            validateStartNodeDoesNotExist(floorId);
-        }
         boolean isExitTarget = resolveExitTarget(request.type(), request.isExitTarget());
         MapNode node = mapGraphRepository.addNode(floor, request.code(), request.type(), request.name(),
                 request.x(), request.y(), isExitTarget);
@@ -75,17 +70,10 @@ public class MapGraphService {
         MapNode node = findNodeOrThrow(nodeId);
         NodeType nextType = request.type() != null ? request.type() : node.getType();
         boolean nextExitTarget = resolveExitTarget(nextType, request.isExitTarget());
-        boolean needsFloorLock = !nextExitTarget
-                || (nextType == NodeType.START && node.getType() != NodeType.START);
-        if (needsFloorLock) {
+        if (!nextExitTarget) {
             // 동일 층에 대한 동시 수정 요청을 직렬화해 마지막 EXIT 카운트 검증과 해제 사이의 경쟁을 방지
             floorRepository.findByIdForUpdate(node.getFloor().getId())
                     .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
-        }
-        if (nextType == NodeType.START && node.getType() != NodeType.START) {
-            validateStartNodeDoesNotExist(node.getFloor().getId());
-        }
-        if (!nextExitTarget) {
             validateNotLastExitNode(node, EvacuationErrorCode.EXIT_NODE_UNSET_NOT_ALLOWED);
         }
         node.changeType(nextType);
@@ -102,12 +90,6 @@ public class MapGraphService {
             return true;
         }
         return requestedExitTarget;
-    }
-
-    private void validateStartNodeDoesNotExist(UUID floorId) {
-        if (mapGraphRepository.existsNodeByFloorAndType(floorId, NodeType.START)) {
-            throw new ApiException(EvacuationErrorCode.FLOOR_START_NODE_ALREADY_EXISTS);
-        }
     }
 
     // 노드 삭제 (연결된 엣지도 함께 삭제)

--- a/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
@@ -18,8 +18,7 @@ public enum EvacuationErrorCode implements BaseErrorCode {
     EXIT_NODE_NOT_DESIGNATED(HttpStatus.NOT_FOUND, "EVAC007", "지정된 출구 노드가 없습니다."),
     ROUTE_RECALCULATION_NOT_FOUND(HttpStatus.NOT_FOUND, "EVAC008", "재탐색 요청을 찾을 수 없습니다."),
     INVALID_RECALCULATION_STATUS_TRANSITION(HttpStatus.CONFLICT, "EVAC009", "이미 처리된 재탐색 요청입니다."),
-    EXIT_NODE_UNSET_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVAC010", "마지막 출구 노드는 EXIT 대상에서 해제할 수 없습니다."),
-    FLOOR_START_NODE_ALREADY_EXISTS(HttpStatus.CONFLICT, "EVAC011", "해당 층에는 이미 대표 대피 시작 노드가 있습니다.");
+    EXIT_NODE_UNSET_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVAC010", "마지막 출구 노드는 EXIT 대상에서 해제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
@@ -176,16 +176,26 @@ class MapGraphServiceTest {
     @Test
     @DisplayName("한 층에 START 후보 노드를 여러 개 생성할 수 있다")
     void createNode_multipleStartNodes_allowed() {
-        CreateMapNodeRequest request =
+        CreateMapNodeRequest firstRequest =
+                new CreateMapNodeRequest("START1", NodeType.START, "대피 시작점 후보 1", 0.1, 0.2, false);
+        CreateMapNodeRequest secondRequest =
                 new CreateMapNodeRequest("START2", NodeType.START, "대피 시작점 후보 2", 0.3, 0.4, false);
-        MapNode savedNode = createNode("START2", NodeType.START);
+        MapNode firstSaved = createNode("START1", NodeType.START);
+        MapNode secondSaved = createNode("START2", NodeType.START);
         given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(mapGraphRepository.addNode(floor, "START1", NodeType.START, "대피 시작점 후보 1", 0.1, 0.2, false))
+                .willReturn(firstSaved);
         given(mapGraphRepository.addNode(floor, "START2", NodeType.START, "대피 시작점 후보 2", 0.3, 0.4, false))
-                .willReturn(savedNode);
+                .willReturn(secondSaved);
 
-        MapNodeResponse response = mapGraphService.createNode(floorId, request);
+        // 같은 층에 첫 번째 START 후보가 이미 존재하는 상태에서
+        mapGraphService.createNode(floorId, firstRequest);
+        // 두 번째 START 후보를 생성해도 거부되지 않는다
+        MapNodeResponse response = mapGraphService.createNode(floorId, secondRequest);
 
+        assertThat(response.code()).isEqualTo("START2");
         assertThat(response.type()).isEqualTo(NodeType.START);
+        verify(mapGraphRepository).addNode(floor, "START1", NodeType.START, "대피 시작점 후보 1", 0.1, 0.2, false);
         verify(mapGraphRepository).addNode(floor, "START2", NodeType.START, "대피 시작점 후보 2", 0.3, 0.4, false);
     }
 
@@ -279,6 +289,8 @@ class MapGraphServiceTest {
     @Test
     @DisplayName("같은 층에 이미 START가 있어도 다른 노드를 START로 변경할 수 있다")
     void updateNodePosition_changeTypeToStart_allowedWithExistingStart() {
+        // 같은 층에 이미 START로 지정된 노드가 존재하는 상태
+        MapNode existingStartNode = createNode("START1", NodeType.START);
         MapNode node = createNode("HALLWAY1", NodeType.HALLWAY);
         UpdateMapNodePositionRequest request =
                 new UpdateMapNodePositionRequest(10.0, 20.0, false, NodeType.START);
@@ -288,6 +300,7 @@ class MapGraphServiceTest {
 
         MapNodeResponse response = mapGraphService.updateNodePosition(node.getId(), request);
 
+        assertThat(existingStartNode.getType()).isEqualTo(NodeType.START);
         assertThat(response.type()).isEqualTo(NodeType.START);
         verify(mapGraphRepository).updateNodePosition(node, 10.0, 20.0, false);
     }

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
@@ -161,12 +161,10 @@ class MapGraphServiceTest {
     @DisplayName("START 노드는 EXIT 대상이 아닌 상태로 생성한다")
     void createNode_startNode_forcesExitTargetFalse() {
         CreateMapNodeRequest request =
-                new CreateMapNodeRequest("START1", NodeType.START, "대표 시작점", 0.1, 0.2, true);
+                new CreateMapNodeRequest("START1", NodeType.START, "대피 시작점 후보 1", 0.1, 0.2, true);
         MapNode savedNode = createNode("START1", NodeType.START);
         given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
-        given(floorRepository.findByIdForUpdate(floorId)).willReturn(Optional.of(floor));
-        given(mapGraphRepository.existsNodeByFloorAndType(floorId, NodeType.START)).willReturn(false);
-        given(mapGraphRepository.addNode(floor, "START1", NodeType.START, "대표 시작점", 0.1, 0.2, false))
+        given(mapGraphRepository.addNode(floor, "START1", NodeType.START, "대피 시작점 후보 1", 0.1, 0.2, false))
                 .willReturn(savedNode);
 
         MapNodeResponse response = mapGraphService.createNode(floorId, request);
@@ -176,19 +174,19 @@ class MapGraphServiceTest {
     }
 
     @Test
-    @DisplayName("한 층에 START 노드를 두 개 생성할 수 없다")
-    void createNode_duplicateStartNode_throws() {
+    @DisplayName("한 층에 START 후보 노드를 여러 개 생성할 수 있다")
+    void createNode_multipleStartNodes_allowed() {
         CreateMapNodeRequest request =
-                new CreateMapNodeRequest("START2", NodeType.START, "대표 시작점", 0.1, 0.2, false);
+                new CreateMapNodeRequest("START2", NodeType.START, "대피 시작점 후보 2", 0.3, 0.4, false);
+        MapNode savedNode = createNode("START2", NodeType.START);
         given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
-        given(floorRepository.findByIdForUpdate(floorId)).willReturn(Optional.of(floor));
-        given(mapGraphRepository.existsNodeByFloorAndType(floorId, NodeType.START)).willReturn(true);
+        given(mapGraphRepository.addNode(floor, "START2", NodeType.START, "대피 시작점 후보 2", 0.3, 0.4, false))
+                .willReturn(savedNode);
 
-        assertThatThrownBy(() -> mapGraphService.createNode(floorId, request))
-                .isInstanceOf(ApiException.class)
-                .hasMessage(EvacuationErrorCode.FLOOR_START_NODE_ALREADY_EXISTS.getMessage());
+        MapNodeResponse response = mapGraphService.createNode(floorId, request);
 
-        verify(mapGraphRepository, never()).addNode(any(), any(), any(), any(), anyDouble(), anyDouble(), anyBoolean());
+        assertThat(response.type()).isEqualTo(NodeType.START);
+        verify(mapGraphRepository).addNode(floor, "START2", NodeType.START, "대피 시작점 후보 2", 0.3, 0.4, false);
     }
 
     // === updateNodePosition ===
@@ -270,7 +268,6 @@ class MapGraphServiceTest {
                 new UpdateMapNodePositionRequest(10.0, 20.0, true, NodeType.START);
         given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
         given(floorRepository.findByIdForUpdate(floorId)).willReturn(Optional.of(floor));
-        given(mapGraphRepository.existsNodeByFloorAndType(floorId, NodeType.START)).willReturn(false);
         given(mapGraphRepository.updateNodePosition(node, 10.0, 20.0, false)).willReturn(node);
 
         MapNodeResponse response = mapGraphService.updateNodePosition(node.getId(), request);
@@ -280,20 +277,19 @@ class MapGraphServiceTest {
     }
 
     @Test
-    @DisplayName("이미 START가 있는 층의 다른 노드를 START로 변경할 수 없다")
-    void updateNodePosition_duplicateStartNode_throws() {
+    @DisplayName("같은 층에 이미 START가 있어도 다른 노드를 START로 변경할 수 있다")
+    void updateNodePosition_changeTypeToStart_allowedWithExistingStart() {
         MapNode node = createNode("HALLWAY1", NodeType.HALLWAY);
         UpdateMapNodePositionRequest request =
                 new UpdateMapNodePositionRequest(10.0, 20.0, false, NodeType.START);
         given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
         given(floorRepository.findByIdForUpdate(floorId)).willReturn(Optional.of(floor));
-        given(mapGraphRepository.existsNodeByFloorAndType(floorId, NodeType.START)).willReturn(true);
+        given(mapGraphRepository.updateNodePosition(node, 10.0, 20.0, false)).willReturn(node);
 
-        assertThatThrownBy(() -> mapGraphService.updateNodePosition(node.getId(), request))
-                .isInstanceOf(ApiException.class)
-                .hasMessage(EvacuationErrorCode.FLOOR_START_NODE_ALREADY_EXISTS.getMessage());
+        MapNodeResponse response = mapGraphService.updateNodePosition(node.getId(), request);
 
-        verify(mapGraphRepository, never()).updateNodePosition(any(), anyDouble(), anyDouble(), anyBoolean());
+        assertThat(response.type()).isEqualTo(NodeType.START);
+        verify(mapGraphRepository).updateNodePosition(node, 10.0, 20.0, false);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #182
- Branch: feat/#182

## 주요 내용

- 도면 관리에서 "층별 START 노드 최대 1개" 제한 정책을 제거하고, START를 특정 시나리오에 귀속되지 않는 대피 시작점 후보 노드로 재정의 (한 층에 여러 개 등록 가능)
- `MapGraphService`의 노드 생성/수정 로직에서 같은 층 START 중복 검증 및 이를 위한 락 획득 로직 제거
- 더 이상 쓰이지 않는 `MapGraphRepository.existsNodeByFloorAndType` / `MapNodeJpaRepository.existsByFloor_IdAndType` 제거
- `EvacuationErrorCode.FLOOR_START_NODE_ALREADY_EXISTS`(EVAC011) 제거
- `MapGraphEditController` Swagger 설명을 새 정책에 맞게 수정 ("층별 대표 START 1개" 문구 삭제, START는 시나리오 설정 화면에서 선택하는 후보이며 이 API가 특정 시나리오의 발화점·시작점을 저장하지 않는다는 점 명시)
- `MapGraphServiceTest`를 START 노드 다중 생성/타입 변경 허용 시나리오로 갱신

## 범위에서 제외한 것

- `FireZoneService.designateOrigin`의 발화층 START 자동 검색/자동 연결 로직은 건드리지 않음 (별도 이슈에서 `POST /evacuation-setup` 신설과 함께 처리 예정)
- DB 마이그레이션 없음: 이 저장소는 Flyway/Liquibase가 없고 `MapNode.type`은 `@Enumerated(EnumType.STRING)`만 걸린 컬럼이라 `START`를 막는 CHECK 제약 자체가 존재하지 않음 (`ddl-auto=update`)


## ✅ Check List

- [x] 테스트 통과 (`MapGraphServiceTest`, `MapGraphEditControllerTest`, `MapGraphControllerTest` + 전체 `./gradlew test`)
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 한 층에 여러 개의 START 노드 후보를 등록할 수 있습니다.
  * 기존 START 노드가 있어도 다른 노드를 START로 지정할 수 있습니다.
  * START 노드는 특정 시나리오에 고정되지 않으며, 시나리오 설정 단계에서 사용할 노드를 선택합니다.
  * 이에 따라 한 층에 START 노드가 이미 있을 때 발생하던 중복 등록 오류가 제거되었습니다.
  * 관련 API 문서가 새로운 START 노드 정책에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->