### PR TITLE
[Feat] #188: 훈련 시나리오 DRAFT 임시 저장 및 READY 전환 구현

### DIFF
--- a/src/main/java/com/saferoute/domain/training/controller/ScenarioEvacuationSetupController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/ScenarioEvacuationSetupController.java
@@ -39,9 +39,13 @@ public class ScenarioEvacuationSetupController {
                     등록해 둔 NodeType.START 후보 노드 중 하나의 ID입니다. 이 API는 임의 좌표로
                     새 노드를 만들지 않으며, 두 값은 반드시 같은 층·같은 건물에 있어야 합니다.
 
-                    시나리오 상태가 READY가 아니거나, 이미 발화점·시작점 설정이 완료된
-                    시나리오에 다시 요청하면 실패합니다(409). 설정 후 수정·삭제 API는 제공하지
-                    않으므로, 값을 바꾸려면 시나리오를 새로 만들어야 합니다.
+                    시나리오 상태가 READY가 아니거나(작성이 아직 끝나지 않은 DRAFT 포함), 이미
+                    발화점·시작점 설정이 완료된 시나리오에 다시 요청하면 실패합니다(409). 설정
+                    후 수정·삭제 API는 제공하지 않으므로, 값을 바꾸려면 시나리오를 새로 만들어야
+                    합니다.
+
+                    DRAFT 시나리오는 POST /api/v1/scenarios/{scenarioId}/ready로 먼저 READY
+                    전환해야 이 API를 호출할 수 있습니다.
 
                     이 API는 FloorGridCell.isFired를 true로 바꾸지 않습니다. 발화점은 시나리오별
                     정적 설정이고, isFired는 실제 훈련 중에만 의미 있는 동적 상태이기 때문입니다.

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
@@ -1,6 +1,6 @@
 package com.saferoute.domain.training.controller;
 
-import com.saferoute.domain.training.dto.CreateScenarioRequest;
+import com.saferoute.domain.training.dto.CreateScenarioDraftRequest;
 import com.saferoute.domain.training.dto.FireZoneResponse;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
@@ -37,7 +37,9 @@ public class TrainingScenarioController {
     @Operation(
             summary = "훈련 시나리오 목록 조회",
             description = """
-                    요청자 학교 소속의 모든 훈련 시나리오를 생성일 최신순으로 반환합니다.
+                    요청자 학교 소속의 모든 훈련 시나리오를 생성일 최신순으로 반환합니다. 아직
+                    건물을 지정하지 않은 DRAFT 시나리오도 작성자(admin) 소속 기준으로 함께
+                    조회됩니다.
 
                     각 시나리오의 deletable은 해당 시나리오에 연결된 훈련 세션이 하나도 없을 때만
                     true입니다. 세션이 하나라도 있으면 과거 훈련 기록 보존을 위해 삭제가
@@ -45,8 +47,10 @@ public class TrainingScenarioController {
                     합니다. reportId는 해당 시나리오의 훈련 리포트가 이미 생성되어 있으면 그
                     id를, 아직 없으면 null을 반환합니다.
 
-                    status 필드는 연결된 세션의 생명주기에 따라 서버가 자동으로 갱신하는 값으로,
-                    이 API로 직접 변경할 수 없습니다.
+                    status 필드는 DRAFT/READY 사이는 이 도메인의 상태 전환 API(POST .../drafts,
+                    POST .../ready)로, 그 이후(IN_PROGRESS/COMPLETED/ERROR)는 연결된 세션의
+                    생명주기에 따라 서버가 자동으로 갱신합니다. 이 목록 조회 API로 직접 바꿀 수는
+                    없습니다.
                     """
     )
     @GetMapping
@@ -59,7 +63,8 @@ public class TrainingScenarioController {
             summary = "훈련 시나리오 단건 조회",
             description = """
                     요청자 학교 소속 시나리오 중 scenarioId에 해당하는 시나리오 상세 정보를
-                    반환합니다.
+                    반환합니다. DRAFT 시나리오는 건물이 없을 수 있어 작성자(admin) 소속 기준으로
+                    조회됩니다.
 
                     목록 조회와 달리 deletable, reportId 필드는 항상 null로 반환되므로 이 값은
                     목록 조회(GET /api/v1/scenarios) 결과를 사용해야 합니다.
@@ -74,33 +79,33 @@ public class TrainingScenarioController {
         return ResponseEntity.ok(scenarioService.getScenario(scenarioId, authentication.getName()));
     }
 
-    // POST /api/v1/scenarios
+    // POST /api/v1/scenarios/drafts
     @Operation(
-            summary = "훈련 시나리오 생성",
+            summary = "훈련 시나리오 DRAFT 생성",
             description = """
-                    새 훈련 시나리오를 생성합니다. buildingId, adminId는 모두 요청자와 같은
-                    학교 소속이어야 하며, 두 값 중 하나라도 조건을 만족하지 못하면 생성에 실패합니다.
+                    시나리오 작성 화면에 진입할 때 미완성 상태로 임시 저장합니다. name,
+                    buildingId, expectedParticipants, scheduledAt을 포함한 모든 필드가
+                    선택값이며, 비워 둔 필드는 null로 저장됩니다.
 
-                    fireSpreadSpeed를 지정하지 않으면 MEDIUM으로 기본 처리됩니다. 이 값은
-                    시나리오 전체에 하나로 적용되며(발화점별 개별 지정 불가), 훈련 시작 후 화재
-                    확산 시뮬레이션의 tick 간격을 결정합니다(FAST가 가장 빠르게 확산).
+                    작성자(admin)는 요청 바디로 받지 않고 JWT 인증 사용자로 고정됩니다.
+                    isTemplate을 지정하지 않으면 false, fireSpreadSpeed를 지정하지 않으면
+                    MEDIUM으로 기본 처리됩니다.
 
-                    startNodeId는 이 API로 받지 않습니다. 시나리오 설정 화면에서
-                    POST /api/v1/scenarios/{scenarioId}/evacuation-setup으로 발화점(격자 셀)과
-                    함께 START 후보 노드를 선택해야 시나리오에 연결됩니다. targetEvacuationSec도
-                    선택값입니다.
+                    buildingId를 지정하면 요청자와 같은 학교 소속 건물이어야 하며, 조건을
+                    만족하지 못하면 생성에 실패합니다.
 
-                    생성 직후 시나리오의 상태는 READY이지만 바로 실행할 수는 없습니다.
-                    evacuation-setup으로 발화점과 훈련 시작점이 함께 설정되어야 훈련을
-                    시작할 수 있습니다. 초안(DRAFT) 저장 플로우는 아직 지원하지 않습니다.
+                    생성 직후 상태는 DRAFT이며, 발화점·START 설정(evacuation-setup), 훈련
+                    세션 생성 등 훈련 실행과 관련된 API는 DRAFT 상태에서 모두 차단됩니다(409).
+                    PATCH /api/v1/scenarios/{scenarioId}로 나머지 필드를 채운 뒤
+                    POST /api/v1/scenarios/{scenarioId}/ready로 작성을 완료해야 합니다.
                     """
     )
-    @PostMapping
-    public ResponseEntity<ScenarioResponse> createScenario(
-            @Valid @RequestBody CreateScenarioRequest request,
+    @PostMapping("/drafts")
+    public ResponseEntity<ScenarioResponse> createDraft(
+            @Valid @RequestBody CreateScenarioDraftRequest request,
             Authentication authentication) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(scenarioService.createScenario(request, authentication.getName()));
+                .body(scenarioService.createDraft(request, authentication.getName()));
     }
 
     // PATCH /api/v1/scenarios/{scenarioId}
@@ -110,14 +115,13 @@ public class TrainingScenarioController {
                     요청 바디에 값이 채워진 필드만 부분 수정합니다. null인 필드는 기존 값을
                     그대로 유지하므로, 값을 지우고 싶다고 해서 null을 보내면 변경되지 않습니다.
 
-                    startNodeId는 이 API로 변경하지 않습니다. POST .../evacuation-setup으로
-                    설정한 값이 그대로 유지됩니다. buildingId, adminId, status는 이 API로
-                    변경할 수 없습니다.
+                    DRAFT/READY 상태에서만 수정할 수 있습니다. IN_PROGRESS/COMPLETED/ERROR
+                    상태의 시나리오를 수정하려 하면 409로 거부됩니다.
 
-                    시나리오의 status(READY/IN_PROGRESS/COMPLETED/ERROR)는 연결된 훈련
-                    세션의 생명주기에 따라 서버가 자동으로 전이시키는 값이라 이 API로는 건드릴
-                    수 없습니다. 이미 훈련 세션이 시작된 시나리오를 수정할 때의 부작용(예: 진행
-                    중인 세션과의 정합성) 검증은 이 API에 포함되어 있지 않습니다.
+                    buildingId는 이 API로 지정·변경할 수 있습니다(요청자와 같은 학교 소속
+                    건물이어야 함). adminId, status는 이 API로 변경할 수 없습니다. startNodeId도
+                    이 API로 변경하지 않으며, POST .../evacuation-setup으로 설정한 값이 그대로
+                    유지됩니다.
                     """
     )
     @PatchMapping("/{scenarioId}")
@@ -126,6 +130,31 @@ public class TrainingScenarioController {
             @Valid @RequestBody UpdateScenarioRequest request,
             Authentication authentication) {
         return ResponseEntity.ok(scenarioService.updateScenario(scenarioId, request, authentication.getName()));
+    }
+
+    // POST /api/v1/scenarios/{scenarioId}/ready
+    @Operation(
+            summary = "훈련 시나리오 작성 완료 (DRAFT → READY)",
+            description = """
+                    DRAFT 시나리오의 기본 정보 작성을 완료하고 READY로 전환합니다. DRAFT가
+                    아닌 시나리오에 호출하면 409(INVALID_STATUS_TRANSITION)로 거부됩니다.
+
+                    name, buildingId, expectedParticipants, scheduledAt, adminId,
+                    fireSpreadSpeed가 모두 채워져 있어야 하며(targetEvacuationSec은 선택값),
+                    하나라도 비어 있으면 400(TRAINING_SCENARIO_REQUIRED_FIELD_MISSING)과 함께
+                    result.missingFields에 누락된 필드 이름 목록을 반환합니다.
+
+                    이 API는 발화점(fire origin)이나 훈련 시작점(START 노드) 설정을 요구하지
+                    않습니다. READY 전환 이후 시나리오 설정 화면(재사용 캔버스)에서
+                    POST /api/v1/scenarios/{scenarioId}/evacuation-setup으로 별도로
+                    설정합니다.
+                    """
+    )
+    @PostMapping("/{scenarioId}/ready")
+    public ResponseEntity<ScenarioResponse> readyScenario(
+            @PathVariable UUID scenarioId,
+            Authentication authentication) {
+        return ResponseEntity.ok(scenarioService.readyScenario(scenarioId, authentication.getName()));
     }
 
     // DELETE /api/v1/scenarios/{scenarioId}

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -148,6 +148,9 @@ public class TrainingSessionController {
           신규 세션은 항상 SCHEDULED 상태와 startedAt=null로 생성됩니다. RUNNING 상태와
           실제 시작 시각은 시작 API(POST /api/v1/sessions/{sessionId}/start)를 호출할 때만
           서버가 설정합니다.
+
+          작성이 완료되지 않은(DRAFT) 시나리오에는 세션을 생성할 수 없습니다(409). 시나리오를
+          POST /api/v1/scenarios/{scenarioId}/ready로 먼저 READY 전환해야 합니다.
           """
   )
   @PostMapping("/{scenarioId}")

--- a/src/main/java/com/saferoute/domain/training/dto/CreateScenarioDraftRequest.java
+++ b/src/main/java/com/saferoute/domain/training/dto/CreateScenarioDraftRequest.java
@@ -1,8 +1,6 @@
 package com.saferoute.domain.training.dto;
 
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
@@ -11,34 +9,28 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+// DRAFT 생성 요청. 시나리오 작성 화면 진입 시 미완성 상태로 임시 저장하는 용도라 모든 필드가
+// 선택값이다. 작성자(admin)는 이 요청이 아니라 JWT 인증 사용자로 고정된다.
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateScenarioRequest {
+public class CreateScenarioDraftRequest {
 
-    @NotBlank
     @Size(min = 2, max = 20)
     private String name;
 
-    @NotNull
     private UUID buildingId;
 
-    @NotNull
     private Integer expectedParticipants;
 
-    // 훈련 리포트의 대피 시간 점수 산정 기준(초). 건물 규모에 따라 관리자가 지정
+    // 훈련 리포트의 대피 시간 점수 산정 기준(초). 값을 지정할 땐 양수여야 한다.
     @Positive
     private Integer targetEvacuationSec;
 
-    @NotNull
     private Instant scheduledAt;
 
     private Boolean isTemplate = false;
 
-    @NotNull
-    private UUID adminId;
-
     // 미지정 시 Service에서 MEDIUM으로 기본 처리
     private FireSpreadSpeed fireSpreadSpeed;
-
 }

--- a/src/main/java/com/saferoute/domain/training/dto/UpdateScenarioRequest.java
+++ b/src/main/java/com/saferoute/domain/training/dto/UpdateScenarioRequest.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.training.dto;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
 import jakarta.validation.constraints.Positive;
@@ -14,6 +15,8 @@ import lombok.NoArgsConstructor;
 public class UpdateScenarioRequest {
 
     private String name;
+    // DRAFT 작성 중 건물을 나중에 지정하거나 바꿀 때 사용한다. null이면 변경하지 않는다.
+    private UUID buildingId;
     private Integer expectedParticipants;
     // null이면 변경하지 않음(TrainingScenario.update() 참고). 값을 지정할 땐 양수여야 한다.
     @Positive

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -14,7 +14,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
@@ -37,13 +36,13 @@ public class TrainingScenario {
     @GeneratedValue
     private UUID id;
 
-    @NotBlank
+    // DRAFT는 아직 이름을 정하지 않았을 수 있어 null을 허용한다. READY 전환 시 필수값으로 검증한다.
     @Size(min = 2, max = 20)
-    @Column(nullable = false, length = 20)
+    @Column(length = 20)
     private String name;
 
-    @NotNull
-    @Column(name = "exp_participants", nullable = false)
+    // DRAFT는 참가 인원 미정 상태를 허용한다. READY 전환 시 필수값으로 검증한다.
+    @Column(name = "exp_participants")
     private Integer expectedParticipants;
 
     // 훈련 리포트의 "총 대피 시간" 항목 점수를 매길 때 기준이 되는 목표 대피 시간(초).
@@ -51,8 +50,8 @@ public class TrainingScenario {
     @Column(name = "target_evacuation_sec")
     private Integer targetEvacuationSec;
 
-    @NotNull
-    @Column(name = "scheduled_at", nullable = false)
+    // DRAFT는 훈련 일시 미정 상태를 허용한다. READY 전환 시 필수값으로 검증한다.
+    @Column(name = "scheduled_at")
     private Instant scheduledAt;
 
     @Column(name = "is_template", nullable = false)
@@ -71,8 +70,9 @@ public class TrainingScenario {
     @Column(name = "fire_spread_speed", nullable = false, length = 10)
     private FireSpreadSpeed fireSpreadSpeed;
 
+    // DRAFT는 건물 미지정 상태를 허용한다. READY 전환 시 필수값으로 검증한다.
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "building_id", nullable = false)
+    @JoinColumn(name = "building_id")
     private Building building;
 
     // 발화 위치를 등록하기 전에는 비어 있을 수 있다. FireZoneService가 발화 층의 START 노드를 연결한다.
@@ -93,6 +93,8 @@ public class TrainingScenario {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
+    // READY 상태로 직접 시작하는 시나리오 생성 (테스트 픽스처 및 하위 호환용).
+    // 실제 API 플로우는 createDraft()로 시작해 ready()로 전이한다.
     public static TrainingScenario create(String name,
                                           Integer expectedParticipants,
                                           Integer targetEvacuationSec,
@@ -112,9 +114,30 @@ public class TrainingScenario {
         scenario.building = building;
         scenario.admin = admin;
         scenario.startNode = startNode;
-        // 생성 직후 READY로 시작하지만, 도면 관리에서 발화점을 등록해 START 노드가
-        // 연결되기 전에는 훈련을 시작할 수 없다. DRAFT 저장 플로우는 아직 지원하지 않는다.
         scenario.status = ScenarioStatus.READY;
+        return scenario;
+    }
+
+    // 시나리오 작성 화면 진입 시 미완성 상태로 임시 저장한다. name/building/expectedParticipants/
+    // scheduledAt은 아직 비어 있을 수 있으며, READY 전환(ready()) 시 필수값으로 검증한다.
+    public static TrainingScenario createDraft(String name,
+                                                Integer expectedParticipants,
+                                                Integer targetEvacuationSec,
+                                                Instant scheduledAt,
+                                                Boolean isTemplate,
+                                                FireSpreadSpeed fireSpreadSpeed,
+                                                Building building,
+                                                User admin) {
+        TrainingScenario scenario = new TrainingScenario();
+        scenario.name = name;
+        scenario.expectedParticipants = expectedParticipants;
+        scenario.targetEvacuationSec = targetEvacuationSec;
+        scenario.scheduledAt = scheduledAt;
+        scenario.isTemplate = isTemplate != null ? isTemplate : false;
+        scenario.fireSpreadSpeed = fireSpreadSpeed != null ? fireSpreadSpeed : FireSpreadSpeed.MEDIUM;
+        scenario.building = building;
+        scenario.admin = admin;
+        scenario.status = ScenarioStatus.DRAFT;
         return scenario;
     }
 
@@ -124,14 +147,19 @@ public class TrainingScenario {
                        Instant scheduledAt,
                        Boolean isTemplate,
                        FireSpreadSpeed fireSpreadSpeed,
-                       MapNode startNode) {
+                       Building building) {
         if (name != null) this.name = name;
         if (expectedParticipants != null) this.expectedParticipants = expectedParticipants;
         if (targetEvacuationSec != null) this.targetEvacuationSec = targetEvacuationSec;
         if (scheduledAt != null) this.scheduledAt = scheduledAt;
         if (isTemplate != null) this.isTemplate = isTemplate;
         if (fireSpreadSpeed != null) this.fireSpreadSpeed = fireSpreadSpeed;
-        if (startNode != null) this.startNode = startNode;
+        if (building != null) this.building = building;
+    }
+
+    // DRAFT → READY 전이. 필수값 검증은 TrainingScenarioService가 담당한다.
+    public void markReady() {
+        this.status = ScenarioStatus.READY;
     }
 
     // 상태 전이 가드는 이 엔티티가 아니라 TrainingSessionService가 담당한다

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingScenarioRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingScenarioRepository.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TrainingScenarioRepository extends JpaRepository<TrainingScenario, UUID> {
-    List<TrainingScenario> findAllByBuilding_SchoolNameOrderByCreatedAtDesc(String schoolName);
+    List<TrainingScenario> findAllByAdmin_SchoolNameOrderByCreatedAtDesc(String schoolName);
 
-    Optional<TrainingScenario> findByIdAndBuilding_SchoolName(UUID id, String schoolName);
+    Optional<TrainingScenario> findByIdAndAdmin_SchoolName(UUID id, String schoolName);
 
     boolean existsByBuilding_Id(UUID buildingId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<TrainingScenario> findForUpdateByIdAndBuilding_SchoolName(UUID id, String schoolName);
+    Optional<TrainingScenario> findForUpdateByIdAndAdmin_SchoolName(UUID id, String schoolName);
 }

--- a/src/main/java/com/saferoute/domain/training/service/FireZoneService.java
+++ b/src/main/java/com/saferoute/domain/training/service/FireZoneService.java
@@ -43,7 +43,7 @@ public class FireZoneService {
 
     private void validateScenarioForSchool(UUID scenarioId, String email) {
         String schoolName = schoolContextService.getSchoolName(email);
-        if (scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, schoolName).isEmpty()) {
+        if (scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, schoolName).isEmpty()) {
             throw new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND);
         }
     }

--- a/src/main/java/com/saferoute/domain/training/service/ScenarioEvacuationSetupService.java
+++ b/src/main/java/com/saferoute/domain/training/service/ScenarioEvacuationSetupService.java
@@ -41,7 +41,7 @@ public class ScenarioEvacuationSetupService {
             UUID scenarioId, CreateScenarioEvacuationSetupRequest request, String email) {
         String schoolName = schoolContextService.getSchoolName(email);
         TrainingScenario scenario = scenarioRepository
-                .findForUpdateByIdAndBuilding_SchoolName(scenarioId, schoolName)
+                .findForUpdateByIdAndAdmin_SchoolName(scenarioId, schoolName)
                 .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND));
 
         if (scenario.getStatus() != ScenarioStatus.READY) {
@@ -83,7 +83,7 @@ public class ScenarioEvacuationSetupService {
     @Transactional(readOnly = true)
     public ScenarioEvacuationSetupResponse get(UUID scenarioId, String email) {
         String schoolName = schoolContextService.getSchoolName(email);
-        TrainingScenario scenario = scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, schoolName)
+        TrainingScenario scenario = scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, schoolName)
                 .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND));
 
         MapNode startNode = scenario.getStartNode();

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -2,9 +2,10 @@ package com.saferoute.domain.training.service;
 
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
-import com.saferoute.domain.training.dto.CreateScenarioRequest;
+import com.saferoute.domain.training.dto.CreateScenarioDraftRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
 import com.saferoute.domain.training.dto.UpdateScenarioRequest;
+import com.saferoute.domain.training.entity.ScenarioStatus;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.report.repository.TrainingReportRepository;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
@@ -16,6 +17,7 @@ import com.saferoute.global.api.error.BuildingErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.error.UserErrorCode;
 import com.saferoute.global.api.exception.ApiException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +43,7 @@ public class TrainingScenarioService {
     public List<ScenarioResponse> getScenarios(String email) {
         String schoolName = schoolContextService.getSchoolName(email);
         List<TrainingScenario> scenarios =
-                scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(schoolName);
+                scenarioRepository.findAllByAdmin_SchoolNameOrderByCreatedAtDesc(schoolName);
         if (scenarios.isEmpty()) {
             return List.of();
         }
@@ -67,15 +69,15 @@ public class TrainingScenarioService {
         return ScenarioResponse.from(findByIdAndEmail(id, email));
     }
 
-    // 생성
+    // DRAFT 생성. 미완성 필드를 허용하며, 작성자는 요청 바디가 아니라 JWT 인증 사용자로 고정된다.
     @Transactional
-    public ScenarioResponse createScenario(CreateScenarioRequest request, String email) {
+    public ScenarioResponse createDraft(CreateScenarioDraftRequest request, String email) {
         String schoolName = schoolContextService.getSchoolName(email);
-        Building building = buildingRepository.findByIdAndSchoolNameForUpdate(request.getBuildingId(), schoolName)
-                .orElseThrow(() -> new ApiException(BuildingErrorCode.BUILDING_NOT_FOUND));
-        User admin = userRepository.findByIdAndSchoolName(request.getAdminId(), schoolName)
+        User admin = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
-        TrainingScenario scenario = TrainingScenario.create(
+        Building building = resolveBuilding(request.getBuildingId(), schoolName);
+
+        TrainingScenario scenario = TrainingScenario.createDraft(
                 request.getName(),
                 request.getExpectedParticipants(),
                 request.getTargetEvacuationSec(),
@@ -83,16 +85,22 @@ public class TrainingScenarioService {
                 request.getIsTemplate(),
                 request.getFireSpreadSpeed(),
                 building,
-                admin,
-                null
+                admin
         );
         return ScenarioResponse.from(scenarioRepository.save(scenario));
     }
 
-    // 수정
+    // 부분 수정. DRAFT/READY 상태에서만 허용되며, 요청에 포함된 값만 반영한다.
     @Transactional
     public ScenarioResponse updateScenario(UUID id, UpdateScenarioRequest request, String email) {
-        TrainingScenario scenario = findByIdAndEmail(id, email);
+        String schoolName = schoolContextService.getSchoolName(email);
+        TrainingScenario scenario = scenarioRepository.findByIdAndAdmin_SchoolName(id, schoolName)
+                .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND));
+        if (!isEditable(scenario.getStatus())) {
+            throw new ApiException(TrainingErrorCode.INVALID_STATUS_TRANSITION);
+        }
+
+        Building building = resolveBuilding(request.getBuildingId(), schoolName);
         scenario.update(
                 request.getName(),
                 request.getExpectedParticipants(),
@@ -100,8 +108,27 @@ public class TrainingScenarioService {
                 request.getScheduledAt(),
                 request.getIsTemplate(),
                 request.getFireSpreadSpeed(),
-                null
+                building
         );
+        return ScenarioResponse.from(scenario);
+    }
+
+    // 작성 완료(DRAFT → READY). 필수값이 하나라도 비어 있으면 누락 필드 목록과 함께 거부한다.
+    @Transactional
+    public ScenarioResponse readyScenario(UUID id, String email) {
+        TrainingScenario scenario = findByIdAndEmail(id, email);
+        if (scenario.getStatus() != ScenarioStatus.DRAFT) {
+            throw new ApiException(TrainingErrorCode.INVALID_STATUS_TRANSITION);
+        }
+
+        List<String> missingFields = collectMissingRequiredFields(scenario);
+        if (!missingFields.isEmpty()) {
+            throw new ApiException(
+                    TrainingErrorCode.TRAINING_SCENARIO_REQUIRED_FIELD_MISSING,
+                    Map.of("missingFields", missingFields));
+        }
+
+        scenario.markReady();
         return ScenarioResponse.from(scenario);
     }
 
@@ -117,7 +144,42 @@ public class TrainingScenarioService {
 
     private TrainingScenario findByIdAndEmail(UUID id, String email) {
         String schoolName = schoolContextService.getSchoolName(email);
-        return scenarioRepository.findByIdAndBuilding_SchoolName(id, schoolName)
+        return scenarioRepository.findByIdAndAdmin_SchoolName(id, schoolName)
                 .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND));
+    }
+
+    private Building resolveBuilding(UUID buildingId, String schoolName) {
+        if (buildingId == null) {
+            return null;
+        }
+        return buildingRepository.findByIdAndSchoolNameForUpdate(buildingId, schoolName)
+                .orElseThrow(() -> new ApiException(BuildingErrorCode.BUILDING_NOT_FOUND));
+    }
+
+    private boolean isEditable(ScenarioStatus status) {
+        return status == ScenarioStatus.DRAFT || status == ScenarioStatus.READY;
+    }
+
+    private List<String> collectMissingRequiredFields(TrainingScenario scenario) {
+        List<String> missingFields = new ArrayList<>();
+        if (scenario.getName() == null) {
+            missingFields.add("name");
+        }
+        if (scenario.getBuildingId() == null) {
+            missingFields.add("buildingId");
+        }
+        if (scenario.getExpectedParticipants() == null) {
+            missingFields.add("expectedParticipants");
+        }
+        if (scenario.getScheduledAt() == null) {
+            missingFields.add("scheduledAt");
+        }
+        if (scenario.getAdminId() == null) {
+            missingFields.add("adminId");
+        }
+        if (scenario.getFireSpreadSpeed() == null) {
+            missingFields.add("fireSpreadSpeed");
+        }
+        return missingFields;
     }
 }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -101,6 +101,10 @@ public class TrainingScenarioService {
         }
 
         Building building = resolveBuilding(request.getBuildingId(), schoolName);
+        if (building != null && scenario.getStartNode() != null
+                && !building.getId().equals(scenario.getBuildingId())) {
+            throw new ApiException(TrainingErrorCode.SCENARIO_EVACUATION_SETUP_ALREADY_EXISTS);
+        }
         scenario.update(
                 request.getName(),
                 request.getExpectedParticipants(),
@@ -162,7 +166,7 @@ public class TrainingScenarioService {
 
     private List<String> collectMissingRequiredFields(TrainingScenario scenario) {
         List<String> missingFields = new ArrayList<>();
-        if (scenario.getName() == null) {
+        if (scenario.getName() == null || scenario.getName().isBlank()) {
             missingFields.add("name");
         }
         if (scenario.getBuildingId() == null) {

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -15,6 +15,7 @@ import com.saferoute.domain.training.dto.TrainingSessionListResponse;
 import com.saferoute.domain.training.dto.TrainingSessionResponse;
 import com.saferoute.domain.training.dto.TrainingSessionSummaryResponse;
 import com.saferoute.domain.training.dto.TrainingStatusResponse;
+import com.saferoute.domain.training.entity.ScenarioStatus;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -70,8 +71,14 @@ public class TrainingSessionService {
     if (user.getRole() != UserRole.MANAGER) {
       throw new ApiException(ErrorCode.FORBIDDEN);
     }
-    TrainingScenario scenario = trainingScenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, schoolName)
+    TrainingScenario scenario = trainingScenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, schoolName)
         .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SCENARIO_NOT_FOUND));
+
+    // 시나리오 작성이 아직 완료되지 않은(DRAFT) 상태에서는 발화점·START 설정 자체가
+    // 불가능하므로, 세션을 먼저 막아 이후의 evacuation-setup/훈련 시작 흐름도 함께 차단한다.
+    if (scenario.getStatus() == ScenarioStatus.DRAFT) {
+      throw new ApiException(TrainingErrorCode.SCENARIO_DRAFT_NOT_ALLOWED);
+    }
 
     if (trainingSessionRepository.existsByScenario_Id(scenarioId)) {
       throw new ApiException(TrainingErrorCode.SESSION_ALREADY_EXISTS);

--- a/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/TrainingErrorCode.java
@@ -24,7 +24,12 @@ public enum TrainingErrorCode implements BaseErrorCode {
     START_NODE_TYPE_INVALID(HttpStatus.CONFLICT, "TRAINING015", "대피 시작 노드의 유형은 START여야 합니다."),
     FIRE_ORIGIN_START_FLOOR_MISMATCH(HttpStatus.CONFLICT, "TRAINING016", "발화 위치와 대피 시작 노드는 같은 층이어야 합니다."),
     FIRE_ORIGIN_ALREADY_CONFIGURED(HttpStatus.CONFLICT, "TRAINING017", "이미 최초 발화점이 설정된 시나리오입니다."),
-    SCENARIO_EVACUATION_SETUP_ALREADY_EXISTS(HttpStatus.CONFLICT, "TRAINING018", "이미 발화점 및 시작점 설정이 완료된 시나리오입니다.");
+    SCENARIO_EVACUATION_SETUP_ALREADY_EXISTS(HttpStatus.CONFLICT, "TRAINING018", "이미 발화점 및 시작점 설정이 완료된 시나리오입니다."),
+    SCENARIO_DRAFT_NOT_ALLOWED(HttpStatus.CONFLICT, "TRAINING019", "작성이 완료되지 않은(DRAFT) 시나리오에서는 이 작업을 수행할 수 없습니다."),
+    TRAINING_SCENARIO_REQUIRED_FIELD_MISSING(
+            HttpStatus.BAD_REQUEST,
+            "TRAINING_SCENARIO_REQUIRED_FIELD_MISSING",
+            "시나리오 작성 완료에 필요한 값이 누락되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/saferoute/global/api/exception/ApiException.java
+++ b/src/main/java/com/saferoute/global/api/exception/ApiException.java
@@ -7,14 +7,25 @@ import lombok.Getter;
 public class ApiException extends RuntimeException {
 
     private final BaseErrorCode errorCode;
+    // 에러 응답 본문(ApiResponse.result)에 함께 실을 부가 정보. 대부분의 예외는 null이며,
+    // 누락 필드 목록처럼 클라이언트가 후속 처리에 필요한 데이터가 있을 때만 채운다.
+    private final Object result;
 
     public ApiException(BaseErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
+        this.result = null;
+    }
+
+    public ApiException(BaseErrorCode errorCode, Object result) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.result = result;
     }
 
     public ApiException(BaseErrorCode errorCode, Throwable cause) {
         super(errorCode.getMessage(), cause);
         this.errorCode = errorCode;
+        this.result = null;
     }
 }

--- a/src/main/java/com/saferoute/global/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/saferoute/global/api/exception/GlobalExceptionHandler.java
@@ -25,8 +25,8 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
-    public ResponseEntity<ApiResponse<Void>> handleApiException(ApiException exception) {
-        return response(exception.getErrorCode(), null);
+    public ResponseEntity<ApiResponse<Object>> handleApiException(ApiException exception) {
+        return response(exception.getErrorCode(), exception.getResult());
     }
 
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)

--- a/src/test/java/com/saferoute/domain/building/service/BuildingScenarioConcurrencyIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/building/service/BuildingScenarioConcurrencyIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.entity.BuildingType;
 import com.saferoute.domain.building.repository.BuildingRepository;
-import com.saferoute.domain.training.dto.CreateScenarioRequest;
+import com.saferoute.domain.training.dto.CreateScenarioDraftRequest;
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
 import com.saferoute.domain.training.service.TrainingScenarioService;
@@ -60,7 +60,7 @@ class BuildingScenarioConcurrencyIntegrationTest {
         try {
             Future<Void> creation = executor.submit(() -> {
                 transactionTemplate.executeWithoutResult(status -> {
-                    scenarioService.createScenario(fixture.request(), fixture.email());
+                    scenarioService.createDraft(fixture.request(), fixture.email());
                     scenarioCreated.countDown();
                     await(allowScenarioCommit);
                 });
@@ -116,7 +116,7 @@ class BuildingScenarioConcurrencyIntegrationTest {
             Future<ApiException> creation = executor.submit(() -> {
                 creationStarted.countDown();
                 try {
-                    scenarioService.createScenario(fixture.request(), fixture.email());
+                    scenarioService.createDraft(fixture.request(), fixture.email());
                     return null;
                 } catch (ApiException exception) {
                     return exception;
@@ -153,14 +153,13 @@ class BuildingScenarioConcurrencyIntegrationTest {
                 "서울특별시 성북구 안전로 1",
                 BuildingType.CLASSROOM,
                 schoolName));
-        CreateScenarioRequest request = new CreateScenarioRequest(
+        CreateScenarioDraftRequest request = new CreateScenarioDraftRequest(
                 "정기 훈련",
                 building.getId(),
                 50,
                 300,
                 Instant.now().plusSeconds(3600),
                 false,
-                admin.getId(),
                 FireSpreadSpeed.MEDIUM);
         return new Fixture(email, building.getId(), request);
     }
@@ -176,6 +175,6 @@ class BuildingScenarioConcurrencyIntegrationTest {
         }
     }
 
-    private record Fixture(String email, UUID buildingId, CreateScenarioRequest request) {
+    private record Fixture(String email, UUID buildingId, CreateScenarioDraftRequest request) {
     }
 }

--- a/src/test/java/com/saferoute/domain/training/service/FireZoneServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/FireZoneServiceTest.java
@@ -52,7 +52,7 @@ class FireZoneServiceTest {
     @Test
     @DisplayName("수동으로 지정한 최초 발화점만 조회한다")
     void getFireOrigins_returnsManualOriginsOnly() {
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(mock(TrainingScenario.class)));
         given(fireZoneRepository.findByScenario_IdAndIsManualAddTrue(scenarioId))
                 .willReturn(List.of(mock(FireZone.class)));
@@ -65,7 +65,7 @@ class FireZoneServiceTest {
     @Test
     @DisplayName("다른 학교 소속 시나리오의 발화점은 조회할 수 없다")
     void getFireOrigins_otherSchool_throws() {
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> fireZoneService.getFireOrigins(scenarioId, EMAIL))
@@ -77,7 +77,7 @@ class FireZoneServiceTest {
     @Test
     @DisplayName("시나리오의 전체 FireZone을 세대순으로 조회한다")
     void getFireZones_returnsAllOrderedBySpreadGeneration() {
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(mock(TrainingScenario.class)));
         given(fireZoneRepository.findByScenario_IdOrderBySpreadGenerationAscAddedAtAsc(scenarioId))
                 .willReturn(List.of(mock(FireZone.class), mock(FireZone.class)));
@@ -90,7 +90,7 @@ class FireZoneServiceTest {
     @Test
     @DisplayName("다른 학교 소속 시나리오의 화재구역은 조회할 수 없다")
     void getFireZones_otherSchool_throws() {
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> fireZoneService.getFireZones(scenarioId, EMAIL))

--- a/src/test/java/com/saferoute/domain/training/service/ScenarioEvacuationSetupServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/ScenarioEvacuationSetupServiceTest.java
@@ -81,7 +81,7 @@ class ScenarioEvacuationSetupServiceTest {
         request = new CreateScenarioEvacuationSetupRequest(gridCellId, startNodeId);
 
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        lenient().when(scenarioRepository.findForUpdateByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        lenient().when(scenarioRepository.findForUpdateByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .thenReturn(Optional.of(scenario));
         lenient().when(scenario.getStatus()).thenReturn(ScenarioStatus.READY);
         lenient().when(scenario.getId()).thenReturn(scenarioId);
@@ -135,7 +135,7 @@ class ScenarioEvacuationSetupServiceTest {
     @Test
     @DisplayName("다른 학교 소속 시나리오는 설정할 수 없다")
     void setup_otherSchool_throws() {
-        given(scenarioRepository.findForUpdateByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findForUpdateByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> scenarioEvacuationSetupService.setup(scenarioId, request, EMAIL))
@@ -294,7 +294,7 @@ class ScenarioEvacuationSetupServiceTest {
     @Test
     @DisplayName("설정 전 조회는 fireOrigin/startNode가 모두 null인 200 응답이다")
     void get_notConfigured_returnsNullFields() {
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
         given(scenario.getStartNode()).willReturn(null);
         given(fireZoneRepository.findByScenario_IdAndIsManualAddTrue(scenarioId)).willReturn(List.of());
@@ -311,7 +311,7 @@ class ScenarioEvacuationSetupServiceTest {
     @DisplayName("설정 후 조회는 발화점·시작점·좌표를 함께 반환한다")
     void get_configured_returnsFields() {
         stubNodeFixtureDetails();
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
         given(scenario.getStartNode()).willReturn(startNode);
         FireZone fireOrigin = mock(FireZone.class);
@@ -330,7 +330,7 @@ class ScenarioEvacuationSetupServiceTest {
     @Test
     @DisplayName("다른 학교 소속 시나리오의 설정은 조회할 수 없다")
     void get_otherSchool_throws() {
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> scenarioEvacuationSetupService.get(scenarioId, EMAIL))

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.training.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -10,9 +11,11 @@ import static org.mockito.Mockito.verify;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.report.repository.TrainingReportRepository;
-import com.saferoute.domain.training.dto.CreateScenarioRequest;
+import com.saferoute.domain.training.dto.CreateScenarioDraftRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
+import com.saferoute.domain.training.dto.UpdateScenarioRequest;
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
+import com.saferoute.domain.training.entity.ScenarioStatus;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.repository.TrainingScenarioRepository;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
@@ -23,6 +26,7 @@ import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -76,26 +80,154 @@ class TrainingScenarioServiceTest {
         return scenario;
     }
 
+    private TrainingScenario draftScenarioWithId(UUID id) {
+        TrainingScenario scenario = TrainingScenario.createDraft(
+                null, null, null, null, false, FireSpreadSpeed.MEDIUM, null, mock(User.class));
+        ReflectionTestUtils.setField(scenario, "id", id);
+        return scenario;
+    }
+
+    // === createDraft ===
+
     @Test
-    @DisplayName("startNodeId와 목표 대피 시간 없이 시나리오를 생성한다")
-    void createScenario_withoutStartNodeAndTarget_succeeds() {
-        UUID buildingId = UUID.randomUUID();
-        UUID adminId = UUID.randomUUID();
-        Building building = mock(Building.class);
+    @DisplayName("건물 없이 이름만 채운 DRAFT를 생성한다")
+    void createDraft_withoutBuilding_succeeds() {
+        CreateScenarioDraftRequest request = new CreateScenarioDraftRequest(
+                "2026년 4월 정기 훈련", null, null, null, null, false, FireSpreadSpeed.MEDIUM);
         User admin = mock(User.class);
-        CreateScenarioRequest request = new CreateScenarioRequest(
-                "정기 훈련", buildingId, 52, null, Instant.now(), false, adminId, FireSpreadSpeed.MEDIUM);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(buildingRepository.findByIdAndSchoolNameForUpdate(buildingId, SCHOOL_NAME))
-                .willReturn(Optional.of(building));
-        given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(admin));
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(admin));
         given(scenarioRepository.save(org.mockito.ArgumentMatchers.any(TrainingScenario.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
-        ScenarioResponse response = trainingScenarioService.createScenario(request, EMAIL);
+        ScenarioResponse response = trainingScenarioService.createDraft(request, EMAIL);
 
-        assertThat(response.getStartNodeId()).isNull();
-        assertThat(response.getTargetEvacuationSec()).isNull();
+        assertThat(response.getStatus()).isEqualTo(ScenarioStatus.DRAFT);
+        assertThat(response.getBuildingId()).isNull();
+        verify(buildingRepository, never()).findByIdAndSchoolNameForUpdate(any(), any());
+    }
+
+    @Test
+    @DisplayName("buildingId를 포함한 DRAFT를 생성하면 학교 소속 건물을 조회해 연결한다")
+    void createDraft_withBuilding_resolvesBuilding() {
+        UUID buildingId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        User admin = mock(User.class);
+        CreateScenarioDraftRequest request = new CreateScenarioDraftRequest(
+                null, buildingId, null, null, null, false, null);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(admin));
+        given(buildingRepository.findByIdAndSchoolNameForUpdate(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(building));
+        given(building.getId()).willReturn(buildingId);
+        given(scenarioRepository.save(org.mockito.ArgumentMatchers.any(TrainingScenario.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        ScenarioResponse response = trainingScenarioService.createDraft(request, EMAIL);
+
+        assertThat(response.getBuildingId()).isEqualTo(buildingId);
+    }
+
+    // === updateScenario ===
+
+    @Test
+    @DisplayName("DRAFT 시나리오는 buildingId를 포함해 부분 수정할 수 있다")
+    void updateScenario_draftScenario_allowsBuildingIdChange() {
+        UUID scenarioId = UUID.randomUUID();
+        UUID buildingId = UUID.randomUUID();
+        TrainingScenario scenario = draftScenarioWithId(scenarioId);
+        Building building = mock(Building.class);
+        UpdateScenarioRequest request = new UpdateScenarioRequest(
+                "이름 채우기", buildingId, 30, null, Instant.now(), null, null);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+        given(buildingRepository.findByIdAndSchoolNameForUpdate(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(building));
+        given(building.getId()).willReturn(buildingId);
+
+        ScenarioResponse response = trainingScenarioService.updateScenario(scenarioId, request, EMAIL);
+
+        assertThat(response.getName()).isEqualTo("이름 채우기");
+        assertThat(response.getBuildingId()).isEqualTo(buildingId);
+    }
+
+    @Test
+    @DisplayName("IN_PROGRESS 시나리오는 수정할 수 없다")
+    void updateScenario_inProgressScenario_throws() {
+        UUID scenarioId = UUID.randomUUID();
+        TrainingScenario scenario = scenarioWithId(scenarioId);
+        scenario.markInProgress();
+        UpdateScenarioRequest request = new UpdateScenarioRequest(
+                "변경 시도", null, null, null, null, null, null);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+
+        assertThatThrownBy(() -> trainingScenarioService.updateScenario(scenarioId, request, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.INVALID_STATUS_TRANSITION);
+    }
+
+    // === readyScenario ===
+
+    @Test
+    @DisplayName("필수값이 모두 채워진 DRAFT는 READY로 전환된다")
+    void readyScenario_allRequiredFieldsPresent_transitionsToReady() {
+        UUID scenarioId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        given(building.getId()).willReturn(UUID.randomUUID());
+        User admin = mock(User.class);
+        given(admin.getId()).willReturn(UUID.randomUUID());
+        TrainingScenario scenario = TrainingScenario.create(
+                "테스트 시나리오", 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null);
+        ReflectionTestUtils.setField(scenario, "id", scenarioId);
+        ReflectionTestUtils.setField(scenario, "status", ScenarioStatus.DRAFT);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+
+        ScenarioResponse response = trainingScenarioService.readyScenario(scenarioId, EMAIL);
+
+        assertThat(response.getStatus()).isEqualTo(ScenarioStatus.READY);
+    }
+
+    @Test
+    @DisplayName("필수값이 비어 있는 DRAFT는 누락 필드 목록과 함께 READY 전환이 거부된다")
+    void readyScenario_missingRequiredFields_throwsWithMissingFieldList() {
+        UUID scenarioId = UUID.randomUUID();
+        TrainingScenario scenario = draftScenarioWithId(scenarioId);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+
+        assertThatThrownBy(() -> trainingScenarioService.readyScenario(scenarioId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .satisfies(exception -> {
+                    ApiException apiException = (ApiException) exception;
+                    assertThat(apiException.getErrorCode())
+                            .isEqualTo(TrainingErrorCode.TRAINING_SCENARIO_REQUIRED_FIELD_MISSING);
+                    @SuppressWarnings("unchecked")
+                    Map<String, List<String>> result = (Map<String, List<String>>) apiException.getResult();
+                    assertThat(result.get("missingFields"))
+                            .contains("name", "buildingId", "expectedParticipants", "scheduledAt");
+                });
+    }
+
+    @Test
+    @DisplayName("이미 READY인 시나리오는 다시 READY 전환할 수 없다")
+    void readyScenario_alreadyReady_throws() {
+        UUID scenarioId = UUID.randomUUID();
+        TrainingScenario scenario = scenarioWithId(scenarioId);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+
+        assertThatThrownBy(() -> trainingScenarioService.readyScenario(scenarioId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.INVALID_STATUS_TRANSITION);
     }
 
     // === getScenarios (deletable) ===
@@ -106,7 +238,7 @@ class TrainingScenarioServiceTest {
         UUID scenarioId = UUID.randomUUID();
         TrainingScenario scenario = scenarioWithId(scenarioId);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
+        given(scenarioRepository.findAllByAdmin_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
                 .willReturn(List.of(scenario));
         given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
                 .willReturn(Set.of());
@@ -125,7 +257,7 @@ class TrainingScenarioServiceTest {
         UUID scenarioId = UUID.randomUUID();
         TrainingScenario scenario = scenarioWithId(scenarioId);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
+        given(scenarioRepository.findAllByAdmin_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
                 .willReturn(List.of(scenario));
         given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
                 .willReturn(Set.of(scenarioId));
@@ -145,7 +277,7 @@ class TrainingScenarioServiceTest {
         String reportId = "abc123XYZ0";
         TrainingScenario scenario = scenarioWithId(scenarioId);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
+        given(scenarioRepository.findAllByAdmin_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
                 .willReturn(List.of(scenario));
         given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
                 .willReturn(Set.of(scenarioId));
@@ -164,7 +296,7 @@ class TrainingScenarioServiceTest {
         UUID scenarioId = UUID.randomUUID();
         TrainingScenario scenario = scenarioWithId(scenarioId);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
+        given(scenarioRepository.findAllByAdmin_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
                 .willReturn(List.of(scenario));
         given(trainingSessionRepository.findScenarioIdsWithAnySession(List.of(scenarioId)))
                 .willReturn(Set.of());
@@ -195,7 +327,7 @@ class TrainingScenarioServiceTest {
     @DisplayName("시나리오가 하나도 없으면 세션/리포트 조회 없이 빈 목록을 반환한다")
     void getScenarios_noScenarios_returnsEmptyListWithoutQueryingSessions() {
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(scenarioRepository.findAllByBuilding_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
+        given(scenarioRepository.findAllByAdmin_SchoolNameOrderByCreatedAtDesc(SCHOOL_NAME))
                 .willReturn(List.of());
 
         List<ScenarioResponse> responses = trainingScenarioService.getScenarios(EMAIL);
@@ -213,7 +345,7 @@ class TrainingScenarioServiceTest {
         UUID scenarioId = UUID.randomUUID();
         TrainingScenario scenario = scenarioWithId(scenarioId);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
         given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(false);
 
@@ -228,7 +360,7 @@ class TrainingScenarioServiceTest {
         UUID scenarioId = UUID.randomUUID();
         TrainingScenario scenario = scenarioWithId(scenarioId);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(scenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
         given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(true);
 

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.report.repository.TrainingReportRepository;
 import com.saferoute.domain.training.dto.CreateScenarioDraftRequest;
 import com.saferoute.domain.training.dto.ScenarioResponse;
@@ -170,6 +171,61 @@ class TrainingScenarioServiceTest {
                 .isEqualTo(TrainingErrorCode.INVALID_STATUS_TRANSITION);
     }
 
+    @Test
+    @DisplayName("발화점·START 설정이 완료된 시나리오는 다른 건물로 변경할 수 없다")
+    void updateScenario_setupCompleted_rejectsDifferentBuilding() {
+        UUID scenarioId = UUID.randomUUID();
+        UUID currentBuildingId = UUID.randomUUID();
+        UUID newBuildingId = UUID.randomUUID();
+        Building currentBuilding = mock(Building.class);
+        given(currentBuilding.getId()).willReturn(currentBuildingId);
+        MapNode startNode = mock(MapNode.class);
+        TrainingScenario scenario = TrainingScenario.create(
+                "테스트 시나리오", 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM,
+                currentBuilding, mock(User.class), startNode);
+        ReflectionTestUtils.setField(scenario, "id", scenarioId);
+        Building newBuilding = mock(Building.class);
+        given(newBuilding.getId()).willReturn(newBuildingId);
+        UpdateScenarioRequest request = new UpdateScenarioRequest(
+                null, newBuildingId, null, null, null, null, null);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+        given(buildingRepository.findByIdAndSchoolNameForUpdate(newBuildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(newBuilding));
+
+        assertThatThrownBy(() -> trainingScenarioService.updateScenario(scenarioId, request, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.SCENARIO_EVACUATION_SETUP_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("발화점·START 설정이 완료된 시나리오도 같은 건물로 재지정하는 수정은 허용된다")
+    void updateScenario_setupCompleted_allowsSameBuilding() {
+        UUID scenarioId = UUID.randomUUID();
+        UUID buildingId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        given(building.getId()).willReturn(buildingId);
+        MapNode startNode = mock(MapNode.class);
+        TrainingScenario scenario = TrainingScenario.create(
+                "테스트 시나리오", 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM,
+                building, mock(User.class), startNode);
+        ReflectionTestUtils.setField(scenario, "id", scenarioId);
+        UpdateScenarioRequest request = new UpdateScenarioRequest(
+                "이름만 변경", buildingId, null, null, null, null, null);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+        given(buildingRepository.findByIdAndSchoolNameForUpdate(buildingId, SCHOOL_NAME))
+                .willReturn(Optional.of(building));
+
+        ScenarioResponse response = trainingScenarioService.updateScenario(scenarioId, request, EMAIL);
+
+        assertThat(response.getName()).isEqualTo("이름만 변경");
+        assertThat(response.getBuildingId()).isEqualTo(buildingId);
+    }
+
     // === readyScenario ===
 
     @Test
@@ -212,6 +268,34 @@ class TrainingScenarioServiceTest {
                     Map<String, List<String>> result = (Map<String, List<String>>) apiException.getResult();
                     assertThat(result.get("missingFields"))
                             .contains("name", "buildingId", "expectedParticipants", "scheduledAt");
+                });
+    }
+
+    @Test
+    @DisplayName("공백만 있는 이름은 채워진 것으로 보지 않고 READY 전환을 거부한다")
+    void readyScenario_blankName_treatedAsMissing() {
+        UUID scenarioId = UUID.randomUUID();
+        Building building = mock(Building.class);
+        given(building.getId()).willReturn(UUID.randomUUID());
+        User admin = mock(User.class);
+        given(admin.getId()).willReturn(UUID.randomUUID());
+        TrainingScenario scenario = TrainingScenario.create(
+                "  ", 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null);
+        ReflectionTestUtils.setField(scenario, "id", scenarioId);
+        ReflectionTestUtils.setField(scenario, "status", ScenarioStatus.DRAFT);
+        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+
+        assertThatThrownBy(() -> trainingScenarioService.readyScenario(scenarioId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .satisfies(exception -> {
+                    ApiException apiException = (ApiException) exception;
+                    assertThat(apiException.getErrorCode())
+                            .isEqualTo(TrainingErrorCode.TRAINING_SCENARIO_REQUIRED_FIELD_MISSING);
+                    @SuppressWarnings("unchecked")
+                    Map<String, List<String>> result = (Map<String, List<String>>) apiException.getResult();
+                    assertThat(result.get("missingFields")).containsExactly("name");
                 });
     }
 

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -192,7 +192,7 @@ class TrainingSessionServiceTest {
         given(manager.getRole()).willReturn(UserRole.MANAGER);
         given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
         TrainingScenario scenario = mock(TrainingScenario.class);
-        given(trainingScenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(trainingScenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
         given(trainingSessionRepository.saveAndFlush(any(TrainingSession.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
@@ -208,6 +208,29 @@ class TrainingSessionServiceTest {
     }
 
     @Test
+    @DisplayName("작성이 완료되지 않은(DRAFT) 시나리오로는 세션을 생성할 수 없다")
+    void create_draftScenario_throwsScenarioDraftNotAllowed() {
+        UUID adminId = UUID.randomUUID();
+        UUID scenarioId = UUID.randomUUID();
+        User manager = mock(User.class);
+        given(manager.getRole()).willReturn(UserRole.MANAGER);
+        given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getStatus()).willReturn(com.saferoute.domain.training.entity.ScenarioStatus.DRAFT);
+        given(trainingScenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
+                .willReturn(Optional.of(scenario));
+
+        CreateSessionRequest request = new CreateSessionRequest(adminId);
+
+        assertThatThrownBy(() -> trainingSessionService.create(request, scenarioId, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(TrainingErrorCode.SCENARIO_DRAFT_NOT_ALLOWED);
+        verify(trainingSessionRepository, never()).existsByScenario_Id(any());
+        verify(trainingSessionRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
     @DisplayName("이미 세션이 존재하는 시나리오로는 세션을 또 생성할 수 없다")
     void create_scenarioAlreadyHasSession_throwsException() {
         UUID adminId = UUID.randomUUID();
@@ -215,7 +238,7 @@ class TrainingSessionServiceTest {
         User manager = mock(User.class);
         given(manager.getRole()).willReturn(UserRole.MANAGER);
         given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
-        given(trainingScenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(trainingScenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(mock(TrainingScenario.class)));
         given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(true);
 
@@ -236,7 +259,7 @@ class TrainingSessionServiceTest {
         User manager = mock(User.class);
         given(manager.getRole()).willReturn(UserRole.MANAGER);
         given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
-        given(trainingScenarioRepository.findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+        given(trainingScenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(mock(TrainingScenario.class)));
         given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(false);
         given(trainingSessionRepository.saveAndFlush(any()))
@@ -260,7 +283,7 @@ class TrainingSessionServiceTest {
         given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME))
                 .willReturn(Optional.of(manager));
         given(trainingScenarioRepository
-                .findByIdAndBuilding_SchoolName(scenarioId, SCHOOL_NAME))
+                .findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.empty());
         CreateSessionRequest request = new CreateSessionRequest(adminId);
 

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -192,6 +192,7 @@ class TrainingSessionServiceTest {
         given(manager.getRole()).willReturn(UserRole.MANAGER);
         given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
         TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getStatus()).willReturn(com.saferoute.domain.training.entity.ScenarioStatus.READY);
         given(trainingScenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
         given(trainingSessionRepository.saveAndFlush(any(TrainingSession.class)))
@@ -238,8 +239,10 @@ class TrainingSessionServiceTest {
         User manager = mock(User.class);
         given(manager.getRole()).willReturn(UserRole.MANAGER);
         given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getStatus()).willReturn(com.saferoute.domain.training.entity.ScenarioStatus.READY);
         given(trainingScenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
-                .willReturn(Optional.of(mock(TrainingScenario.class)));
+                .willReturn(Optional.of(scenario));
         given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(true);
 
         CreateSessionRequest request = new CreateSessionRequest(adminId);
@@ -259,8 +262,10 @@ class TrainingSessionServiceTest {
         User manager = mock(User.class);
         given(manager.getRole()).willReturn(UserRole.MANAGER);
         given(userRepository.findByIdAndSchoolName(adminId, SCHOOL_NAME)).willReturn(Optional.of(manager));
+        TrainingScenario scenario = mock(TrainingScenario.class);
+        given(scenario.getStatus()).willReturn(com.saferoute.domain.training.entity.ScenarioStatus.READY);
         given(trainingScenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
-                .willReturn(Optional.of(mock(TrainingScenario.class)));
+                .willReturn(Optional.of(scenario));
         given(trainingSessionRepository.existsByScenario_Id(scenarioId)).willReturn(false);
         given(trainingSessionRepository.saveAndFlush(any()))
                 .willThrow(new org.springframework.dao.DataIntegrityViolationException("unique constraint"));


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #188
- Branch: feat/#188

## 주요 내용

- 시나리오 작성 화면에서 미완성 데이터를 임시 저장할 수 있도록 `ScenarioStatus.DRAFT`를 지원합니다.
- `POST /api/v1/scenarios/drafts`: name/buildingId/expectedParticipants/scheduledAt이 모두 비어 있어도 DRAFT로 생성됩니다. 작성자(admin)는 요청 바디가 아니라 JWT 인증 사용자로 고정됩니다. isTemplate 미지정 시 false, fireSpreadSpeed 미지정 시 MEDIUM으로 기본 처리됩니다.
- `PATCH /api/v1/scenarios/{scenarioId}`: DRAFT/READY 상태에서만 부분 수정을 허용합니다(IN_PROGRESS/COMPLETED/ERROR는 409). buildingId도 이 API로 지정·변경할 수 있도록 필드를 추가했습니다.
- `POST /api/v1/scenarios/{scenarioId}/ready`: DRAFT → READY 전환입니다. name/buildingId/expectedParticipants/scheduledAt/adminId/fireSpreadSpeed가 모두 채워져 있어야 하며(targetEvacuationSec은 선택), 하나라도 비어 있으면 `400 TRAINING_SCENARIO_REQUIRED_FIELD_MISSING`과 함께 `result.missingFields`로 누락 필드 이름 목록을 반환합니다. 이 단계에서는 발화점·START 설정을 요구하지 않습니다.
- **[Breaking] 기존 `POST /api/v1/scenarios`(즉시 READY 생성) 엔드포인트를 제거**하고 DRAFT 우선 플로우로 대체했습니다. 프론트는 `POST /api/v1/scenarios/drafts` → (필요시 PATCH) → `POST /api/v1/scenarios/{scenarioId}/ready` 순서로 호출을 교체해야 합니다.
- `GET /api/v1/scenarios`, `GET /api/v1/scenarios/{scenarioId}`: DRAFT는 building이 없을 수 있어, 학교 소속 검증 기준을 building에서 작성자(admin) 기준으로 변경했습니다(READY 이상도 동일 쿼리로 통합 — building이 지정되면 항상 admin과 같은 학교이므로 안전합니다).
- DRAFT 시나리오에서의 기능 제한
  - 발화점·START 설정(`POST .../evacuation-setup`): 기존 "READY가 아니면 409" 검증이 DRAFT도 그대로 걸러냅니다.
  - 훈련 세션 생성(`POST /api/v1/sessions/{scenarioId}`): DRAFT 시나리오에 대해 명시적으로 `409 SCENARIO_DRAFT_NOT_ALLOWED`를 반환하도록 추가했습니다.
  - current-route 조회 / 훈련 시작 / 재탐색 / 리포트 생성: 세션 자체가 생성될 수 없으므로 별도 분기 없이 자연히 차단됩니다.
- 세션 관련 기존 DTO/API 경로/응답 구조는 변경하지 않았습니다(세션 생성 시 DRAFT 차단 분기만 추가).
- 상태 전이는 DRAFT→READY(ready API), READY→IN_PROGRESS→COMPLETED/ERROR(세션 생명주기)만 허용되며, READY→DRAFT / COMPLETED→READY / ERROR→READY로 되돌리는 API는 제공하지 않습니다.

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 시나리오를 DRAFT로 임시 저장한 뒤 READY로 전환하는 2단계 작성 흐름을 제공합니다.
  * DRAFT 작성 중 시나리오의 선택 정보와 건물 정보를 나중에 지정하거나 수정할 수 있습니다.
  * 시나리오 작성 완료에 필요한 필드가 누락된 경우 안내하는 오류 응답을 제공합니다.

* **변경 사항**
  * 시나리오 목록과 접근 권한을 작성자 소속 학교 기준으로 확인합니다.
  * DRAFT 상태 시나리오로는 훈련 세션 생성 및 대피 설정을 진행할 수 없습니다.
  * 관련 API 문서와 오류 응답에 상태별 이용 조건을 명확히 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->