### PR TITLE
[Feat] #199: targetEvacuationSec 10분으로 고정 및 수정 불가

### DIFF
--- a/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingScenarioController.java
@@ -140,7 +140,8 @@ public class TrainingScenarioController {
                     아닌 시나리오에 호출하면 409(INVALID_STATUS_TRANSITION)로 거부됩니다.
 
                     name, buildingId, expectedParticipants, scheduledAt, adminId,
-                    fireSpreadSpeed가 모두 채워져 있어야 하며(targetEvacuationSec은 선택값),
+                    fireSpreadSpeed가 모두 채워져 있어야 합니다. targetEvacuationSec은 항상
+                    10분(600초)으로 고정되며 요청으로 지정하거나 바꿀 수 없습니다.
                     하나라도 비어 있으면 400(TRAINING_SCENARIO_REQUIRED_FIELD_MISSING)과 함께
                     result.missingFields에 누락된 필드 이름 목록을 반환합니다.
 

--- a/src/main/java/com/saferoute/domain/training/dto/CreateScenarioDraftRequest.java
+++ b/src/main/java/com/saferoute/domain/training/dto/CreateScenarioDraftRequest.java
@@ -1,7 +1,6 @@
 package com.saferoute.domain.training.dto;
 
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
 import java.util.UUID;
@@ -11,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 // DRAFT 생성 요청. 시나리오 작성 화면 진입 시 미완성 상태로 임시 저장하는 용도라 모든 필드가
 // 선택값이다. 작성자(admin)는 이 요청이 아니라 JWT 인증 사용자로 고정된다.
+// targetEvacuationSec은 항상 10분(600초) 고정이라 요청 필드로 받지 않는다.
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -22,10 +22,6 @@ public class CreateScenarioDraftRequest {
     private UUID buildingId;
 
     private Integer expectedParticipants;
-
-    // 훈련 리포트의 대피 시간 점수 산정 기준(초). 값을 지정할 땐 양수여야 한다.
-    @Positive
-    private Integer targetEvacuationSec;
 
     private Instant scheduledAt;
 

--- a/src/main/java/com/saferoute/domain/training/dto/UpdateScenarioRequest.java
+++ b/src/main/java/com/saferoute/domain/training/dto/UpdateScenarioRequest.java
@@ -4,11 +4,11 @@ import java.time.Instant;
 import java.util.UUID;
 
 import com.saferoute.domain.training.entity.FireSpreadSpeed;
-import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+// targetEvacuationSec은 항상 10분(600초) 고정이라 요청 필드로 받지 않는다.
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,9 +18,6 @@ public class UpdateScenarioRequest {
     // DRAFT 작성 중 건물을 나중에 지정하거나 바꿀 때 사용한다. null이면 변경하지 않는다.
     private UUID buildingId;
     private Integer expectedParticipants;
-    // null이면 변경하지 않음(TrainingScenario.update() 참고). 값을 지정할 땐 양수여야 한다.
-    @Positive
-    private Integer targetEvacuationSec;
     private Instant scheduledAt;
     private Boolean isTemplate;
     private FireSpreadSpeed fireSpreadSpeed;

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -46,9 +46,11 @@ public class TrainingScenario {
     private Integer expectedParticipants;
 
     // 훈련 리포트의 "총 대피 시간" 항목 점수를 매길 때 기준이 되는 목표 대피 시간(초).
-    // 건물 규모/층수마다 적정 대피시간이 달라 고정값이 아니라 시나리오별로 관리자가 지정한다.
-    @Column(name = "target_evacuation_sec")
-    private Integer targetEvacuationSec;
+    // 모든 시나리오에 동일하게 10분(600초)을 적용하며, 관리자가 값을 지정하거나 바꿀 수 없다.
+    public static final int DEFAULT_TARGET_EVACUATION_SEC = 600;
+
+    @Column(name = "target_evacuation_sec", nullable = false)
+    private Integer targetEvacuationSec = DEFAULT_TARGET_EVACUATION_SEC;
 
     // DRAFT는 훈련 일시 미정 상태를 허용한다. READY 전환 시 필수값으로 검증한다.
     @Column(name = "scheduled_at")
@@ -97,7 +99,6 @@ public class TrainingScenario {
     // 실제 API 플로우는 createDraft()로 시작해 ready()로 전이한다.
     public static TrainingScenario create(String name,
                                           Integer expectedParticipants,
-                                          Integer targetEvacuationSec,
                                           Instant scheduledAt,
                                           Boolean isTemplate,
                                           FireSpreadSpeed fireSpreadSpeed,
@@ -107,7 +108,6 @@ public class TrainingScenario {
         TrainingScenario scenario = new TrainingScenario();
         scenario.name = name;
         scenario.expectedParticipants = expectedParticipants;
-        scenario.targetEvacuationSec = targetEvacuationSec;
         scenario.scheduledAt = scheduledAt;
         scenario.isTemplate = isTemplate != null ? isTemplate : false;
         scenario.fireSpreadSpeed = fireSpreadSpeed != null ? fireSpreadSpeed : FireSpreadSpeed.MEDIUM;
@@ -122,7 +122,6 @@ public class TrainingScenario {
     // scheduledAt은 아직 비어 있을 수 있으며, READY 전환(ready()) 시 필수값으로 검증한다.
     public static TrainingScenario createDraft(String name,
                                                 Integer expectedParticipants,
-                                                Integer targetEvacuationSec,
                                                 Instant scheduledAt,
                                                 Boolean isTemplate,
                                                 FireSpreadSpeed fireSpreadSpeed,
@@ -131,7 +130,6 @@ public class TrainingScenario {
         TrainingScenario scenario = new TrainingScenario();
         scenario.name = name;
         scenario.expectedParticipants = expectedParticipants;
-        scenario.targetEvacuationSec = targetEvacuationSec;
         scenario.scheduledAt = scheduledAt;
         scenario.isTemplate = isTemplate != null ? isTemplate : false;
         scenario.fireSpreadSpeed = fireSpreadSpeed != null ? fireSpreadSpeed : FireSpreadSpeed.MEDIUM;
@@ -143,14 +141,12 @@ public class TrainingScenario {
 
     public void update(String name,
                        Integer expectedParticipants,
-                       Integer targetEvacuationSec,
                        Instant scheduledAt,
                        Boolean isTemplate,
                        FireSpreadSpeed fireSpreadSpeed,
                        Building building) {
         if (name != null) this.name = name;
         if (expectedParticipants != null) this.expectedParticipants = expectedParticipants;
-        if (targetEvacuationSec != null) this.targetEvacuationSec = targetEvacuationSec;
         if (scheduledAt != null) this.scheduledAt = scheduledAt;
         if (isTemplate != null) this.isTemplate = isTemplate;
         if (fireSpreadSpeed != null) this.fireSpreadSpeed = fireSpreadSpeed;

--- a/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingScenarioService.java
@@ -80,7 +80,6 @@ public class TrainingScenarioService {
         TrainingScenario scenario = TrainingScenario.createDraft(
                 request.getName(),
                 request.getExpectedParticipants(),
-                request.getTargetEvacuationSec(),
                 request.getScheduledAt(),
                 request.getIsTemplate(),
                 request.getFireSpreadSpeed(),
@@ -108,7 +107,6 @@ public class TrainingScenarioService {
         scenario.update(
                 request.getName(),
                 request.getExpectedParticipants(),
-                request.getTargetEvacuationSec(),
                 request.getScheduledAt(),
                 request.getIsTemplate(),
                 request.getFireSpreadSpeed(),

--- a/src/test/java/com/saferoute/domain/building/service/BuildingScenarioConcurrencyIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/building/service/BuildingScenarioConcurrencyIntegrationTest.java
@@ -157,7 +157,6 @@ class BuildingScenarioConcurrencyIntegrationTest {
                 "정기 훈련",
                 building.getId(),
                 50,
-                300,
                 Instant.now().plusSeconds(3600),
                 false,
                 FireSpreadSpeed.MEDIUM);

--- a/src/test/java/com/saferoute/domain/report/service/TrainingReportLazyLoadingIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/report/service/TrainingReportLazyLoadingIntegrationTest.java
@@ -68,7 +68,7 @@ class TrainingReportLazyLoadingIntegrationTest {
         Building building = buildingRepository.save(
                 Building.create("테스트관", "서울특별시 안전구 1", BuildingType.CLASSROOM, "SafeRoute School"));
         TrainingScenario scenario = trainingScenarioRepository.save(TrainingScenario.create(
-                "정기 훈련", 50, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null));
+                "정기 훈련", 50, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null));
 
         Instant startedAt = Instant.now().minusSeconds(300);
         TrainingSession session = TrainingSession.create(TrainingStatus.RUNNING, startedAt, admin, scenario);

--- a/src/test/java/com/saferoute/domain/training/repository/FireZoneRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/training/repository/FireZoneRepositoryTest.java
@@ -69,7 +69,7 @@ class FireZoneRepositoryTest {
 
     private TrainingScenario scenario(String name) {
         return scenarioRepository.save(TrainingScenario.create(
-                name, 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null));
+                name, 10, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null));
     }
 
     private void sessionWithStatus(TrainingScenario scenario, TrainingStatus status) {

--- a/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingScenarioServiceTest.java
@@ -70,7 +70,6 @@ class TrainingScenarioServiceTest {
         TrainingScenario scenario = TrainingScenario.create(
                 "테스트 시나리오",
                 10,
-                300,
                 Instant.now(),
                 false,
                 FireSpreadSpeed.MEDIUM,
@@ -83,7 +82,7 @@ class TrainingScenarioServiceTest {
 
     private TrainingScenario draftScenarioWithId(UUID id) {
         TrainingScenario scenario = TrainingScenario.createDraft(
-                null, null, null, null, false, FireSpreadSpeed.MEDIUM, null, mock(User.class));
+                null, null, null, false, FireSpreadSpeed.MEDIUM, null, mock(User.class));
         ReflectionTestUtils.setField(scenario, "id", id);
         return scenario;
     }
@@ -94,7 +93,7 @@ class TrainingScenarioServiceTest {
     @DisplayName("건물 없이 이름만 채운 DRAFT를 생성한다")
     void createDraft_withoutBuilding_succeeds() {
         CreateScenarioDraftRequest request = new CreateScenarioDraftRequest(
-                "2026년 4월 정기 훈련", null, null, null, null, false, FireSpreadSpeed.MEDIUM);
+                "2026년 4월 정기 훈련", null, null, null, false, FireSpreadSpeed.MEDIUM);
         User admin = mock(User.class);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
         given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(admin));
@@ -115,7 +114,7 @@ class TrainingScenarioServiceTest {
         Building building = mock(Building.class);
         User admin = mock(User.class);
         CreateScenarioDraftRequest request = new CreateScenarioDraftRequest(
-                null, buildingId, null, null, null, false, null);
+                null, buildingId, null, null, false, null);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
         given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(admin));
         given(buildingRepository.findByIdAndSchoolNameForUpdate(buildingId, SCHOOL_NAME))
@@ -139,7 +138,7 @@ class TrainingScenarioServiceTest {
         TrainingScenario scenario = draftScenarioWithId(scenarioId);
         Building building = mock(Building.class);
         UpdateScenarioRequest request = new UpdateScenarioRequest(
-                "이름 채우기", buildingId, 30, null, Instant.now(), null, null);
+                "이름 채우기", buildingId, 30, Instant.now(), null, null);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
         given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
@@ -160,7 +159,7 @@ class TrainingScenarioServiceTest {
         TrainingScenario scenario = scenarioWithId(scenarioId);
         scenario.markInProgress();
         UpdateScenarioRequest request = new UpdateScenarioRequest(
-                "변경 시도", null, null, null, null, null, null);
+                "변경 시도", null, null, null, null, null);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
         given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
@@ -181,13 +180,13 @@ class TrainingScenarioServiceTest {
         given(currentBuilding.getId()).willReturn(currentBuildingId);
         MapNode startNode = mock(MapNode.class);
         TrainingScenario scenario = TrainingScenario.create(
-                "테스트 시나리오", 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM,
+                "테스트 시나리오", 10, Instant.now(), false, FireSpreadSpeed.MEDIUM,
                 currentBuilding, mock(User.class), startNode);
         ReflectionTestUtils.setField(scenario, "id", scenarioId);
         Building newBuilding = mock(Building.class);
         given(newBuilding.getId()).willReturn(newBuildingId);
         UpdateScenarioRequest request = new UpdateScenarioRequest(
-                null, newBuildingId, null, null, null, null, null);
+                null, newBuildingId, null, null, null, null);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
         given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
@@ -209,11 +208,11 @@ class TrainingScenarioServiceTest {
         given(building.getId()).willReturn(buildingId);
         MapNode startNode = mock(MapNode.class);
         TrainingScenario scenario = TrainingScenario.create(
-                "테스트 시나리오", 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM,
+                "테스트 시나리오", 10, Instant.now(), false, FireSpreadSpeed.MEDIUM,
                 building, mock(User.class), startNode);
         ReflectionTestUtils.setField(scenario, "id", scenarioId);
         UpdateScenarioRequest request = new UpdateScenarioRequest(
-                "이름만 변경", buildingId, null, null, null, null, null);
+                "이름만 변경", buildingId, null, null, null, null);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
         given(scenarioRepository.findByIdAndAdmin_SchoolName(scenarioId, SCHOOL_NAME))
                 .willReturn(Optional.of(scenario));
@@ -237,7 +236,7 @@ class TrainingScenarioServiceTest {
         User admin = mock(User.class);
         given(admin.getId()).willReturn(UUID.randomUUID());
         TrainingScenario scenario = TrainingScenario.create(
-                "테스트 시나리오", 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null);
+                "테스트 시나리오", 10, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null);
         ReflectionTestUtils.setField(scenario, "id", scenarioId);
         ReflectionTestUtils.setField(scenario, "status", ScenarioStatus.DRAFT);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
@@ -280,7 +279,7 @@ class TrainingScenarioServiceTest {
         User admin = mock(User.class);
         given(admin.getId()).willReturn(UUID.randomUUID());
         TrainingScenario scenario = TrainingScenario.create(
-                "  ", 10, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null);
+                "  ", 10, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, admin, null);
         ReflectionTestUtils.setField(scenario, "id", scenarioId);
         ReflectionTestUtils.setField(scenario, "status", ScenarioStatus.DRAFT);
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);

--- a/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/service/WebSocketIntegrationTest.java
@@ -153,7 +153,6 @@ class WebSocketIntegrationTest {
         trainingScenario = TrainingScenario.create(
                 "정기 훈련",
                 50,
-                300,
                 Instant.now(),
                 false,
                 FireSpreadSpeed.MEDIUM,
@@ -234,7 +233,7 @@ class WebSocketIntegrationTest {
         mapEdgeJpaRepository.save(MapEdge.create(floor, startNode, exitNode, 3.0, true));
 
         TrainingScenario scenario = TrainingScenario.create(
-                "정기 훈련", 50, 300, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, managerUser, startNode);
+                "정기 훈련", 50, Instant.now(), false, FireSpreadSpeed.MEDIUM, building, managerUser, startNode);
         return trainingScenarioRepository.save(scenario);
     }
 


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #199 
- Branch:

## 주요 내용

-

## ✅ Check List

- [ ] 테스트 통과
- [ ] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 훈련 시나리오의 목표 대피 시간이 시나리오별 설정값에서 모든 시나리오에 공통으로 적용되는 600초(10분)로 변경되었습니다.
  - 시나리오 생성 및 수정 요청에서 목표 대피 시간을 직접 지정하거나 변경할 수 없습니다.
  - 관련 API 문서에 목표 대피 시간의 고정 정책이 명확히 안내됩니다.

- **테스트**
  - 변경된 시나리오 생성·수정 방식에 맞춰 관련 테스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->