### PR TITLE
[Fix] #194: 이벤트 타임라인 100건 제한 및 cctvCode 필터 누락 수정

### DIFF
--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
@@ -92,6 +92,43 @@ public class CongestionEventRepository {
                 .toList();
     }
 
+    // 이벤트 타임라인 조회 전용: 최신순으로 커서 페이지네이션하며, cctvCode 필터를 DynamoDB
+    // FilterExpression으로 적용한다(애플리케이션 레벨 필터 대신) - 필터로 줄어든 만큼 SDK가
+    // LastEvaluatedKey를 따라 다음 물리 페이지를 자동으로 더 읽어오므로, 특정 CCTV로 필터링해도
+    // 다른 CCTV 이벤트에 밀려 결과가 누락되지 않는다.
+    public List<CongestionEventItem> findPageBySessionId(
+            String trainingSessionId,
+            String cctvCode,
+            int limit,
+            Long beforeDetectedAt,
+            String beforeEventId
+    ) {
+        validateLimit(limit);
+        QueryConditional queryConditional = beforeDetectedAt == null
+                ? QueryConditional.keyEqualTo(Key.builder()
+                        .partitionValue(CongestionEventItem.buildGsi1Pk(trainingSessionId))
+                        .build())
+                : QueryConditional.sortLessThan(Key.builder()
+                        .partitionValue(CongestionEventItem.buildGsi1Pk(trainingSessionId))
+                        .sortValue(CongestionEventItem.buildGsi1Sk(beforeDetectedAt, beforeEventId))
+                        .build());
+        QueryEnhancedRequest.Builder requestBuilder = QueryEnhancedRequest.builder()
+                .queryConditional(queryConditional)
+                .scanIndexForward(false);
+        if (cctvCode != null) {
+            requestBuilder.filterExpression(Expression.builder()
+                    .expression("#cctvCode = :cctvCode")
+                    .putExpressionName("#cctvCode", "cctvCode")
+                    .putExpressionValue(":cctvCode", AttributeValue.fromS(cctvCode))
+                    .build());
+        }
+
+        return gsi1.query(requestBuilder.build()).stream()
+                .flatMap(page -> page.items().stream())
+                .limit(limit)
+                .toList();
+    }
+
     public boolean updateEventStatus(
             String eventId,
             EventProcessingStatus expectedStatus,

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
@@ -114,7 +114,8 @@ public class CongestionEventRepository {
                         .build());
         QueryEnhancedRequest.Builder requestBuilder = QueryEnhancedRequest.builder()
                 .queryConditional(queryConditional)
-                .scanIndexForward(false);
+                .scanIndexForward(false)
+                .limit(limit);
         if (cctvCode != null) {
             requestBuilder.filterExpression(Expression.builder()
                     .expression("#cctvCode = :cctvCode")

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -660,13 +660,19 @@ public class TrainingMonitoringController {
             summary = "이벤트 타임라인 조회",
             description = """
                     훈련 세션에서 발생한 혼잡 감지 이벤트(CongestionEventItem)와 경로 재탐색 이벤트
-                    (RouteRecalculation)를 발생 시각 오름차순으로 통합해 반환합니다. 세션 상태와
-                    무관하게 조회할 수 있습니다.
+                    (RouteRecalculation)를 발생 시각 최신순으로 통합해 커서 페이지네이션으로
+                    반환합니다. 세션 상태와 무관하게 조회할 수 있습니다.
+
+                    cursor를 생략하면 가장 최신 이벤트부터 반환합니다. 다음 페이지가 있으면
+                    응답의 nextCursor를 다음 요청의 cursor로 그대로 전달하면 되며, hasNext가
+                    false이면 더 이상 조회할 이벤트가 없다는 뜻입니다.
 
                     경로 재탐색 한 건은 요청 시점 이벤트 하나로 시작해, 관리자가 승인/거절하거나
                     시스템이 자동 취소하면 해소 시점 이벤트가 하나 더 추가됩니다.
 
-                    cctvCode를 지정하면 해당 CCTV와 관련된 이벤트만 반환합니다.
+                    cctvCode를 지정하면 해당 CCTV와 관련된 이벤트만 반환합니다. 이 필터는 DynamoDB
+                    쿼리 단계에서 적용되므로, 다른 CCTV 이벤트가 많아도 원하는 CCTV의 이벤트가
+                    누락되지 않습니다.
 
                     AI 분석 시작, 경로 이탈, 위험 구역 진입 이벤트는 아직 Pi/AI 쪽 이벤트 수신
                     계약이 없어 이 API에 포함되지 않습니다.
@@ -700,11 +706,27 @@ public class TrainingMonitoringController {
                                                     "congestionLevel": "CAUTION",
                                                     "message": "혼잡 감지 · CCTV_001"
                                                   }
-                                                ]
+                                                ],
+                                                "nextCursor": "MTc4NzcyMjA5NTAwMHwzYzlmN2UyYS0zYjM5LTRmMGEtOWYwYS02YTJiNmIxZjVhMTE",
+                                                "hasNext": true
                                               }
                                             }
                                             """
                             )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "cursor 형식이 올바르지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON400",
+                                      "message": "입력값이 올바르지 않습니다."
+                                    }
+                                    """)
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -760,10 +782,17 @@ public class TrainingMonitoringController {
             @PathVariable UUID sessionId,
             @Parameter(description = "특정 CCTV의 이벤트만 조회하려면 지정", example = "CCTV_001")
             @RequestParam(required = false) String cctvCode,
+            @Parameter(description = "한 페이지에 조회할 이벤트 개수", example = "20")
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int limit,
+            @Parameter(
+                    description = "이전 응답의 nextCursor. 생략하면 최신 이벤트부터 조회",
+                    example = "MTc4NzcyMjA5NTAwMHwzYzlmN2UyYS0zYjM5LTRmMGEtOWYwYS02YTJiNmIxZjVhMTE"
+            )
+            @RequestParam(required = false) String cursor,
             Authentication authentication
     ) {
         MonitoringEventListResponse response = trainingMonitoringService.getEvents(
-                sessionId, cctvCode, authentication.getName());
+                sessionId, cctvCode, limit, cursor, authentication.getName());
         return ResponseEntity.ok(ApiResponse.success(
                 TrainingSuccessCode.MONITORING_EVENT_LIST_FOUND,
                 response

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringEventListResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringEventListResponse.java
@@ -5,15 +5,25 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.UUID;
 
-@Schema(description = "훈련 세션의 이벤트 타임라인")
+@Schema(description = "훈련 세션의 이벤트 타임라인 (최신순 커서 페이지네이션)")
 public record MonitoringEventListResponse(
         @Schema(description = "조회한 훈련 세션 ID", example = "d669294e-55e1-4c00-bf67-229d89b76948")
         UUID sessionId,
 
         @ArraySchema(
-                arraySchema = @Schema(description = "발생 시각 오름차순으로 정렬된 이벤트 목록. 없으면 빈 배열"),
+                arraySchema = @Schema(description = "발생 시각 최신순으로 정렬된 이벤트 목록. 없으면 빈 배열"),
                 schema = @Schema(implementation = MonitoringEventResponse.class)
         )
-        List<MonitoringEventResponse> events
+        List<MonitoringEventResponse> events,
+
+        @Schema(
+                description = "다음 페이지 조회에 사용할 커서. 다음 페이지가 없으면 null",
+                example = "MTc4NzcyMjA5NTAwMHwzYzlmN2UyYS0zYjM5LTRmMGEtOWYwYS02YTJiNmIxZjVhMTE",
+                nullable = true
+        )
+        String nextCursor,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
 ) {
 }

--- a/src/main/java/com/saferoute/domain/training/service/PageCursor.java
+++ b/src/main/java/com/saferoute/domain/training/service/PageCursor.java
@@ -5,21 +5,22 @@ import com.saferoute.global.api.exception.ApiException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-// 프레임 목록의 nextCursor를 만들고 해석한다. 클라이언트에는 불투명한 문자열로만 노출된다.
-// capturedAt이 같은 프레임이 페이지 경계에 있어도 eventId를 함께 인코딩해 페이지 재개 지점을
-// 정확히 가리키도록 한다 (ObservationItem.buildGsi1Sk 참고).
-final class FrameCursor {
+// 최신순 커서 페이지네이션(프레임 목록, 이벤트 타임라인)의 nextCursor를 만들고 해석한다.
+// 클라이언트에는 불투명한 문자열로만 노출된다. timestamp가 같은 항목이 페이지 경계에 있어도
+// id를 함께 인코딩해 페이지 재개 지점을 정확히 가리키도록 한다
+// (ObservationItem.buildGsi1Sk, CongestionEventItem.buildGsi1Sk 참고).
+final class PageCursor {
 
     private static final String SEPARATOR = "|";
 
-    private FrameCursor() {
+    private PageCursor() {
     }
 
-    record Position(long capturedAt, String eventId) {
+    record Position(long timestamp, String id) {
     }
 
-    static String encode(long capturedAt, String eventId) {
-        String raw = capturedAt + SEPARATOR + eventId;
+    static String encode(long timestamp, String id) {
+        String raw = timestamp + SEPARATOR + id;
         return Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
     }
@@ -34,9 +35,9 @@ final class FrameCursor {
             if (separatorIndex < 0 || separatorIndex == decoded.length() - 1) {
                 throw new IllegalArgumentException("cursor 형식이 올바르지 않습니다.");
             }
-            long capturedAt = Long.parseLong(decoded.substring(0, separatorIndex));
-            String eventId = decoded.substring(separatorIndex + 1);
-            return new Position(capturedAt, eventId);
+            long timestamp = Long.parseLong(decoded.substring(0, separatorIndex));
+            String id = decoded.substring(separatorIndex + 1);
+            return new Position(timestamp, id);
         } catch (IllegalArgumentException exception) {
             throw new ApiException(ErrorCode.INVALID_INPUT, exception);
         }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -154,9 +154,9 @@ public class TrainingMonitoringService {
     ) {
         TrainingSession session = findSessionForSchool(sessionId, email);
         Cctv cctv = findCctvInSessionBuilding(cctvId, session);
-        FrameCursor.Position position = FrameCursor.decode(cursor);
-        Long beforeCapturedAt = position != null ? position.capturedAt() : null;
-        String beforeEventId = position != null ? position.eventId() : null;
+        PageCursor.Position position = PageCursor.decode(cursor);
+        Long beforeCapturedAt = position != null ? position.timestamp() : null;
+        String beforeEventId = position != null ? position.id() : null;
 
         // hasNext 판단을 위해 요청한 개수보다 하나 더 조회한다.
         List<ObservationItem> page = observationRepository.findPageBySessionIdAndCctvCode(
@@ -169,7 +169,7 @@ public class TrainingMonitoringService {
                 .map(this::toFrameResponse)
                 .toList();
         String nextCursor = hasNext
-                ? FrameCursor.encode(
+                ? PageCursor.encode(
                         items.get(items.size() - 1).getCapturedAt(),
                         items.get(items.size() - 1).getEventId())
                 : null;
@@ -177,25 +177,69 @@ public class TrainingMonitoringService {
         return new MonitoringFrameListResponse(sessionId, cctvId, frames, nextCursor, hasNext);
     }
 
-    // 혼잡 감지 이벤트(CongestionEventItem)와 경로 재탐색 이벤트(RouteRecalculation)를 발생 시각순으로 합친다.
-    // 관측값(ObservationItem)은 5초 주기 스냅샷이라 타임라인에 넣으면 너무 촘촘해져서 제외한다 -
-    // "이벤트"로 부를 만한 STARTED/LEVEL_UP/ENDED 전환만 대상으로 한다.
-    // 재탐색 한 건은 요청 시점과(있다면) 해소 시점 두 항목으로 나뉠 수 있다.
-    public MonitoringEventListResponse getEvents(UUID sessionId, String cctvCode, String email) {
+    // 혼잡 감지 이벤트(CongestionEventItem)와 경로 재탐색 이벤트(RouteRecalculation)를 발생 시각
+    // 최신순으로 합쳐 커서 페이지네이션한다. 관측값(ObservationItem)은 5초 주기 스냅샷이라
+    // 타임라인에 넣으면 너무 촘촘해져서 제외한다 - "이벤트"로 부를 만한 STARTED/LEVEL_UP/ENDED
+    // 전환만 대상으로 한다. 재탐색 한 건은 요청 시점과(있다면) 해소 시점 두 항목으로 나뉠 수 있다.
+    //
+    // 혼잡 이벤트(DynamoDB)는 세션당 수백 건까지도 쌓일 수 있어 커서 페이지네이션 + cctvCode
+    // DB 필터가 필요하다. 재탐색 이벤트(PostgreSQL)는 쿨다운으로 발생 빈도가 낮아 매 요청마다
+    // 전량 조회해도 무리가 없으므로 별도 페이지네이션 없이 가져온 뒤, 혼잡 이벤트와 동일한 커서
+    // 경계로 걸러 중복 없이 병합한다.
+    public MonitoringEventListResponse getEvents(
+            UUID sessionId, String cctvCode, int limit, String cursor, String email
+    ) {
         findSessionForSchool(sessionId, email);
 
-        List<MonitoringEventResponse> events = new ArrayList<>();
-        congestionEventRepository.findAllBySessionId(sessionId.toString()).stream()
-                .filter(item -> matchesCctv(item.getCctvCode(), cctvCode))
-                .map(MonitoringEventResponse::fromCongestionEvent)
-                .forEach(events::add);
+        PageCursor.Position position = PageCursor.decode(cursor);
+        Long beforeOccurredAt = position != null ? position.timestamp() : null;
+        String beforeEventId = position != null ? position.id() : null;
 
+        // hasNext 판단을 위해 요청한 개수보다 하나 더 조회한다.
+        List<MonitoringEventResponse> congestionEvents = congestionEventRepository
+                .findPageBySessionId(sessionId.toString(), cctvCode, limit + 1, beforeOccurredAt, beforeEventId)
+                .stream()
+                .map(MonitoringEventResponse::fromCongestionEvent)
+                .toList();
+
+        List<MonitoringEventResponse> allRecalculationEvents = new ArrayList<>();
         routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(sessionId).stream()
                 .filter(recalculation -> matchesCctv(recalculation.getCctvCode(), cctvCode))
-                .forEach(recalculation -> addRecalculationEvents(events, recalculation));
+                .forEach(recalculation -> addRecalculationEvents(allRecalculationEvents, recalculation));
+        List<MonitoringEventResponse> recalculationEvents = beforeOccurredAt == null
+                ? allRecalculationEvents
+                : allRecalculationEvents.stream()
+                        .filter(event -> isBeforeCursor(event, beforeOccurredAt, beforeEventId))
+                        .toList();
 
-        events.sort(Comparator.comparingLong(MonitoringEventResponse::occurredAt));
-        return new MonitoringEventListResponse(sessionId, events);
+        List<MonitoringEventResponse> merged = new ArrayList<>(congestionEvents.size() + recalculationEvents.size());
+        merged.addAll(congestionEvents);
+        merged.addAll(recalculationEvents);
+        merged.sort(EVENT_ORDER);
+
+        boolean hasNext = merged.size() > limit;
+        List<MonitoringEventResponse> page = hasNext ? merged.subList(0, limit) : merged;
+        String nextCursor = hasNext
+                ? PageCursor.encode(page.get(page.size() - 1).occurredAt(), page.get(page.size() - 1).eventId())
+                : null;
+
+        return new MonitoringEventListResponse(sessionId, page, nextCursor, hasNext);
+    }
+
+    // 발생 시각 내림차순(최신 먼저), 같은 시각이면 eventId 내림차순. isBeforeCursor()와 방향을
+    // 맞춰야 페이지 경계에서 이벤트가 중복되거나 누락되지 않는다.
+    private static final Comparator<MonitoringEventResponse> EVENT_ORDER = Comparator
+            .comparingLong(MonitoringEventResponse::occurredAt).reversed()
+            .thenComparing(Comparator.comparing(MonitoringEventResponse::eventId).reversed());
+
+    // 커서보다 "이후 페이지"에 속하는(=더 오래된) 이벤트인지 판단한다. CongestionEventRepository의
+    // sortLessThan 커서 조건과 동일한 (timestamp, id) 비교 규칙을 써야 두 소스를 병합했을 때 경계가
+    // 어긋나지 않는다.
+    private boolean isBeforeCursor(MonitoringEventResponse event, long beforeOccurredAt, String beforeEventId) {
+        if (event.occurredAt() != beforeOccurredAt) {
+            return event.occurredAt() < beforeOccurredAt;
+        }
+        return event.eventId().compareTo(beforeEventId) < 0;
     }
 
     private void addRecalculationEvents(List<MonitoringEventResponse> events, RouteRecalculation recalculation) {

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepositoryTest.java
@@ -104,6 +104,66 @@ class CongestionEventRepositoryTest {
     }
 
     @Test
+    void 이벤트_타임라인은_최신순으로_조회한다() {
+        CongestionEventItem newest = item("event-1", 2_000L);
+        CongestionEventItem oldest = item("event-2", 1_000L);
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(CongestionEventItem.class)
+                        .items(List.of(newest, oldest)).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        List<CongestionEventItem> result = repository.findPageBySessionId(
+                SESSION_ID.toString(), null, 10, null, null);
+
+        verify(gsi1).query(captor.capture());
+        assertThat(captor.getValue().scanIndexForward()).isFalse();
+        assertThat(captor.getValue().filterExpression()).isNull();
+        assertThat(captor.getValue().queryConditional()
+                .expression(TableSchema.fromBean(CongestionEventItem.class), CongestionEventItem.GSI1_NAME)
+                .expressionValues().values())
+                .extracting(value -> value.s())
+                .contains("SESSION#" + SESSION_ID);
+        assertThat(result).containsExactly(newest, oldest);
+    }
+
+    @Test
+    void cctvCode가_있으면_필터_익스프레션을_적용한다() {
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(CongestionEventItem.class)
+                        .items(List.of()).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        repository.findPageBySessionId(SESSION_ID.toString(), "CCTV_001", 10, null, null);
+
+        verify(gsi1).query(captor.capture());
+        assertThat(captor.getValue().filterExpression()).isNotNull();
+        assertThat(captor.getValue().filterExpression().expression())
+                .isEqualTo("#cctvCode = :cctvCode");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":cctvCode").s())
+                .isEqualTo("CCTV_001");
+    }
+
+    @Test
+    void cursor가_있으면_해당_시각_이전_이벤트만_조회한다() {
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(CongestionEventItem.class)
+                        .items(List.of()).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        repository.findPageBySessionId(SESSION_ID.toString(), null, 10, 2_000L, "event-1");
+
+        verify(gsi1).query(captor.capture());
+        assertThat(captor.getValue().queryConditional()
+                .expression(TableSchema.fromBean(CongestionEventItem.class), CongestionEventItem.GSI1_NAME)
+                .expressionValues().values())
+                .extracting(value -> value.s())
+                .contains("EVENT#2000#event-1");
+    }
+
+    @Test
     void 이벤트를_RECEIVED_PROCESSING_PROCESSED_순서로_변경한다() {
         ArgumentCaptor<UpdateItemEnhancedRequest<CongestionEventItem>> captor = updateCaptor();
 

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepositoryTest.java
@@ -118,6 +118,7 @@ class CongestionEventRepositoryTest {
 
         verify(gsi1).query(captor.capture());
         assertThat(captor.getValue().scanIndexForward()).isFalse();
+        assertThat(captor.getValue().limit()).isEqualTo(10);
         assertThat(captor.getValue().filterExpression()).isNull();
         assertThat(captor.getValue().queryConditional()
                 .expression(TableSchema.fromBean(CongestionEventItem.class), CongestionEventItem.GSI1_NAME)

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -440,8 +440,8 @@ class TrainingMonitoringControllerTest {
                 CongestionLevel.CAUTION,
                 "혼잡 감지 · CCTV_001"
         );
-        given(trainingMonitoringService.getEvents(SESSION_ID, null, EMAIL))
-                .willReturn(new MonitoringEventListResponse(SESSION_ID, List.of(event)));
+        given(trainingMonitoringService.getEvents(SESSION_ID, null, 20, null, EMAIL))
+                .willReturn(new MonitoringEventListResponse(SESSION_ID, List.of(event), "next-cursor", true));
 
         mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
@@ -456,13 +456,15 @@ class TrainingMonitoringControllerTest {
                 .andExpect(jsonPath("$.result.events[0].occurredAt").value(1_787_722_095_000L))
                 .andExpect(jsonPath("$.result.events[0].cctvCode").value("CCTV_001"))
                 .andExpect(jsonPath("$.result.events[0].congestionLevel").value("CAUTION"))
-                .andExpect(jsonPath("$.result.events[0].message").value("혼잡 감지 · CCTV_001"));
+                .andExpect(jsonPath("$.result.events[0].message").value("혼잡 감지 · CCTV_001"))
+                .andExpect(jsonPath("$.result.nextCursor").value("next-cursor"))
+                .andExpect(jsonPath("$.result.hasNext").value(true));
     }
 
     @Test
     void cctvCode_쿼리파라미터를_서비스에_그대로_전달한다() throws Exception {
-        given(trainingMonitoringService.getEvents(SESSION_ID, "CCTV_001", EMAIL))
-                .willReturn(new MonitoringEventListResponse(SESSION_ID, List.of()));
+        given(trainingMonitoringService.getEvents(SESSION_ID, "CCTV_001", 20, null, EMAIL))
+                .willReturn(new MonitoringEventListResponse(SESSION_ID, List.of(), null, false));
 
         mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
                         .param("cctvCode", "CCTV_001")
@@ -472,8 +474,41 @@ class TrainingMonitoringControllerTest {
     }
 
     @Test
+    void 이벤트_타임라인_조회시_limit과_cursor_쿼리파라미터를_서비스에_그대로_전달한다() throws Exception {
+        given(trainingMonitoringService.getEvents(SESSION_ID, null, 5, "prev-cursor", EMAIL))
+                .willReturn(new MonitoringEventListResponse(SESSION_ID, List.of(), null, false));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
+                        .param("limit", "5")
+                        .param("cursor", "prev-cursor")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.events").isEmpty());
+    }
+
+    @Test
+    void 이벤트_타임라인_조회_limit이_범위를_벗어나면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
+                        .param("limit", "0")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 이벤트_타임라인_조회시_cursor_형식이_올바르지_않으면_400을_반환한다() throws Exception {
+        given(trainingMonitoringService.getEvents(SESSION_ID, null, 20, "invalid-cursor", EMAIL))
+                .willThrow(new ApiException(ErrorCode.INVALID_INPUT));
+
+        mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)
+                        .param("cursor", "invalid-cursor")
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON400"));
+    }
+
+    @Test
     void 이벤트_타임라인_조회시_세션을_찾을_수_없으면_404를_반환한다() throws Exception {
-        given(trainingMonitoringService.getEvents(SESSION_ID, null, EMAIL))
+        given(trainingMonitoringService.getEvents(SESSION_ID, null, 20, null, EMAIL))
                 .willThrow(new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
 
         mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/events", SESSION_ID)

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -702,7 +702,7 @@ class TrainingMonitoringServiceTest {
                 .containsExactly(3_000L, 2_000L);
         assertThat(response.hasNext()).isTrue();
         assertThat(response.nextCursor())
-                .isEqualTo(FrameCursor.encode(2_000L, middleEventId.toString()));
+                .isEqualTo(PageCursor.encode(2_000L, middleEventId.toString()));
     }
 
     @Test
@@ -736,7 +736,7 @@ class TrainingMonitoringServiceTest {
                 .willReturn(List.of());
 
         service.getFrames(
-                SESSION_ID, CCTV_ID, 20, FrameCursor.encode(1_000L, cursorEventId.toString()), EMAIL);
+                SESSION_ID, CCTV_ID, 20, PageCursor.encode(1_000L, cursorEventId.toString()), EMAIL);
 
         verify(observationRepository).findPageBySessionIdAndCctvCode(
                 SESSION_ID.toString(), "CCTV_001", 21, 1_000L, cursorEventId.toString());
@@ -820,89 +820,142 @@ class TrainingMonitoringServiceTest {
     }
 
     @Test
-    void 혼잡_이벤트와_재탐색_이벤트를_발생_시각순으로_합쳐_반환한다() {
+    void 혼잡_이벤트와_재탐색_이벤트를_발생_시각_최신순으로_합쳐_반환한다() {
         stubSession(TrainingStatus.RUNNING);
         CongestionEventItem congestionEvent = congestionEventItem(
                 "CCTV_001", CongestionEventType.CONGESTION_STARTED, 1_000L, CongestionLevel.CAUTION);
-        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString()))
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
                 .willReturn(List.of(congestionEvent));
         RouteRecalculation recalculation = recalculation(
                 "CCTV_001", CongestionLevel.CROWDED, Instant.ofEpochMilli(2_000L), null, null);
         given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
                 .willReturn(List.of(recalculation));
 
-        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, EMAIL);
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, 20, null, EMAIL);
 
         assertThat(response.sessionId()).isEqualTo(SESSION_ID);
         assertThat(response.events())
                 .extracting(MonitoringEventResponse::type, MonitoringEventResponse::occurredAt)
                 .containsExactly(
-                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.CONGESTION_STARTED, 1_000L),
-                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.ROUTE_RECALCULATION_REQUESTED, 2_000L)
+                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.ROUTE_RECALCULATION_REQUESTED, 2_000L),
+                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.CONGESTION_STARTED, 1_000L)
                 );
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
     }
 
     @Test
     void 해소된_재탐색은_요청과_해소_두_이벤트로_나뉜다() {
         stubSession(TrainingStatus.RUNNING);
-        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString())).willReturn(List.of());
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
+                .willReturn(List.of());
         RouteRecalculation recalculation = recalculation(
                 "CCTV_001", CongestionLevel.CROWDED,
                 Instant.ofEpochMilli(1_000L), Instant.ofEpochMilli(3_000L), RecalculationStatus.APPROVED);
         given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
                 .willReturn(List.of(recalculation));
 
-        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, EMAIL);
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, 20, null, EMAIL);
 
         assertThat(response.events())
                 .extracting(MonitoringEventResponse::type)
                 .containsExactly(
-                        MonitoringEventType.ROUTE_RECALCULATION_REQUESTED,
-                        MonitoringEventType.EVACUATION_ROUTE_UPDATED
+                        MonitoringEventType.EVACUATION_ROUTE_UPDATED,
+                        MonitoringEventType.ROUTE_RECALCULATION_REQUESTED
                 );
     }
 
     @Test
-    void cctvCode로_필터링한다() {
+    void cctvCode를_저장소_조회_조건으로_전달한다() {
         stubSession(TrainingStatus.RUNNING);
         CongestionEventItem matching = congestionEventItem(
                 "CCTV_001", CongestionEventType.CONGESTION_STARTED, 1_000L, CongestionLevel.CAUTION);
-        CongestionEventItem other = congestionEventItem(
-                "CCTV_002", CongestionEventType.CONGESTION_STARTED, 1_500L, CongestionLevel.CAUTION);
-        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString()))
-                .willReturn(List.of(matching, other));
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), "CCTV_001", 21, null, null))
+                .willReturn(List.of(matching));
         given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
                 .willReturn(List.of());
 
-        MonitoringEventListResponse response = service.getEvents(SESSION_ID, "CCTV_001", EMAIL);
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, "CCTV_001", 20, null, EMAIL);
 
         assertThat(response.events()).singleElement()
                 .extracting(MonitoringEventResponse::cctvCode)
                 .isEqualTo("CCTV_001");
+        verify(congestionEventRepository)
+                .findPageBySessionId(SESSION_ID.toString(), "CCTV_001", 21, null, null);
     }
 
     @Test
     void 이벤트가_없는_세션은_빈_타임라인을_반환한다() {
         stubSession(TrainingStatus.RUNNING);
-        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString())).willReturn(List.of());
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
+                .willReturn(List.of());
         given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
                 .willReturn(List.of());
 
-        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, EMAIL);
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, 20, null, EMAIL);
 
         assertThat(response.events()).isEmpty();
+        assertThat(response.hasNext()).isFalse();
     }
 
     @Test
     void 종료된_세션도_이벤트_타임라인을_조회할_수_있다() {
         stubSession(TrainingStatus.COMPLETED);
-        given(congestionEventRepository.findAllBySessionId(SESSION_ID.toString())).willReturn(List.of());
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
+                .willReturn(List.of());
         given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
                 .willReturn(List.of());
 
-        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, EMAIL);
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, 20, null, EMAIL);
 
         assertThat(response.events()).isEmpty();
+    }
+
+    @Test
+    void 혼잡_이벤트가_limit을_초과하면_hasNext가_true이고_nextCursor를_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        CongestionEventItem newest = congestionEventItem(
+                "CCTV_001", CongestionEventType.CONGESTION_STARTED, 3_000L, CongestionLevel.CAUTION);
+        CongestionEventItem middle = congestionEventItem(
+                "CCTV_001", CongestionEventType.CONGESTION_LEVEL_UP, 2_000L, CongestionLevel.CROWDED);
+        CongestionEventItem oldest = congestionEventItem(
+                "CCTV_001", CongestionEventType.CONGESTION_ENDED, 1_000L, CongestionLevel.NORMAL);
+        // limit+1(=3)을 요청해 3건이 그대로 돌아오면 더 있을 수 있다는 뜻이라 hasNext=true다.
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 3, null, null))
+                .willReturn(List.of(newest, middle, oldest));
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of());
+
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, 2, null, EMAIL);
+
+        assertThat(response.events())
+                .extracting(MonitoringEventResponse::occurredAt)
+                .containsExactly(3_000L, 2_000L);
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.nextCursor())
+                .isEqualTo(PageCursor.encode(2_000L, middle.getEventId()));
+    }
+
+    @Test
+    void cursor_이전에_이미_반환된_재탐색_이벤트는_다음_페이지에서_중복되지_않는다() {
+        stubSession(TrainingStatus.RUNNING);
+        UUID cursorEventId = UUID.randomUUID();
+        given(congestionEventRepository.findPageBySessionId(
+                SESSION_ID.toString(), null, 21, 2_000L, cursorEventId.toString()))
+                .willReturn(List.of());
+        RouteRecalculation alreadyShown = recalculation(
+                "CCTV_001", CongestionLevel.CROWDED, Instant.ofEpochMilli(3_000L), null, null);
+        RouteRecalculation stillToShow = recalculation(
+                "CCTV_001", CongestionLevel.CROWDED, Instant.ofEpochMilli(1_000L), null, null);
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of(alreadyShown, stillToShow));
+
+        MonitoringEventListResponse response = service.getEvents(
+                SESSION_ID, null, 20, PageCursor.encode(2_000L, cursorEventId.toString()), EMAIL);
+
+        assertThat(response.events())
+                .extracting(MonitoringEventResponse::occurredAt)
+                .containsExactly(1_000L);
     }
 
     private CongestionEventItem congestionEventItem(


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #194
- Branch: feat/#194

## 주요 내용

- 혼잡 이벤트 타임라인 조회(`GET /monitoring/events`)가 `CongestionEventRepository.findAllBySessionId`의 기본 limit(100건)에 걸려 있어, 세션당 혼잡 이벤트가 100건을 넘으면 최신 이벤트가 응답에서 통째로 누락되고 있었음
- `cctvCode` 필터도 DB 쿼리가 아니라 이미 100건으로 잘린 결과에 애플리케이션 레벨로 적용되고 있어, 필터 대상 CCTV의 이벤트가 다른 CCTV 이벤트에 밀려 빈 결과가 나올 수 있었음
- `CongestionEventRepository`에 `findPageBySessionId` 추가: 최신순(`scanIndexForward(false)`) 커서 페이지네이션 + `cctvCode`를 DynamoDB `FilterExpression`으로 적용
- `GET /monitoring/events`에 `cursor`/`limit` 쿼리 파라미터 추가, 응답 정렬을 오름차순 → 최신순으로 변경
- `FrameCursor`를 `PageCursor`로 일반화해서 프레임 목록과 이벤트 타임라인이 같은 커서 인코딩 로직을 공유하도록 정리

## 정책

- 조회 방향: 최신순 + 페이지네이션 채택 (오래된순 유지 시 "최신 이벤트가 안 보인다"는 원래 버그 성격과 안 맞음)
- `cctvCode` 필터는 반드시 DB 쿼리 단계(DynamoDB FilterExpression)에서 적용 — 애플리케이션 레벨 필터로 인한 누락 재발 방지. FilterExpression으로 걸러진 만큼 SDK가 `LastEvaluatedKey`를 따라 다음 물리 페이지를 자동으로 더 읽어오므로, 특정 CCTV로 필터링해도 결과가 누락되지 않음
- 혼잡 이벤트(DynamoDB, 세션당 최대 수백 건까지 쌓일 수 있음)만 커서로 페이지네이션하고, 재탐색 이벤트(PostgreSQL, 쿨다운으로 발생 빈도가 낮아 매 요청 전량 조회해도 무리 없음)는 페이지네이션 없이 전량 조회한 뒤 동일한 `(occurredAt, eventId)` 커서 경계로 걸러 병합 — 두 소스를 섞어도 페이지 경계에서 이벤트가 중복되거나 누락되지 않음
- 기존 `findAllBySessionId(sessionId, limit)`는 리포트의 병목 횟수 집계(`TrainingReportService`, limit 5000)가 그대로 쓰고 있어 변경하지 않음 — 이슈 범위 밖

## API 변경

- `GET /api/v1/sessions/{sessionId}/monitoring/events`
  - 신규 쿼리 파라미터: `limit`(기본 20, 1~100), `cursor`(선택)
  - 응답에 `nextCursor`, `hasNext` 필드 추가
  - 이벤트 정렬이 발생 시각 오름차순 → 최신순으로 변경 (breaking change)
  - 잘못된 `cursor` 형식이면 400 반환 (프레임 목록 API와 동일한 규칙)

## 프론트 연동 참고 (Swagger에도 반영됨)

- 이벤트 정렬이 최신순으로 바뀌었으므로 기존에 오름차순을 전제로 렌더링하던 화면이 있다면 확인 필요
- `cctvCode` 필터는 이제 DB 쿼리 단계에서 적용되어 다른 CCTV 이벤트가 아무리 많아도 누락되지 않음
- 프레임 목록 API와 동일한 커서 페이지네이션 패턴(`cursor` 생략 시 최신부터, `nextCursor`/`hasNext`로 다음 페이지 판단)

## 테스트

- `CongestionEventRepositoryTest`: 최신순 조회, `cctvCode` FilterExpression 적용 여부, cursor 커서 경계 조건 검증 테스트 추가
- `TrainingMonitoringServiceTest`: 혼잡 이벤트/재탐색 이벤트 병합·정렬, `limit` 초과 시 `hasNext`/`nextCursor`, cursor로 이미 반환된 재탐색 이벤트가 다음 페이지에서 중복되지 않는지 검증하는 테스트 추가
- `TrainingMonitoringControllerTest`: `limit`/`cursor` 쿼리 파라미터 전달, 잘못된 cursor 400 처리 테스트 추가
- `./gradlew build` 전체 통과 확인

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 이벤트 타임라인이 최신순으로 통합 조회됩니다.
  * `limit`과 커서를 사용한 페이지네이션을 지원합니다.
  * 응답에 `nextCursor`와 `hasNext`가 제공됩니다.
  * CCTV 코드로 이벤트를 필터링할 수 있습니다.
  * 잘못된 페이지 크기 또는 커서 입력에 대해 400 오류가 반환됩니다.
  * 프레임 및 이벤트 조회에서 공통 페이지 커서 형식을 사용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->