### PR TITLE
[docs] #186: 훈련 시작 검증 및 기본 경로를 시나리오 startNodeId 기준으로 연동

### DIFF
--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -232,9 +232,9 @@ public class TrainingSessionController {
       description = """
           이 세션에 대해 "지금 안내되고 있는" 대피 경로 하나를 노드 목록과 총 가중치로
           반환합니다. 가장 최근 승인된 경로 재탐색이 있으면 그 경로(fromApprovedRecalculation
-          =true)를, 없으면 도면 관리에서 발화층에 지정한 대표 START 노드를
-          기준으로 새로 계산한 최단 경로
-          (fromApprovedRecalculation=false)를 반환합니다.
+          =true)를, 없으면 시나리오 설정(POST .../evacuation-setup)에서 선택한 startNode를
+          기준으로 새로 계산한 최단 경로(fromApprovedRecalculation=false, source=INITIAL)를
+          반환합니다. 두 경우 모두 경로의 첫 노드는 항상 이 시나리오의 startNodeId입니다.
 
           세션 상태(RUNNING 여부)는 검증하지 않습니다. 아직 시작 전(SCHEDULED)인 세션은
           승인된 재탐색이 있을 수 없으므로 자연히 최단 경로가 반환되고, 이미 종료된
@@ -245,7 +245,7 @@ public class TrainingSessionController {
           훈련 진행 화면은 일반 최단 경로 API에 startNodeId를 직접 전달하지 않고 이 세션 기준
           API를 사용합니다.
 
-          시나리오에 발화층의 START 노드가 연결되어 있지 않으면 실패합니다.
+          시나리오에 evacuation-setup으로 설정된 startNode가 없으면 실패합니다.
           """
   )
   @GetMapping("/{sessionId}/current-route")


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #186
- Branch: feat/#186

## 주요 내용

이번 PR은 "훈련 시작 검증 및 기본 경로를 시나리오 startNodeId 기준으로 연동"(#186) 요구사항을 하나씩 실제 코드로 재검증한 결과, **대부분 이미 충족되어 있음을 확인**하고 남은 문서 문구 하나만 정리한 PR입니다.

- `GET /api/v1/sessions/{sessionId}/current-route` Swagger 설명에 남아 있던 "도면 관리에서 발화층에 지정한 대표 START 노드를 기준으로 계산" 같은 폐기된 정책 문구 제거
- 실제로는 `evacuation-setup`에서 선택한 `scenario.startNode`를 기준으로 INITIAL/재탐색 경로가 계산된다는 사실대로 설명을 갱신하고, 두 경우 모두 경로의 첫 노드가 항상 시나리오의 `startNodeId`라는 점을 명시

## 확인만 하고 코드는 건드리지 않은 것 (근거 포함)

| 요구사항 | 확인 결과 |
|---|---|
| `/sessions/{id}/start`가 발화점·startNode 존재/타입/같은 층 검증 | 이미 구현되어 있음 (#184에서 markFired 이동 작업 때 이미 있던 검증 로직) |
| 발화점과 startNode가 같은 건물인지 재검증 | `evacuation-setup`에서 둘 다 `scenario.buildingId`와 비교해 저장하고, 설정 후 수정 API가 없어 저장 후 어긋날 방법이 구조적으로 없음 → `/start`에서 다시 검증해도 항상 참인 조건이라 추가하지 않음 |
| `current-route`(`source=INITIAL`) 첫 노드 = `scenario.startNodeId` | 이미 그렇게 동작 중이며 `RouteRecalculationServiceTest`에 기존 테스트로 검증되어 있음 |
| 재탐색 경로도 같은 startNode에서 시작 | `RouteRecalculationService`가 처음부터 `scenario.getStartNode()` 기준으로 작성되어 있었음 |
| 훈련 시작 실패 시 세션/시나리오/화재 셀 상태 롤백 | `TrainingSessionServiceTest`에 기존 케이스로 검증되어 있음 |

세션·경로 계산 쪽 코드는 애초에 "발화층 START 자동 선택"을 전제로 짜여 있지 않고 처음부터 `scenario.startNode` 기준이었기 때문에, #182(도면 관리 START 다중화)·#184(evacuation-setup 신설)만으로 이미 앞뒤가 맞는 상태였습니다.

## 프론트 영향

없음 (문서 문구만 수정, API 요청/응답 스펙 변경 없음).

## ✅ Check List

- [x] 테스트 통과 (전체 `./gradlew test` — 화재 확산, 재탐색 승인, current-route, IoT 유도등, 훈련 종료 초기화, 시나리오 CRUD 포함 회귀 전부 통과)
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?