### PR TITLE
[Feat] #181: CCTV 현재 혼잡 상태 갱신 정책 정리 및 조회 API 추가

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -14,10 +14,8 @@ import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationS
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
-import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
 import com.saferoute.domain.telemetry.dynamo.entity.EventProcessingStatus;
 import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
-import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -47,7 +45,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class CongestionEventService {
 
     private final CongestionEventRepository congestionEventRepository;
-    private final CurrentCctvStateRepository currentCctvStateRepository;
     private final TrainingSessionRepository trainingSessionRepository;
     private final CctvGridCellRepository cctvGridCellRepository;
     private final MapEdgeGridCellRepository mapEdgeGridCellRepository;
@@ -106,7 +103,9 @@ public class CongestionEventService {
 
         try {
             List<MapEdge> affectedEdges = resolveAffectedEdges(cctv.getId());
-            updateCurrentState(session.getId(), cctv.getCode(), request, saveResult.item());
+            // 현재 상태(CurrentCctvStateItem)는 5초 주기 Observation만을 기준 데이터로 삼는다.
+            // 즉시 이벤트는 여기서 상태를 갱신하지 않고 타임라인/재탐색 트리거/WebSocket 발행에만 쓰인다
+            // (CongestionObservationService.updateCurrentState 참고).
 
             CongestionLevel savedLevel = saveResult.item().getCongestionLevel();
             RecalculationTriggerType triggerType = mapTriggerType(saveResult.item().getEventType());
@@ -168,24 +167,6 @@ public class CongestionEventService {
         }
         return congestionEventRepository.updateEventStatus(
                 item.getEventId(), current, EventProcessingStatus.PROCESSING);
-    }
-
-    private void updateCurrentState(
-            UUID sessionId, String cctvCode, ReportCongestionEventRequest request, CongestionEventItem item
-    ) {
-        CurrentCctvStateItem stateItem = CurrentCctvStateItem.create(
-                sessionId,
-                cctvCode,
-                request.headcount(),
-                item.getDensity(),
-                item.getCongestionLevel(),
-                request.detectedAt(),
-                request.configVersion()
-        );
-        // 오래된 이벤트가 최신 상태를 덮어쓰지 않도록 조건부 갱신 (detectedAt 기준). 실패해도 이벤트 저장 자체는 유지한다.
-        if (!currentCctvStateRepository.updateIfLatest(stateItem)) {
-            log.debug("더 최신 상태가 있어 CCTV 현재 상태 갱신을 건너뜀: cctvCode={}", cctvCode);
-        }
     }
 
     private void validateEventIdentity(

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -173,8 +173,8 @@ public class CongestionObservationService {
         CurrentCctvStateItem stateItem = CurrentCctvStateItem.create(
                 sessionId,
                 cctvCode,
-                request.avgHeadcount(),
-                request.peakHeadcount(),
+                item.getAvgHeadcount(),
+                item.getPeakHeadcount(),
                 item.getDensity(),
                 item.getCongestionLevel(),
                 request.capturedAt(),

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -173,7 +173,8 @@ public class CongestionObservationService {
         CurrentCctvStateItem stateItem = CurrentCctvStateItem.create(
                 sessionId,
                 cctvCode,
-                (int) Math.round(request.avgHeadcount()),
+                request.avgHeadcount(),
+                request.peakHeadcount(),
                 item.getDensity(),
                 item.getCongestionLevel(),
                 request.capturedAt(),

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/CurrentCctvStateItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/CurrentCctvStateItem.java
@@ -13,7 +13,8 @@ public class CurrentCctvStateItem {
     private String sk;
     private String trainingSessionId;
     private String cctvCode;
-    private Integer headcount;
+    private Double avgHeadcount;
+    private Integer peakHeadcount;
     private Double density;
     private CongestionLevel congestionLevel;
     private Long lastDetectedAt;
@@ -22,10 +23,13 @@ public class CurrentCctvStateItem {
     public CurrentCctvStateItem() {
     }
 
+    // 기준 데이터는 5초 주기 Observation으로 통일한다 - 즉시 혼잡 이벤트(CongestionEventService)는
+    // 더 이상 이 아이템을 직접 갱신하지 않는다 (이벤트 타임라인/재탐색 트리거/WebSocket 알림 용도로만 쓰임).
     public static CurrentCctvStateItem create(
             UUID trainingSessionId,
             String cctvCode,
-            Integer headcount,
+            Double avgHeadcount,
+            Integer peakHeadcount,
             Double density,
             CongestionLevel congestionLevel,
             long lastDetectedAt,
@@ -34,7 +38,8 @@ public class CurrentCctvStateItem {
         CurrentCctvStateItem item = new CurrentCctvStateItem();
         item.trainingSessionId = trainingSessionId.toString();
         item.cctvCode = cctvCode;
-        item.headcount = headcount;
+        item.avgHeadcount = avgHeadcount;
+        item.peakHeadcount = peakHeadcount;
         item.density = density;
         item.congestionLevel = congestionLevel;
         item.lastDetectedAt = lastDetectedAt;
@@ -66,8 +71,11 @@ public class CurrentCctvStateItem {
     public String getCctvCode() { return cctvCode; }
     public void setCctvCode(String cctvCode) { this.cctvCode = cctvCode; }
 
-    public Integer getHeadcount() { return headcount; }
-    public void setHeadcount(Integer headcount) { this.headcount = headcount; }
+    public Double getAvgHeadcount() { return avgHeadcount; }
+    public void setAvgHeadcount(Double avgHeadcount) { this.avgHeadcount = avgHeadcount; }
+
+    public Integer getPeakHeadcount() { return peakHeadcount; }
+    public void setPeakHeadcount(Integer peakHeadcount) { this.peakHeadcount = peakHeadcount; }
 
     public Double getDensity() { return density; }
     public void setDensity(Double density) { this.density = density; }

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -1,5 +1,7 @@
 package com.saferoute.domain.training.controller;
 
+import com.saferoute.domain.training.dto.CurrentCctvStateListApiResponse;
+import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListApiResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListApiResponse;
@@ -30,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(
         name = "훈련 모니터링",
-        description = "실행 중인 훈련의 카메라별 최신 주기 캡처 조회 API"
+        description = "실행 중인 훈련의 카메라별 최신 주기 캡처, CCTV별 현재 혼잡 상태, 프레임, 이벤트 타임라인 조회 API"
 )
 @RestController
 @RequestMapping("/api/v1/sessions/{sessionId}/monitoring")
@@ -209,6 +211,176 @@ public class TrainingMonitoringController {
                 trainingMonitoringService.getCameras(sessionId, authentication.getName());
         return ResponseEntity.ok(ApiResponse.success(
                 TrainingSuccessCode.MONITORING_CAMERA_LIST_FOUND,
+                response
+        ));
+    }
+
+    @Operation(
+            summary = "CCTV별 현재 혼잡 상태 조회",
+            description = """
+                    실행 중인 훈련 세션의 건물에 설치된 활성 CCTV별 현재 혼잡 상태를 반환합니다.
+
+                    기준 데이터는 5초 주기 Observation입니다. 혼잡 시작/상승/해소 즉시 이벤트는
+                    이 상태를 갱신하지 않으며, 이벤트 타임라인(GET /monitoring/events)과 WebSocket
+                    알림에만 반영됩니다.
+
+                    avgHeadcount는 최근 5초 관측 구간의 평균 인원, peakHeadcount는 같은 구간의
+                    순간 최대 인원입니다. density와 congestionLevel은 서버가 계산한 값을 그대로
+                    반환합니다.
+
+                    아직 상태가 없는 CCTV도 목록에서 누락되지 않고 avgHeadcount 등이 모두 null인
+                    상태로 포함되며, 이때 stale은 항상 true입니다. 마지막 관측(lastDetectedAt) 이후
+                    설정된 stateStaleAfterSec가 지난 CCTV도 stale이 true로 반환되므로, 클라이언트는
+                    congestionLevel이 남아있더라도 stale이 true면 이를 NORMAL이 아니라 '정보 없음/
+                    오래됨'으로 표시해야 합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "CCTV별 현재 혼잡 상태 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    implementation = CurrentCctvStateListApiResponse.class
+                            ),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "상태가 있는 CCTV",
+                                            value = """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "TRAINING_SUCCESS_010",
+                                                      "message": "CCTV 현재 혼잡 상태 조회에 성공했습니다.",
+                                                      "result": {
+                                                        "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                                        "observedAt": 1787722095000,
+                                                        "states": [
+                                                          {
+                                                            "cctvId": "67b86e33-7874-494c-855f-e591e7847c09",
+                                                            "cctvCode": "CCTV_001",
+                                                            "cctvName": "CAM-1",
+                                                            "buildingName": "A동",
+                                                            "floorName": "3층",
+                                                            "location": "A동 3층",
+                                                            "avgHeadcount": 8.6,
+                                                            "peakHeadcount": 12,
+                                                            "density": 0.42,
+                                                            "congestionLevel": "CROWDED",
+                                                            "lastDetectedAt": 1787722095000,
+                                                            "stale": false,
+                                                            "configVersion": 3
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "상태가 없거나 오래된 CCTV",
+                                            value = """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "TRAINING_SUCCESS_010",
+                                                      "message": "CCTV 현재 혼잡 상태 조회에 성공했습니다.",
+                                                      "result": {
+                                                        "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                                        "observedAt": 1787722095000,
+                                                        "states": [
+                                                          {
+                                                            "cctvId": "8b767966-b423-4d1b-bc2a-4107de97ad72",
+                                                            "cctvCode": "CCTV_002",
+                                                            "cctvName": "CAM-2",
+                                                            "buildingName": "A동",
+                                                            "floorName": "1층",
+                                                            "location": "A동 1층",
+                                                            "avgHeadcount": null,
+                                                            "peakHeadcount": null,
+                                                            "density": null,
+                                                            "congestionLevel": null,
+                                                            "lastDetectedAt": null,
+                                                            "stale": true,
+                                                            "configVersion": null
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "JWT가 없거나 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "MANAGER 권한이 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON403",
+                                      "message": "접근 권한이 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "세션이 없거나 요청자와 다른 학교의 세션",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING001",
+                                      "message": "훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "훈련 세션이 RUNNING 상태가 아님",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING006",
+                                      "message": "진행 중인 훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    @GetMapping("/current-states")
+    public ResponseEntity<ApiResponse<CurrentCctvStateListResponse>> getCurrentStates(
+            @Parameter(
+                    description = "조회할 RUNNING 훈련 세션의 UUID",
+                    required = true,
+                    example = "d669294e-55e1-4c00-bf67-229d89b76948"
+            )
+            @PathVariable UUID sessionId,
+            Authentication authentication
+    ) {
+        CurrentCctvStateListResponse response =
+                trainingMonitoringService.getCurrentStates(sessionId, authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success(
+                TrainingSuccessCode.MONITORING_CURRENT_STATE_LIST_FOUND,
                 response
         ));
     }

--- a/src/main/java/com/saferoute/domain/training/dto/CurrentCctvStateListApiResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/CurrentCctvStateListApiResponse.java
@@ -1,0 +1,22 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "CurrentCctvStateListApiResponse",
+        description = "CCTV별 현재 혼잡 상태 목록의 공통 API 응답 스키마"
+)
+public record CurrentCctvStateListApiResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean isSuccess,
+
+        @Schema(description = "응답 코드", example = "TRAINING_SUCCESS_010")
+        String code,
+
+        @Schema(description = "응답 메시지", example = "CCTV 현재 혼잡 상태 조회에 성공했습니다.")
+        String message,
+
+        @Schema(description = "CCTV별 현재 혼잡 상태 목록")
+        CurrentCctvStateListResponse result
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/CurrentCctvStateListResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/CurrentCctvStateListResponse.java
@@ -1,0 +1,22 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "훈련 세션의 CCTV별 현재 혼잡 상태 목록")
+public record CurrentCctvStateListResponse(
+        @Schema(description = "조회한 훈련 세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
+        UUID sessionId,
+
+        @Schema(description = "이 응답을 만든 시각(Unix epoch milliseconds)", example = "1787722095000")
+        long observedAt,
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "활성 CCTV별 현재 상태 목록. CCTV가 없으면 빈 배열"),
+                schema = @Schema(implementation = CurrentCctvStateResponse.class)
+        )
+        List<CurrentCctvStateResponse> states
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/CurrentCctvStateResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/CurrentCctvStateResponse.java
@@ -1,0 +1,126 @@
+package com.saferoute.domain.training.dto;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "CCTV 한 대의 현재 혼잡 상태")
+public record CurrentCctvStateResponse(
+        @Schema(description = "CCTV ID", example = "67b86e33-7874-494c-855f-e591e7847c09")
+        UUID cctvId,
+
+        @Schema(description = "CCTV 고유 코드", example = "CCTV_001")
+        String cctvCode,
+
+        @Schema(description = "관리자가 지정한 CCTV 이름", example = "CAM-1")
+        String cctvName,
+
+        @Schema(description = "CCTV가 설치된 건물명", example = "A동")
+        String buildingName,
+
+        @Schema(description = "화면 표시용 층 이름", example = "3층")
+        String floorName,
+
+        @Schema(description = "건물명과 층 이름을 조합한 표시 위치", example = "A동 3층")
+        String location,
+
+        @Schema(
+                description = "최근 5초 관측 구간의 평균 인원. 상태가 없으면 null",
+                example = "8.6",
+                nullable = true
+        )
+        Double avgHeadcount,
+
+        @Schema(
+                description = "최근 5초 관측 구간의 순간 최대 인원. 상태가 없으면 null",
+                example = "12",
+                nullable = true
+        )
+        Integer peakHeadcount,
+
+        @Schema(description = "밀집도(㎡당 인원). 상태가 없으면 null", example = "0.42", nullable = true)
+        Double density,
+
+        @Schema(description = "혼잡 단계. 상태가 없으면 null", example = "CROWDED", nullable = true)
+        CongestionLevel congestionLevel,
+
+        @Schema(
+                description = "상태를 마지막으로 관측한 시각(Unix epoch milliseconds). 상태가 없으면 null",
+                example = "1787722095000",
+                nullable = true
+        )
+        Long lastDetectedAt,
+
+        @Schema(
+                description = "stateStaleAfterSec를 초과해 오래됐거나 상태가 아직 없으면 true. "
+                        + "true일 때는 congestionLevel 등을 NORMAL로 오인하지 말고 '정보 없음/오래됨'으로 표시해야 한다",
+                example = "false"
+        )
+        boolean stale,
+
+        @Schema(
+                description = "상태가 저장될 때 적용된 혼잡 설정 버전. 상태가 없으면 null",
+                example = "3",
+                nullable = true
+        )
+        Long configVersion
+) {
+
+    public static CurrentCctvStateResponse withoutState(Cctv cctv) {
+        Location location = Location.from(cctv);
+        return new CurrentCctvStateResponse(
+                cctv.getId(),
+                cctv.getCode(),
+                cctv.getName(),
+                location.buildingName(),
+                location.floorName(),
+                location.displayName(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                true,
+                null
+        );
+    }
+
+    public static CurrentCctvStateResponse withState(Cctv cctv, CurrentCctvStateItem item, boolean stale) {
+        Location location = Location.from(cctv);
+        return new CurrentCctvStateResponse(
+                cctv.getId(),
+                cctv.getCode(),
+                cctv.getName(),
+                location.buildingName(),
+                location.floorName(),
+                location.displayName(),
+                item.getAvgHeadcount(),
+                item.getPeakHeadcount(),
+                item.getDensity(),
+                item.getCongestionLevel(),
+                item.getLastDetectedAt(),
+                stale,
+                item.getConfigVersion()
+        );
+    }
+
+    private record Location(String buildingName, String floorName, String displayName) {
+
+        private static Location from(Cctv cctv) {
+            Floor floor = cctv.getCustomNode().getFloor();
+            String buildingName = floor.getBuilding().getName();
+            String floorName = formatFloorName(floor.getFloorNum());
+            return new Location(buildingName, floorName, buildingName + " " + floorName);
+        }
+
+        private static String formatFloorName(int floorNum) {
+            if (floorNum < 0) {
+                return "지하 " + Math.abs((long) floorNum) + "층";
+            }
+            return floorNum + "층";
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -1,14 +1,19 @@
 package com.saferoute.domain.training.service;
 
+import com.saferoute.domain.congestion.service.CongestionConfigService;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.evacuation.recalculation.repository.RouteRecalculationRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
 import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
+import com.saferoute.domain.training.dto.CurrentCctvStateResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListResponse;
@@ -24,6 +29,7 @@ import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
 import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -46,9 +52,11 @@ public class TrainingMonitoringService {
     private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final ObservationRepository observationRepository;
     private final CongestionEventRepository congestionEventRepository;
+    private final CurrentCctvStateRepository currentCctvStateRepository;
     private final RouteRecalculationRepository routeRecalculationRepository;
     private final S3PresignedUrlService s3PresignedUrlService;
     private final SchoolContextService schoolContextService;
+    private final CongestionConfigService congestionConfigService;
 
     public MonitoringCameraListResponse getCameras(UUID sessionId, String email) {
         TrainingSession session = findRunningSessionForSchool(sessionId, email);
@@ -70,6 +78,44 @@ public class TrainingMonitoringService {
                 .map(cctv -> toResponse(cctv, capturesByCctvCode.get(cctv.getCode())))
                 .toList();
         return new MonitoringCameraListResponse(sessionId, cameras);
+    }
+
+    // 상태가 아직 없는 CCTV도 목록에서 누락하지 않고 stale=true인 null 상태로 반환한다.
+    // 기준 데이터가 5초 주기 Observation이므로, 마지막 관측 이후 stateStaleAfterSec가 지났으면
+    // congestionLevel 등이 남아있어도 stale=true로 표시해 "오래된 정보를 NORMAL로 오인"하는 것을 막는다.
+    public CurrentCctvStateListResponse getCurrentStates(UUID sessionId, String email) {
+        TrainingSession session = findRunningSessionForSchool(sessionId, email);
+        UUID buildingId = session.getScenario().getBuilding().getId();
+        List<Cctv> cctvs = cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        buildingId);
+        long observedAt = Instant.now().toEpochMilli();
+        if (cctvs.isEmpty()) {
+            return new CurrentCctvStateListResponse(sessionId, observedAt, List.of());
+        }
+
+        int stateStaleAfterSec = congestionConfigService.getConfig().getStateStaleAfterSec();
+        Map<String, CurrentCctvStateItem> statesByCctvCode =
+                currentCctvStateRepository.findAllBySessionId(sessionId.toString()).stream()
+                        .collect(Collectors.toMap(
+                                CurrentCctvStateItem::getCctvCode,
+                                Function.identity()
+                        ));
+
+        List<CurrentCctvStateResponse> states = cctvs.stream()
+                .map(cctv -> toStateResponse(cctv, statesByCctvCode.get(cctv.getCode()), observedAt, stateStaleAfterSec))
+                .toList();
+        return new CurrentCctvStateListResponse(sessionId, observedAt, states);
+    }
+
+    private CurrentCctvStateResponse toStateResponse(
+            Cctv cctv, CurrentCctvStateItem item, long observedAt, int stateStaleAfterSec
+    ) {
+        if (item == null) {
+            return CurrentCctvStateResponse.withoutState(cctv);
+        }
+        boolean stale = observedAt - item.getLastDetectedAt() > stateStaleAfterSec * 1_000L;
+        return CurrentCctvStateResponse.withState(cctv, item, stale);
     }
 
     public MonitoringFrameListResponse getFrames(

--- a/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
@@ -33,6 +33,11 @@ public enum TrainingSuccessCode implements BaseCode {
             HttpStatus.OK,
             "TRAINING_SUCCESS_009",
             "모니터링 이벤트 타임라인 조회에 성공했습니다."
+    ),
+    MONITORING_CURRENT_STATE_LIST_FOUND(
+            HttpStatus.OK,
+            "TRAINING_SUCCESS_010",
+            "CCTV 현재 혼잡 상태 조회에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -129,12 +129,13 @@ public class SecurityConfig {
 
                         // 훈련 모니터링 카메라와 캡처 이미지는 관리자 화면에서만 조회한다.
                         // 카메라 카드 목록(/cameras), 프레임 목록(/cameras/{cctvId}/frames), 이벤트
-                        // 타임라인(/events)을 모두 포함해야 한다.
+                        // 타임라인(/events), CCTV별 현재 혼잡 상태(/current-states)를 모두 포함해야 한다.
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/api/v1/sessions/*/monitoring/cameras",
                                 "/api/v1/sessions/*/monitoring/cameras/**",
-                                "/api/v1/sessions/*/monitoring/events"
+                                "/api/v1/sessions/*/monitoring/events",
+                                "/api/v1/sessions/*/monitoring/current-states"
                         ).hasRole("MANAGER")
 
                         // 세션 목록은 모니터링 화면 진입점으로 쓰이므로 카메라 조회와 동일하게 관리자 전용이다.

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -34,7 +34,6 @@ import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.EventProcessingStatus;
 import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
-import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -65,9 +64,6 @@ class CongestionEventServiceTest {
 
     @Mock
     private CongestionEventRepository congestionEventRepository;
-
-    @Mock
-    private CurrentCctvStateRepository currentCctvStateRepository;
 
     @Mock
     private TrainingSessionRepository trainingSessionRepository;
@@ -219,7 +215,6 @@ class CongestionEventServiceTest {
         service.reportCongestionEvent(cctv, request(5));
 
         verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
-        verify(currentCctvStateRepository).updateIfLatest(any());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
@@ -101,7 +101,7 @@ class TelemetryItemTest {
     @Test
     void 현재_상태는_세션과_CCTV로_키를_만들고_TTL이_없다() {
         CurrentCctvStateItem item = CurrentCctvStateItem.create(
-                SESSION_ID, "CCTV_001", 9, 4.5, CongestionLevel.CROWDED,
+                SESSION_ID, "CCTV_001", 8.6, 9, 4.5, CongestionLevel.CROWDED,
                 1_786_500_002_300L, 1L
         );
 

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CurrentCctvStateRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CurrentCctvStateRepositoryTest.java
@@ -95,7 +95,7 @@ class CurrentCctvStateRepositoryTest {
 
     private CurrentCctvStateItem item(String cctvCode, long timestamp) {
         return CurrentCctvStateItem.create(
-                SESSION_ID, cctvCode, 9, 4.5, CongestionLevel.CROWDED, timestamp, 1L
+                SESSION_ID, cctvCode, 8.6, 12, 4.5, CongestionLevel.CROWDED, timestamp, 1L
         );
     }
 }

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
+import com.saferoute.domain.training.dto.CurrentCctvStateResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListResponse;
@@ -225,6 +227,94 @@ class TrainingMonitoringControllerTest {
                 .andExpect(jsonPath("$.code").value("S3_ERROR_005"))
                 .andExpect(jsonPath("$.message")
                         .value("S3 이미지 조회 URL 발급에 실패했습니다."));
+    }
+
+    @Test
+    void CCTV별_현재_혼잡_상태를_공통_응답으로_반환한다() throws Exception {
+        CurrentCctvStateResponse state = new CurrentCctvStateResponse(
+                CCTV_ID,
+                "CCTV_001",
+                "CAM-1",
+                "A동",
+                "3층",
+                "A동 3층",
+                8.6,
+                12,
+                0.42,
+                CongestionLevel.CROWDED,
+                1_787_722_095_000L,
+                false,
+                3L
+        );
+        given(trainingMonitoringService.getCurrentStates(SESSION_ID, EMAIL))
+                .willReturn(new CurrentCctvStateListResponse(SESSION_ID, 1_787_722_095_000L, List.of(state)));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/current-states", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("TRAINING_SUCCESS_010"))
+                .andExpect(jsonPath("$.result.sessionId").value(SESSION_ID.toString()))
+                .andExpect(jsonPath("$.result.observedAt").value(1_787_722_095_000L))
+                .andExpect(jsonPath("$.result.states[0].cctvId").value(CCTV_ID.toString()))
+                .andExpect(jsonPath("$.result.states[0].cctvCode").value("CCTV_001"))
+                .andExpect(jsonPath("$.result.states[0].avgHeadcount").value(8.6))
+                .andExpect(jsonPath("$.result.states[0].peakHeadcount").value(12))
+                .andExpect(jsonPath("$.result.states[0].density").value(0.42))
+                .andExpect(jsonPath("$.result.states[0].congestionLevel").value("CROWDED"))
+                .andExpect(jsonPath("$.result.states[0].lastDetectedAt").value(1_787_722_095_000L))
+                .andExpect(jsonPath("$.result.states[0].stale").value(false))
+                .andExpect(jsonPath("$.result.states[0].configVersion").value(3));
+    }
+
+    @Test
+    void 상태가_없는_CCTV는_null_필드와_stale_true로_반환한다() throws Exception {
+        CurrentCctvStateResponse state = new CurrentCctvStateResponse(
+                CCTV_ID,
+                "CCTV_002",
+                "CAM-2",
+                "A동",
+                "1층",
+                "A동 1층",
+                null,
+                null,
+                null,
+                null,
+                null,
+                true,
+                null
+        );
+        given(trainingMonitoringService.getCurrentStates(SESSION_ID, EMAIL))
+                .willReturn(new CurrentCctvStateListResponse(SESSION_ID, 1_787_722_095_000L, List.of(state)));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/current-states", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.states[0].avgHeadcount").value((Object) null))
+                .andExpect(jsonPath("$.result.states[0].congestionLevel").value((Object) null))
+                .andExpect(jsonPath("$.result.states[0].stale").value(true));
+    }
+
+    @Test
+    void 현재_상태_조회시_세션을_찾을_수_없으면_404를_반환한다() throws Exception {
+        given(trainingMonitoringService.getCurrentStates(SESSION_ID, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/current-states", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
+    void 현재_상태_조회시_실행_중인_세션이_아니면_409를_반환한다() throws Exception {
+        given(trainingMonitoringService.getCurrentStates(SESSION_ID, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/current-states", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("TRAINING006"));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -522,6 +522,30 @@ class TrainingMonitoringServiceTest {
     }
 
     @Test
+    void stale_판정은_기본값이_아닌_설정된_stateStaleAfterSec를_사용한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(3);
+        // 기본값(15초)이었다면 20초 전 관측은 stale이지만, stateStaleAfterSec를 30초로 설정하면 stale이 아니어야 한다.
+        long lastDetectedAt = Instant.now().toEpochMilli() - 20_000L;
+        CurrentCctvStateItem state = CurrentCctvStateItem.create(
+                SESSION_ID, "CCTV_001", 8.6, 12, 0.42, CongestionLevel.CROWDED, lastDetectedAt, 3L
+        );
+        CongestionConfig config = CongestionConfig.createDefault();
+        config.updateSettings(null, null, null, null, null, null, null, null, 30);
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(currentCctvStateRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(state));
+        given(congestionConfigService.getConfig()).willReturn(config);
+
+        CurrentCctvStateResponse response = service.getCurrentStates(SESSION_ID, EMAIL).states().get(0);
+
+        assertThat(response.stale()).isFalse();
+    }
+
+    @Test
     void 활성_CCTV가_없으면_현재_상태_조회도_빈_목록을_반환한다() {
         stubSession(TrainingStatus.RUNNING);
         given(cctvJpaRepository

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.congestion.entity.CongestionConfig;
+import com.saferoute.domain.congestion.service.CongestionConfigService;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
@@ -17,11 +19,15 @@ import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
+import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
 import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
+import com.saferoute.domain.training.dto.CurrentCctvStateResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListResponse;
@@ -71,11 +77,15 @@ class TrainingMonitoringServiceTest {
     @Mock
     private CongestionEventRepository congestionEventRepository;
     @Mock
+    private CurrentCctvStateRepository currentCctvStateRepository;
+    @Mock
     private RouteRecalculationRepository routeRecalculationRepository;
     @Mock
     private S3PresignedUrlService s3PresignedUrlService;
     @Mock
     private SchoolContextService schoolContextService;
+    @Mock
+    private CongestionConfigService congestionConfigService;
 
     private TrainingMonitoringService service;
 
@@ -87,9 +97,11 @@ class TrainingMonitoringServiceTest {
                 latestMonitoringCaptureRepository,
                 observationRepository,
                 congestionEventRepository,
+                currentCctvStateRepository,
                 routeRecalculationRepository,
                 s3PresignedUrlService,
-                schoolContextService
+                schoolContextService,
+                congestionConfigService
         );
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
     }
@@ -427,6 +439,109 @@ class TrainingMonitoringServiceTest {
                         "errorCode",
                         TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND
                 );
+        verify(cctvJpaRepository, never())
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void 현재_상태가_있는_CCTV는_avg_peak를_분리해서_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(3);
+        // 기본 설정 stateStaleAfterSec=15초 - 방금 관측된 상태이므로 stale이 아니어야 한다.
+        long freshLastDetectedAt = Instant.now().toEpochMilli() - 1_000L;
+        CurrentCctvStateItem state = CurrentCctvStateItem.create(
+                SESSION_ID, "CCTV_001", 8.6, 12, 0.42, CongestionLevel.CROWDED, freshLastDetectedAt, 3L
+        );
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(currentCctvStateRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(state));
+        given(congestionConfigService.getConfig()).willReturn(CongestionConfig.createDefault());
+
+        CurrentCctvStateListResponse response = service.getCurrentStates(SESSION_ID, EMAIL);
+
+        assertThat(response.sessionId()).isEqualTo(SESSION_ID);
+        assertThat(response.states()).singleElement().satisfies(cctvState -> {
+            assertThat(cctvState.cctvCode()).isEqualTo("CCTV_001");
+            assertThat(cctvState.avgHeadcount()).isEqualTo(8.6);
+            assertThat(cctvState.peakHeadcount()).isEqualTo(12);
+            assertThat(cctvState.density()).isEqualTo(0.42);
+            assertThat(cctvState.congestionLevel()).isEqualTo(CongestionLevel.CROWDED);
+            assertThat(cctvState.lastDetectedAt()).isEqualTo(freshLastDetectedAt);
+            assertThat(cctvState.stale()).isFalse();
+            assertThat(cctvState.configVersion()).isEqualTo(3L);
+        });
+    }
+
+    @Test
+    void 상태가_없는_CCTV도_목록에서_누락하지_않고_stale로_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(3);
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(currentCctvStateRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of());
+        given(congestionConfigService.getConfig()).willReturn(CongestionConfig.createDefault());
+
+        CurrentCctvStateResponse state = service.getCurrentStates(SESSION_ID, EMAIL).states().get(0);
+
+        assertThat(state.avgHeadcount()).isNull();
+        assertThat(state.peakHeadcount()).isNull();
+        assertThat(state.density()).isNull();
+        assertThat(state.congestionLevel()).isNull();
+        assertThat(state.lastDetectedAt()).isNull();
+        assertThat(state.stale()).isTrue();
+    }
+
+    @Test
+    void stateStaleAfterSec를_초과한_상태는_stale로_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        Cctv cctv = cctv(3);
+        // 기본 설정 stateStaleAfterSec=15초. lastDetectedAt을 현재로부터 20초 전으로 만들어 stale 유도.
+        long staleLastDetectedAt = Instant.now().toEpochMilli() - 20_000L;
+        CurrentCctvStateItem state = CurrentCctvStateItem.create(
+                SESSION_ID, "CCTV_001", 8.6, 12, 0.42, CongestionLevel.CROWDED, staleLastDetectedAt, 3L
+        );
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of(cctv));
+        given(currentCctvStateRepository.findAllBySessionId(SESSION_ID.toString()))
+                .willReturn(List.of(state));
+        given(congestionConfigService.getConfig()).willReturn(CongestionConfig.createDefault());
+
+        CurrentCctvStateResponse response = service.getCurrentStates(SESSION_ID, EMAIL).states().get(0);
+
+        assertThat(response.stale()).isTrue();
+        assertThat(response.congestionLevel()).isEqualTo(CongestionLevel.CROWDED);
+    }
+
+    @Test
+    void 활성_CCTV가_없으면_현재_상태_조회도_빈_목록을_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        given(cctvJpaRepository
+                .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
+                        BUILDING_ID))
+                .willReturn(List.of());
+
+        CurrentCctvStateListResponse response = service.getCurrentStates(SESSION_ID, EMAIL);
+
+        assertThat(response.states()).isEmpty();
+        verify(currentCctvStateRepository, never()).findAllBySessionId(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 현재_상태_조회는_실행_중이_아닌_세션은_거부한다() {
+        stubSession(TrainingStatus.COMPLETED);
+
+        assertThatThrownBy(() -> service.getCurrentStates(SESSION_ID, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND);
         verify(cctvJpaRepository, never())
                 .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
                         org.mockito.ArgumentMatchers.any());

--- a/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
@@ -210,6 +210,32 @@ class SecurityAuthorizationIntegrationTest {
     }
 
     @Test
+    @DisplayName("일반 사용자는 CCTV별 현재 혼잡 상태를 조회할 수 없다")
+    void normalUserCannotReadTrainingMonitoringCurrentStates() throws Exception {
+        String token = signupAndLogin(UserRole.NORMAL);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/current-states", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("관리자는 CCTV별 현재 혼잡 상태 엔드포인트에 접근할 수 있다")
+    void managerCanReadTrainingMonitoringCurrentStates() throws Exception {
+        String token = signupAndLogin(UserRole.MANAGER);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/current-states", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
     @DisplayName("일반 사용자는 훈련 세션 목록을 조회할 수 없다")
     void normalUserCannotReadTrainingSessions() throws Exception {
         String token = signupAndLogin(UserRole.NORMAL);


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #181
- Branch: feat/#181

## 주요 내용

- `CurrentCctvStateItem`의 `headcount` 단일 필드를 `avgHeadcount`(평균)/`peakHeadcount`(순간 최대)로 분리해서 저장하도록 수정
- 즉시 혼잡 이벤트(`CongestionEventService`)가 더 이상 `CurrentCctvStateItem`을 직접 갱신하지 않도록 변경 — 기준 데이터를 5초 주기 Observation으로 통일하고, 즉시 이벤트는 이벤트 타임라인/경로 재탐색 트리거/WebSocket 알림 용도로만 사용
- `GET /api/v1/sessions/{sessionId}/monitoring/current-states` 신규 API 추가
  - 세션이 속한 건물의 활성 CCTV별 현재 혼잡 상태(평균/최대 인원, 밀집도, 혼잡 단계, 마지막 관측 시각)를 반환
  - 상태가 아직 없는 CCTV도 목록에서 누락하지 않고 null 필드로 포함
  - 마지막 관측 이후 `stateStaleAfterSec`(기본 15초)가 지나면 `stale: true`를 반환해, 오래된 정보를 정상(NORMAL)으로 오인하지 않도록 함
  - 기존 cameras/frames/events API와 동일하게 요청자 학교·세션 소속 건물 검증, RUNNING 세션만 조회 허용

## 프론트 연동 참고

- `avgHeadcount`(평균 인원)와 `peakHeadcount`(순간 최대 인원)가 분리되어 내려오므로 화면 용도에 맞게 선택해서 사용
- `stale: true`면 `congestionLevel` 등 다른 필드 값이 남아있어도 "정보 없음/오래됨"으로 표시 — NORMAL로 표시하지 말 것
- 종료된 세션은 이 API로 아직 조회 불가 (RUNNING 세션만 허용). 종료 세션 조회 지원은 후속 이슈에서 별도로 진행 예정

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 세션별 CCTV 현재 혼잡 상태를 조회하는 API를 추가했습니다.
  * CCTV별 평균·최대 인원수, 밀도, 혼잡 단계, 최근 감지 시각, 설정 버전을 제공합니다.
  * 상태가 없거나 오래된 CCTV는 별도로 표시해 데이터 최신 여부를 확인할 수 있습니다.
  * CCTV 위치 정보와 지하층 표시를 응답에 포함합니다.

* **개선 사항**
  * 평균 인원수를 소수점 원본 값으로 제공하도록 개선했습니다.
  * 현재 CCTV 상태를 주기적인 관측 데이터 기준으로 일관되게 관리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->