### PR TITLE
[Feat] #180: 모니터링 세션 context 정보 및 프레임 시간 필드 정리

### DIFF
--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -4,6 +4,8 @@ import com.saferoute.domain.training.dto.CurrentCctvStateListApiResponse;
 import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListApiResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.dto.MonitoringContextApiResponse;
+import com.saferoute.domain.training.dto.MonitoringContextResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListApiResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameListApiResponse;
@@ -216,6 +218,132 @@ public class TrainingMonitoringController {
     }
 
     @Operation(
+            summary = "모니터링 세션 정보 조회",
+            description = """
+                    모니터링 상세 화면 헤더에 필요한 세션 기본 정보(시나리오명, 건물명, 상태,
+                    시작/종료 시각, 경과 시간)와 전역 설정값(저장 간격, CCTV 현재 상태 stale
+                    판정 기준)을 한 번에 반환합니다.
+
+                    startedAt/endedAt은 훈련 전체의 시작/종료 시각입니다. 프레임 목록
+                    (GET .../monitoring/cameras/{cctvId}/frames)의 windowStart/windowEnd
+                    (개별 프레임의 분석 구간)와는 다른 시간 축이므로 혼동하지 마세요.
+
+                    elapsedSeconds는 RUNNING 세션이면 현재 시각 기준으로 계속 늘어나는 값이고,
+                    종료된 세션이면 종료 시각 기준으로 고정된 값입니다.
+
+                    snapshotIntervalSec, stateStaleAfterSec는 세션별 값이 아니라 전역 혼잡 설정
+                    (CongestionConfig)의 현재 값입니다. 훈련 진행 중 관리자가 설정을 바꾸면
+                    이 API가 반환하는 값도 함께 바뀝니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "모니터링 세션 정보 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    implementation = MonitoringContextApiResponse.class
+                            ),
+                            examples = @ExampleObject(
+                                    name = "진행 중인 세션",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "TRAINING_SUCCESS_011",
+                                              "message": "모니터링 세션 정보 조회에 성공했습니다.",
+                                              "result": {
+                                                "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+                                                "scenarioName": "3학년 A동 화재 대피 훈련",
+                                                "buildingName": "A동",
+                                                "status": "RUNNING",
+                                                "startedAt": 1787722000000,
+                                                "endedAt": null,
+                                                "elapsedSeconds": 95,
+                                                "snapshotIntervalSec": 5,
+                                                "stateStaleAfterSec": 15
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "JWT가 없거나 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "MANAGER 권한이 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON403",
+                                      "message": "접근 권한이 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "세션이 없거나 요청자와 다른 학교의 세션",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING001",
+                                      "message": "훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "훈련 세션이 RUNNING 상태가 아님",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TRAINING006",
+                                      "message": "진행 중인 훈련 세션을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    @GetMapping("/context")
+    public ResponseEntity<ApiResponse<MonitoringContextResponse>> getContext(
+            @Parameter(
+                    description = "조회할 RUNNING 훈련 세션의 UUID",
+                    required = true,
+                    example = "d669294e-55e1-4c00-bf67-229d89b76948"
+            )
+            @PathVariable UUID sessionId,
+            Authentication authentication
+    ) {
+        MonitoringContextResponse response =
+                trainingMonitoringService.getContext(sessionId, authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success(
+                TrainingSuccessCode.MONITORING_CONTEXT_FOUND,
+                response
+        ));
+    }
+
+    @Operation(
             summary = "CCTV별 현재 혼잡 상태 조회",
             description = """
                     실행 중인 훈련 세션의 건물에 설치된 활성 CCTV별 현재 혼잡 상태를 반환합니다.
@@ -398,6 +526,11 @@ public class TrainingMonitoringController {
                     각 프레임의 imageUrl은 S3 presigned GET URL이며 영구 URL이 아닙니다.
                     이미지 업로드가 아직 끝나지 않은 프레임은 imageUrl, urlExpiresAt이 null로
                     반환됩니다. capturedAt은 Unix epoch milliseconds 단위입니다.
+
+                    windowStart/windowEnd는 이 프레임이 대표하는 분석 구간(보통 5초)의
+                    시작/종료 시각이고, capturedAt은 그 구간을 대표해 저장된 프레임이 실제로
+                    촬영된 시각입니다. 훈련 전체의 시작/종료 시각(GET .../monitoring/context의
+                    startedAt/endedAt)과는 다른 시간 축이므로 혼동하지 마세요.
                     """
     )
     @ApiResponses({
@@ -423,6 +556,8 @@ public class TrainingMonitoringController {
                                                   {
                                                     "frameId": "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11",
                                                     "capturedAt": 1787722095000,
+                                                    "windowStart": 1787722090000,
+                                                    "windowEnd": 1787722095000,
                                                     "imageUrl": "https://example-bucket.s3.amazonaws.com/training/session/monitoring/CCTV_001/frame.jpg",
                                                     "urlExpiresAt": 1787725695000,
                                                     "headcount": 12,

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -228,8 +228,9 @@ public class TrainingMonitoringController {
                     (GET .../monitoring/cameras/{cctvId}/frames)의 windowStart/windowEnd
                     (개별 프레임의 분석 구간)와는 다른 시간 축이므로 혼동하지 마세요.
 
-                    elapsedSeconds는 RUNNING 세션이면 현재 시각 기준으로 계속 늘어나는 값이고,
-                    종료된 세션이면 종료 시각 기준으로 고정된 값입니다.
+                    이 API는 다른 모니터링 조회 API와 동일하게 RUNNING 세션만 허용합니다(종료된
+                    세션 조회는 별도 이슈에서 다룰 예정입니다). elapsedSeconds는 현재 시각과
+                    startedAt의 차이이며 호출 시점마다 계속 늘어나는 값입니다.
 
                     snapshotIntervalSec, stateStaleAfterSec는 세션별 값이 아니라 전역 혼잡 설정
                     (CongestionConfig)의 현재 값입니다. 훈련 진행 중 관리자가 설정을 바꾸면

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingSessionController.java
@@ -200,6 +200,10 @@ public class TrainingSessionController {
 
           정상 종료 여부는 관리자가 직접 끝내는 강제 종료(force-end)와 구분됩니다. 정상
           종료는 시나리오를 COMPLETED로, 강제 종료는 ERROR로 남긴다는 점이 다릅니다.
+
+          응답의 endedAt에 방금 기록된 종료 시각이 그대로 담겨 오므로, 화면은 별도 조회 없이
+          이 값을 바로 표시하면 됩니다. 단, 새로고침 후 세션을 다시 조회해 종료 시각을
+          복구하는 API는 아직 없습니다.
           """
   )
   @PostMapping("/{sessionId}/end")
@@ -220,6 +224,10 @@ public class TrainingSessionController {
           정상 종료(end)와 동일하게 시나리오의 화재 셀 초기화, 대기 중인 경로 재탐색 요청
           무효화, 유도등 평상시 복구가 함께 일어나지만, 시나리오 status는 COMPLETED가 아니라
           ERROR로 표시되어 정상 종료와 구분됩니다.
+
+          응답의 endedAt에 방금 기록된 강제 종료 시각이 그대로 담겨 오므로, 화면은 별도 조회
+          없이 이 값을 바로 표시하면 됩니다. 단, 새로고침 후 세션을 다시 조회해 종료 시각을
+          복구하는 API는 아직 없습니다.
           """
   )
   @PostMapping("/{sessionId}/force-end")

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringContextApiResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringContextApiResponse.java
@@ -1,0 +1,22 @@
+package com.saferoute.domain.training.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "MonitoringContextApiResponse",
+        description = "모니터링 세션 정보의 공통 API 응답 스키마"
+)
+public record MonitoringContextApiResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean isSuccess,
+
+        @Schema(description = "응답 코드", example = "TRAINING_SUCCESS_011")
+        String code,
+
+        @Schema(description = "응답 메시지", example = "모니터링 세션 정보 조회에 성공했습니다.")
+        String message,
+
+        @Schema(description = "모니터링 세션 정보")
+        MonitoringContextResponse result
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringContextResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringContextResponse.java
@@ -1,0 +1,47 @@
+package com.saferoute.domain.training.dto;
+
+import com.saferoute.domain.training.entity.TrainingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "모니터링 상세 화면에 필요한 세션 기본 정보")
+public record MonitoringContextResponse(
+        @Schema(description = "조회한 훈련 세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
+        UUID sessionId,
+
+        @Schema(description = "시나리오명", example = "3학년 A동 화재 대피 훈련")
+        String scenarioName,
+
+        @Schema(description = "세션이 속한 건물명", example = "A동")
+        String buildingName,
+
+        @Schema(description = "세션 상태", example = "RUNNING")
+        TrainingStatus status,
+
+        @Schema(description = "훈련 시작 시각(Unix epoch milliseconds)", example = "1787722000000")
+        long startedAt,
+
+        @Schema(
+                description = "훈련 종료 시각(Unix epoch milliseconds). 아직 종료되지 않았으면 null",
+                example = "1787723000000",
+                nullable = true
+        )
+        Long endedAt,
+
+        @Schema(
+                description = "경과 시간(초). RUNNING이면 현재 시각 기준, 종료된 세션이면 "
+                        + "종료 시각 기준으로 고정된 값",
+                example = "95"
+        )
+        long elapsedSeconds,
+
+        @Schema(description = "Pi 관측 저장 간격(초). 전역 설정값", example = "5")
+        int snapshotIntervalSec,
+
+        @Schema(
+                description = "CCTV 현재 상태(current-states)가 stale로 판정되는 기준(초). 전역 설정값",
+                example = "15"
+        )
+        int stateStaleAfterSec
+) {
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameResponse.java
@@ -14,6 +14,18 @@ public record MonitoringFrameResponse(
         long capturedAt,
 
         @Schema(
+                description = "이 프레임이 속한 분석 구간의 시작 시각(Unix epoch milliseconds)",
+                example = "1787722090000"
+        )
+        long windowStart,
+
+        @Schema(
+                description = "이 프레임이 속한 분석 구간의 종료 시각(Unix epoch milliseconds)",
+                example = "1787722095000"
+        )
+        long windowEnd,
+
+        @Schema(
                 description = "프레임 이미지의 S3 presigned GET URL. 이미지 업로드가 아직 끝나지 않았으면 null",
                 example = "https://example-bucket.s3.amazonaws.com/training/session/monitoring/CCTV_001/frame.jpg",
                 nullable = true
@@ -41,6 +53,8 @@ public record MonitoringFrameResponse(
         return new MonitoringFrameResponse(
                 item.getEventId(),
                 item.getCapturedAt(),
+                item.getWindowStart(),
+                item.getWindowEnd(),
                 null,
                 null,
                 item.getPeakHeadcount(),
@@ -53,6 +67,8 @@ public record MonitoringFrameResponse(
         return new MonitoringFrameResponse(
                 item.getEventId(),
                 item.getCapturedAt(),
+                item.getWindowStart(),
+                item.getWindowEnd(),
                 presignedGetUrl.viewUrl(),
                 presignedGetUrl.expiresAt().toEpochMilli(),
                 item.getPeakHeadcount(),

--- a/src/main/java/com/saferoute/domain/training/dto/TrainingSessionResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/TrainingSessionResponse.java
@@ -13,6 +13,7 @@ public class TrainingSessionResponse {
   private UUID id;
   private TrainingStatus status;
   private Instant startedAt;
+  private Instant endedAt;
   private String adminName;
   private String scenarioName;
 
@@ -21,6 +22,7 @@ public class TrainingSessionResponse {
         .id(session.getId())
         .status(session.getStatus())
         .startedAt(session.getStartedAt())
+        .endedAt(session.getEndedAt())
         .adminName(session.getAdmin().getUsername())
         .scenarioName(session.getScenario().getName())
         .build();

--- a/src/main/java/com/saferoute/domain/training/dto/TrainingSessionResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/TrainingSessionResponse.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.training.dto;
 
 import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.entity.TrainingSession;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
@@ -9,12 +10,28 @@ import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "훈련 세션 생성/시작/종료/강제종료 API의 공통 응답")
 public class TrainingSessionResponse {
+  @Schema(description = "세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
   private UUID id;
+
+  @Schema(description = "세션 상태", example = "COMPLETED")
   private TrainingStatus status;
+
+  @Schema(description = "훈련 시작 시각. 아직 시작되지 않았으면(SCHEDULED) null", nullable = true)
   private Instant startedAt;
+
+  @Schema(
+      description = "훈련 종료 시각(정상 종료 또는 강제 종료). RUNNING이거나 아직 "
+          + "시작되지 않았으면 null. end/force-end 응답에는 방금 종료 처리된 시각이 그대로 담깁니다.",
+      nullable = true
+  )
   private Instant endedAt;
+
+  @Schema(description = "세션을 생성한 관리자 이름", example = "박현지")
   private String adminName;
+
+  @Schema(description = "훈련 시나리오명", example = "3학년 A동 화재 대피 훈련")
   private String scenarioName;
 
   public static TrainingSessionResponse from(TrainingSession session) {

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -1,5 +1,6 @@
 package com.saferoute.domain.training.service;
 
+import com.saferoute.domain.congestion.entity.CongestionConfig;
 import com.saferoute.domain.congestion.service.CongestionConfigService;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.repository.CctvJpaRepository;
@@ -16,6 +17,7 @@ import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
 import com.saferoute.domain.training.dto.CurrentCctvStateResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
+import com.saferoute.domain.training.dto.MonitoringContextResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListResponse;
 import com.saferoute.domain.training.dto.MonitoringEventResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
@@ -78,6 +80,27 @@ public class TrainingMonitoringService {
                 .map(cctv -> toResponse(cctv, capturesByCctvCode.get(cctv.getCode())))
                 .toList();
         return new MonitoringCameraListResponse(sessionId, cameras);
+    }
+
+    // 모니터링 상세 화면 헤더에 필요한 세션 기본 정보 + 전역 설정값(저장 간격, stale 기준)을
+    // 한 번에 제공한다. RUNNING 세션만 허용하는 다른 모니터링 조회 API와 동일한 제약을 쓰며,
+    // 종료된 세션 조회 허용 여부는 별도 이슈에서 다룬다.
+    public MonitoringContextResponse getContext(UUID sessionId, String email) {
+        TrainingSession session = findRunningSessionForSchool(sessionId, email);
+        CongestionConfig config = congestionConfigService.getConfig();
+        long elapsedSeconds = Instant.now().getEpochSecond() - session.getStartedAt().getEpochSecond();
+
+        return new MonitoringContextResponse(
+                session.getId(),
+                session.getScenario().getName(),
+                session.getScenario().getBuilding().getName(),
+                session.getStatus(),
+                session.getStartedAt().toEpochMilli(),
+                session.getEndedAt() != null ? session.getEndedAt().toEpochMilli() : null,
+                elapsedSeconds,
+                config.getSnapshotIntervalSec(),
+                config.getStateStaleAfterSec()
+        );
     }
 
     // 상태가 아직 없는 CCTV도 목록에서 누락하지 않고 stale=true인 null 상태로 반환한다.

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -31,6 +31,7 @@ import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
 import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -88,7 +89,7 @@ public class TrainingMonitoringService {
     public MonitoringContextResponse getContext(UUID sessionId, String email) {
         TrainingSession session = findRunningSessionForSchool(sessionId, email);
         CongestionConfig config = congestionConfigService.getConfig();
-        long elapsedSeconds = Instant.now().getEpochSecond() - session.getStartedAt().getEpochSecond();
+        long elapsedSeconds = Duration.between(session.getStartedAt(), Instant.now()).getSeconds();
 
         return new MonitoringContextResponse(
                 session.getId(),

--- a/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/TrainingSuccessCode.java
@@ -38,6 +38,11 @@ public enum TrainingSuccessCode implements BaseCode {
             HttpStatus.OK,
             "TRAINING_SUCCESS_010",
             "CCTV 현재 혼잡 상태 조회에 성공했습니다."
+    ),
+    MONITORING_CONTEXT_FOUND(
+            HttpStatus.OK,
+            "TRAINING_SUCCESS_011",
+            "모니터링 세션 정보 조회에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saferoute/global/config/SecurityConfig.java
+++ b/src/main/java/com/saferoute/global/config/SecurityConfig.java
@@ -129,13 +129,15 @@ public class SecurityConfig {
 
                         // 훈련 모니터링 카메라와 캡처 이미지는 관리자 화면에서만 조회한다.
                         // 카메라 카드 목록(/cameras), 프레임 목록(/cameras/{cctvId}/frames), 이벤트
-                        // 타임라인(/events), CCTV별 현재 혼잡 상태(/current-states)를 모두 포함해야 한다.
+                        // 타임라인(/events), CCTV별 현재 혼잡 상태(/current-states), 세션 정보
+                        // (/context)를 모두 포함해야 한다.
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/api/v1/sessions/*/monitoring/cameras",
                                 "/api/v1/sessions/*/monitoring/cameras/**",
                                 "/api/v1/sessions/*/monitoring/events",
-                                "/api/v1/sessions/*/monitoring/current-states"
+                                "/api/v1/sessions/*/monitoring/current-states",
+                                "/api/v1/sessions/*/monitoring/context"
                         ).hasRole("MANAGER")
 
                         // 세션 목록은 모니터링 화면 진입점으로 쓰이므로 카메라 조회와 동일하게 관리자 전용이다.

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -94,28 +94,6 @@ class TrainingMonitoringControllerTest {
     }
 
     @Test
-    void 종료된_세션의_모니터링_정보에는_endedAt이_포함된다() throws Exception {
-        MonitoringContextResponse context = new MonitoringContextResponse(
-                SESSION_ID,
-                "3학년 A동 화재 대피 훈련",
-                "A동",
-                TrainingStatus.COMPLETED,
-                1_787_722_000_000L,
-                1_787_723_000_000L,
-                1000L,
-                5,
-                15
-        );
-        given(trainingMonitoringService.getContext(SESSION_ID, EMAIL)).willReturn(context);
-
-        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/context", SESSION_ID)
-                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.status").value("COMPLETED"))
-                .andExpect(jsonPath("$.result.endedAt").value(1_787_723_000_000L));
-    }
-
-    @Test
     void 모니터링_정보_조회시_세션을_찾을_수_없으면_404를_반환한다() throws Exception {
         given(trainingMonitoringService.getContext(SESSION_ID, EMAIL))
                 .willThrow(new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -9,6 +9,7 @@ import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
 import com.saferoute.domain.training.dto.CurrentCctvStateResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.dto.MonitoringContextResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListResponse;
 import com.saferoute.domain.training.dto.MonitoringEventResponse;
@@ -16,6 +17,7 @@ import com.saferoute.domain.training.dto.MonitoringEventSeverity;
 import com.saferoute.domain.training.dto.MonitoringEventType;
 import com.saferoute.domain.training.dto.MonitoringFrameListResponse;
 import com.saferoute.domain.training.dto.MonitoringFrameResponse;
+import com.saferoute.domain.training.entity.TrainingStatus;
 import com.saferoute.domain.training.service.TrainingMonitoringService;
 import com.saferoute.global.api.code.ErrorCode;
 import com.saferoute.global.api.error.CctvErrorCode;
@@ -59,6 +61,81 @@ class TrainingMonitoringControllerTest {
 
     @MockitoBean
     private TrainingMonitoringService trainingMonitoringService;
+
+    @Test
+    void 모니터링_세션_정보를_공통_응답으로_반환한다() throws Exception {
+        MonitoringContextResponse context = new MonitoringContextResponse(
+                SESSION_ID,
+                "3학년 A동 화재 대피 훈련",
+                "A동",
+                TrainingStatus.RUNNING,
+                1_787_722_000_000L,
+                null,
+                95L,
+                5,
+                15
+        );
+        given(trainingMonitoringService.getContext(SESSION_ID, EMAIL)).willReturn(context);
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/context", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("TRAINING_SUCCESS_011"))
+                .andExpect(jsonPath("$.result.sessionId").value(SESSION_ID.toString()))
+                .andExpect(jsonPath("$.result.scenarioName").value("3학년 A동 화재 대피 훈련"))
+                .andExpect(jsonPath("$.result.buildingName").value("A동"))
+                .andExpect(jsonPath("$.result.status").value("RUNNING"))
+                .andExpect(jsonPath("$.result.startedAt").value(1_787_722_000_000L))
+                .andExpect(jsonPath("$.result.endedAt").value((Object) null))
+                .andExpect(jsonPath("$.result.elapsedSeconds").value(95))
+                .andExpect(jsonPath("$.result.snapshotIntervalSec").value(5))
+                .andExpect(jsonPath("$.result.stateStaleAfterSec").value(15));
+    }
+
+    @Test
+    void 종료된_세션의_모니터링_정보에는_endedAt이_포함된다() throws Exception {
+        MonitoringContextResponse context = new MonitoringContextResponse(
+                SESSION_ID,
+                "3학년 A동 화재 대피 훈련",
+                "A동",
+                TrainingStatus.COMPLETED,
+                1_787_722_000_000L,
+                1_787_723_000_000L,
+                1000L,
+                5,
+                15
+        );
+        given(trainingMonitoringService.getContext(SESSION_ID, EMAIL)).willReturn(context);
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/context", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.result.endedAt").value(1_787_723_000_000L));
+    }
+
+    @Test
+    void 모니터링_정보_조회시_세션을_찾을_수_없으면_404를_반환한다() throws Exception {
+        given(trainingMonitoringService.getContext(SESSION_ID, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/context", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
+    void 모니터링_정보_조회시_실행_중인_세션이_아니면_409를_반환한다() throws Exception {
+        given(trainingMonitoringService.getContext(SESSION_ID, EMAIL))
+                .willThrow(new ApiException(TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/context", SESSION_ID)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("TRAINING006"));
+    }
 
     @Test
     void 카메라별_최신_캡처_목록을_공통_응답으로_반환한다() throws Exception {
@@ -322,6 +399,8 @@ class TrainingMonitoringControllerTest {
         MonitoringFrameResponse frame = new MonitoringFrameResponse(
                 "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11",
                 1_787_722_095_000L,
+                1_787_722_090_000L,
+                1_787_722_095_000L,
                 "https://example.com/frame.jpg",
                 1_787_725_695_000L,
                 12,
@@ -344,6 +423,8 @@ class TrainingMonitoringControllerTest {
                 .andExpect(jsonPath("$.result.frames[0].frameId")
                         .value("3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11"))
                 .andExpect(jsonPath("$.result.frames[0].capturedAt").value(1_787_722_095_000L))
+                .andExpect(jsonPath("$.result.frames[0].windowStart").value(1_787_722_090_000L))
+                .andExpect(jsonPath("$.result.frames[0].windowEnd").value(1_787_722_095_000L))
                 .andExpect(jsonPath("$.result.frames[0].imageUrl")
                         .value("https://example.com/frame.jpg"))
                 .andExpect(jsonPath("$.result.frames[0].urlExpiresAt").value(1_787_725_695_000L))

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingSessionControllerTest.java
@@ -219,14 +219,23 @@ class TrainingSessionControllerTest {
     // === end ===
 
     @Test
-    @DisplayName("POST /sessions/{sessionId}/end - 정상 종료하면 200을 반환한다")
+    @DisplayName("POST /sessions/{sessionId}/end - 정상 종료하면 200을 반환하고 endedAt을 포함한다")
     void endTrainingSession_success() throws Exception {
-        given(trainingSessionService.end(sessionId, EMAIL)).willReturn(sampleResponse(TrainingStatus.COMPLETED));
+        Instant endedAt = Instant.parse("2026-09-03T10:00:00Z");
+        TrainingSessionResponse response = TrainingSessionResponse.builder()
+                .status(TrainingStatus.COMPLETED)
+                .startedAt(Instant.parse("2026-09-03T09:00:00Z"))
+                .endedAt(endedAt)
+                .adminName("박현지")
+                .scenarioName("정기 훈련")
+                .build();
+        given(trainingSessionService.end(sessionId, EMAIL)).willReturn(response);
 
         mockMvc.perform(post("/api/v1/sessions/{sessionId}/end", sessionId)
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.status").value("COMPLETED"));
+                .andExpect(jsonPath("$.result.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.result.endedAt").value(endedAt.toString()));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -48,6 +48,7 @@ import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.s3.dto.PresignedGetUrl;
 import com.saferoute.infrastructure.s3.service.S3PresignedUrlService;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -591,7 +592,9 @@ class TrainingMonitoringServiceTest {
         CongestionConfig config = CongestionConfig.createDefault();
         given(congestionConfigService.getConfig()).willReturn(config);
 
+        Instant before = Instant.now();
         MonitoringContextResponse response = service.getContext(SESSION_ID, EMAIL);
+        Instant after = Instant.now();
 
         assertThat(response.sessionId()).isEqualTo(SESSION_ID);
         assertThat(response.scenarioName()).isEqualTo("3학년 A동 화재 대피 훈련");
@@ -599,7 +602,13 @@ class TrainingMonitoringServiceTest {
         assertThat(response.status()).isEqualTo(TrainingStatus.RUNNING);
         assertThat(response.startedAt()).isEqualTo(startedAt.toEpochMilli());
         assertThat(response.endedAt()).isNull();
-        assertThat(response.elapsedSeconds()).isGreaterThanOrEqualTo(0L);
+        // Clock을 주입하지 않으므로(코드베이스 전체가 Instant.now()를 직접 쓰는 컨벤션) 정확히 하나의
+        // 값으로 고정할 수는 없지만, 호출 직전/직후로 경계를 좁혀 실제 경과 시간과 일치하는지 검증한다.
+        assertThat(response.elapsedSeconds())
+                .isBetween(
+                        Duration.between(startedAt, before).getSeconds(),
+                        Duration.between(startedAt, after).getSeconds()
+                );
         assertThat(response.snapshotIntervalSec()).isEqualTo(config.getSnapshotIntervalSec());
         assertThat(response.stateStaleAfterSec()).isEqualTo(config.getStateStaleAfterSec());
     }

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -29,6 +29,7 @@ import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
 import com.saferoute.domain.training.dto.CurrentCctvStateResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraListResponse;
+import com.saferoute.domain.training.dto.MonitoringContextResponse;
 import com.saferoute.domain.training.dto.MonitoringCameraResponse;
 import com.saferoute.domain.training.dto.MonitoringEventListResponse;
 import com.saferoute.domain.training.dto.MonitoringEventResponse;
@@ -569,6 +570,57 @@ class TrainingMonitoringServiceTest {
         verify(cctvJpaRepository, never())
                 .findAllByEnabledTrueAndCustomNode_Floor_Building_IdOrderByCustomNode_Floor_FloorNumAscCodeAsc(
                         org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void 진행중인_세션의_모니터링_정보를_반환한다() {
+        TrainingSession session = org.mockito.Mockito.mock(TrainingSession.class);
+        TrainingScenario scenario = org.mockito.Mockito.mock(TrainingScenario.class);
+        Building building = org.mockito.Mockito.mock(Building.class);
+        Instant startedAt = Instant.now().minusSeconds(100);
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(SESSION_ID, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+        given(session.getStatus()).willReturn(TrainingStatus.RUNNING);
+        given(session.getId()).willReturn(SESSION_ID);
+        given(session.getStartedAt()).willReturn(startedAt);
+        given(session.getEndedAt()).willReturn(null);
+        given(session.getScenario()).willReturn(scenario);
+        given(scenario.getName()).willReturn("3학년 A동 화재 대피 훈련");
+        given(scenario.getBuilding()).willReturn(building);
+        given(building.getName()).willReturn("A동");
+        CongestionConfig config = CongestionConfig.createDefault();
+        given(congestionConfigService.getConfig()).willReturn(config);
+
+        MonitoringContextResponse response = service.getContext(SESSION_ID, EMAIL);
+
+        assertThat(response.sessionId()).isEqualTo(SESSION_ID);
+        assertThat(response.scenarioName()).isEqualTo("3학년 A동 화재 대피 훈련");
+        assertThat(response.buildingName()).isEqualTo("A동");
+        assertThat(response.status()).isEqualTo(TrainingStatus.RUNNING);
+        assertThat(response.startedAt()).isEqualTo(startedAt.toEpochMilli());
+        assertThat(response.endedAt()).isNull();
+        assertThat(response.elapsedSeconds()).isGreaterThanOrEqualTo(0L);
+        assertThat(response.snapshotIntervalSec()).isEqualTo(config.getSnapshotIntervalSec());
+        assertThat(response.stateStaleAfterSec()).isEqualTo(config.getStateStaleAfterSec());
+    }
+
+    @Test
+    void 모니터링_정보_조회는_실행_중이_아닌_세션은_거부한다() {
+        stubSession(TrainingStatus.COMPLETED);
+
+        assertThatThrownBy(() -> service.getContext(SESSION_ID, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TrainingErrorCode.RUNNING_TRAINING_SESSION_NOT_FOUND);
+    }
+
+    @Test
+    void 모니터링_정보_조회는_다른_학교의_세션은_존재_여부를_노출하지_않고_거부한다() {
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(SESSION_ID, SCHOOL_NAME))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getContext(SESSION_ID, EMAIL))
+                .isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TrainingErrorCode.TRAINING_SESSION_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -22,6 +22,7 @@ import com.saferoute.domain.evacuation.service.EvacuationRouteService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.training.dto.CreateSessionRequest;
 import com.saferoute.domain.training.dto.TrainingSessionListResponse;
+import com.saferoute.domain.training.dto.TrainingSessionResponse;
 import com.saferoute.domain.training.dto.TrainingSessionSummaryResponse;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -504,10 +505,11 @@ class TrainingSessionServiceTest {
         TrainingSession session = sessionWithStatus(TrainingStatus.RUNNING);
         given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME)).willReturn(Optional.of(session));
 
-        trainingSessionService.end(sessionId, EMAIL);
+        TrainingSessionResponse response = trainingSessionService.end(sessionId, EMAIL);
 
         assertThat(session.getStatus()).isEqualTo(TrainingStatus.COMPLETED);
         assertThat(session.getEndedAt()).isNotNull();
+        assertThat(response.getEndedAt()).isEqualTo(session.getEndedAt());
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
         verify(session.getScenario(), times(1)).markCompleted();
         verify(ioTLightService).resetToNormal(buildingId);
@@ -546,9 +548,11 @@ class TrainingSessionServiceTest {
         TrainingSession session = sessionWithStatus(TrainingStatus.RUNNING);
         given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME)).willReturn(Optional.of(session));
 
-        trainingSessionService.forceEnd(sessionId, EMAIL);
+        TrainingSessionResponse response = trainingSessionService.forceEnd(sessionId, EMAIL);
 
         assertThat(session.getStatus()).isEqualTo(TrainingStatus.STOPPED);
+        assertThat(session.getEndedAt()).isNotNull();
+        assertThat(response.getEndedAt()).isEqualTo(session.getEndedAt());
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(session);
         verify(session.getScenario(), times(1)).markError();
         verify(ioTLightService).resetToNormal(buildingId);

--- a/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
+++ b/src/test/java/com/saferoute/global/security/SecurityAuthorizationIntegrationTest.java
@@ -236,6 +236,32 @@ class SecurityAuthorizationIntegrationTest {
     }
 
     @Test
+    @DisplayName("일반 사용자는 모니터링 세션 정보를 조회할 수 없다")
+    void normalUserCannotReadTrainingMonitoringContext() throws Exception {
+        String token = signupAndLogin(UserRole.NORMAL);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/context", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("관리자는 모니터링 세션 정보 엔드포인트에 접근할 수 있다")
+    void managerCanReadTrainingMonitoringContext() throws Exception {
+        String token = signupAndLogin(UserRole.MANAGER);
+
+        mockMvc.perform(
+                        get("/api/v1/sessions/{sessionId}/monitoring/context", UUID.randomUUID())
+                                .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAINING001"));
+    }
+
+    @Test
     @DisplayName("일반 사용자는 훈련 세션 목록을 조회할 수 없다")
     void normalUserCannotReadTrainingSessions() throws Exception {
         String token = signupAndLogin(UserRole.NORMAL);


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #180
- Branch: feat/#180

## 주요 내용

- `TrainingSessionResponse`(세션 생성/시작/종료/강제종료 API의 공통 응답)에 `endedAt` 추가
  - 지금까지 `TrainingSession` 엔티티와 WebSocket 훈련 상태 이벤트에는 `endedAt`이 있었지만 REST 응답에는 빠져 있어, 종료 API를 호출한 클라이언트가 응답만으로 종료 시각을 받을 방법이 없었음
  - `end`/`force-end` 응답에 방금 기록된 종료 시각이 그대로 담겨 오도록 수정
- `GET /api/v1/sessions/{sessionId}/monitoring/context` 신규 API 추가
  - 모니터링 상세 화면 헤더에 필요한 세션 기본 정보(시나리오명, 건물명, 상태, 시작/종료 시각, 경과 시간)와 전역 설정값(저장 간격, CCTV 현재 상태 stale 판정 기준)을 한 번에 제공
  - 다른 모니터링 조회 API와 동일하게 RUNNING 세션만 허용, SecurityConfig의 MANAGER 전용 규칙에도 함께 추가
- 프레임 목록(`GET .../monitoring/cameras/{cctvId}/frames`) 응답에 `windowStart`/`windowEnd`(분석 구간 시작/종료 시각) 추가
  - `ObservationItem`에는 이미 있었지만 관리자용 응답에는 `capturedAt`(대표 프레임 촬영 시각)만 노출되어 "촬영 종료 시간"을 표현할 방법이 없었음

## 정책

- `elapsedSeconds`: RUNNING이면 현재 시각 기준, 종료된 세션이면 종료 시각 기준으로 고정
- `snapshotIntervalSec`/`stateStaleAfterSec`: 세션별 값이 아니라 전역 `CongestionConfig`의 현재 값을 그대로 노출 (설정이 바뀌면 응답도 함께 바뀜)
- `windowStart`/`windowEnd`(프레임 분석 구간)와 `context`의 `startedAt`/`endedAt`(훈련 전체)은 서로 다른 시간 축 — Swagger에 명시
- `context` API는 종료된 세션을 아직 조회할 수 없음 (RUNNING만 허용). 새로고침 후 종료 시각을 복구하는 경로는 이번 PR 범위 밖 — 종료 세션 읽기 허용은 후속 이슈에서 처리 예정

## 프론트 연동 참고 (Swagger에도 반영됨)

- `/end`, `/force-end` 응답의 `endedAt`은 방금 종료 처리된 시각이 그대로 담겨 오므로 별도 조회 없이 바로 표시 가능. 단 새로고침 후 재조회로 복구하는 API는 아직 없음
- `context.snapshotIntervalSec`/`stateStaleAfterSec`는 세션별이 아닌 전역 설정값
- `windowStart`/`windowEnd` vs `startedAt`/`endedAt` 시간 축 혼동 주의

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모니터링 화면에서 세션 기본 정보와 혼잡 설정값을 조회할 수 있습니다.
  * 모니터링 프레임 응답에 분석 구간의 시작·종료 시각이 포함됩니다.
  * 세션 종료 응답에서 실제 종료 시각을 확인할 수 있습니다.
* **권한**
  * 모니터링 세션 정보 조회는 관리자 권한으로 제한됩니다.
* **문서화**
  * 세션 종료 시각 및 프레임 분석 구간에 대한 API 설명과 예시가 보강되었습니다.
* **테스트**
  * 모니터링 컨텍스트 조회, 권한, 종료 시각 및 오류 상황 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->