### PR TITLE
[Feat] #202: 일반 모니터링 이벤트 저장 및 타임라인 조회

### DIFF
--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/GeneralMonitoringEventItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/GeneralMonitoringEventItem.java
@@ -1,0 +1,164 @@
+package com.saferoute.domain.telemetry.dynamo.entity;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondarySortKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+// 혼잡 이벤트(CongestionEventItem)와 별도로 BE가 직접 판정해서 만드는 일반 모니터링 이벤트
+// (AI_ANALYSIS_STARTED, ROUTE_DEVIATION_DETECTED)를 저장한다. eventId를 결정적으로 만들어
+// attribute_not_exists 조건부 put에 태우면, 별도의 마커 아이템 없이도 세션+CCTV당 정확히
+// 한 번만 저장되도록 보장할 수 있다 (예: AI 분석 시작 판정).
+@DynamoDbBean
+public class GeneralMonitoringEventItem {
+
+    public static final String GSI1_NAME = "GSI1";
+    public static final long TTL_SECONDS = 30L * 24 * 60 * 60;
+
+    private String pk;
+    private String sk;
+    private String gsi1Pk;
+    private String gsi1Sk;
+    private String eventId;
+    private String trainingSessionId;
+    private String cctvCode;
+    private GeneralMonitoringEventType eventType;
+    private Long occurredAt;
+    private CongestionLevel congestionLevel;
+    private Long expiresAt;
+
+    public GeneralMonitoringEventItem() {
+    }
+
+    public static GeneralMonitoringEventItem create(
+            String eventId,
+            String trainingSessionId,
+            String cctvCode,
+            GeneralMonitoringEventType eventType,
+            long occurredAt,
+            CongestionLevel congestionLevel
+    ) {
+        GeneralMonitoringEventItem item = new GeneralMonitoringEventItem();
+        item.eventId = eventId;
+        item.trainingSessionId = trainingSessionId;
+        item.cctvCode = cctvCode;
+        item.eventType = eventType;
+        item.occurredAt = occurredAt;
+        item.congestionLevel = congestionLevel;
+        item.expiresAt = Math.floorDiv(occurredAt, 1_000L) + TTL_SECONDS;
+        item.pk = buildPk(eventId);
+        item.sk = "META";
+        item.gsi1Pk = buildGsi1Pk(trainingSessionId);
+        item.gsi1Sk = buildGsi1Sk(occurredAt, eventId);
+        return item;
+    }
+
+    public static String buildPk(String eventId) {
+        return "MONITORING_EVENT#" + eventId;
+    }
+
+    public static String buildGsi1Pk(String trainingSessionId) {
+        return "SESSION#" + trainingSessionId;
+    }
+
+    public static String buildGsi1Sk(long occurredAt, String eventId) {
+        return "EVENT#" + occurredAt + "#" + eventId;
+    }
+
+    @DynamoDbPartitionKey
+    public String getPk() {
+        return pk;
+    }
+
+    public void setPk(String pk) {
+        this.pk = pk;
+    }
+
+    @DynamoDbSortKey
+    public String getSk() {
+        return sk;
+    }
+
+    public void setSk(String sk) {
+        this.sk = sk;
+    }
+
+    @DynamoDbAttribute("GSI1_PK")
+    @DynamoDbSecondaryPartitionKey(indexNames = GSI1_NAME)
+    public String getGsi1Pk() {
+        return gsi1Pk;
+    }
+
+    public void setGsi1Pk(String gsi1Pk) {
+        this.gsi1Pk = gsi1Pk;
+    }
+
+    @DynamoDbAttribute("GSI1_SK")
+    @DynamoDbSecondarySortKey(indexNames = GSI1_NAME)
+    public String getGsi1Sk() {
+        return gsi1Sk;
+    }
+
+    public void setGsi1Sk(String gsi1Sk) {
+        this.gsi1Sk = gsi1Sk;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getTrainingSessionId() {
+        return trainingSessionId;
+    }
+
+    public void setTrainingSessionId(String trainingSessionId) {
+        this.trainingSessionId = trainingSessionId;
+    }
+
+    public String getCctvCode() {
+        return cctvCode;
+    }
+
+    public void setCctvCode(String cctvCode) {
+        this.cctvCode = cctvCode;
+    }
+
+    public GeneralMonitoringEventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(GeneralMonitoringEventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public Long getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(Long occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+
+    public CongestionLevel getCongestionLevel() {
+        return congestionLevel;
+    }
+
+    public void setCongestionLevel(CongestionLevel congestionLevel) {
+        this.congestionLevel = congestionLevel;
+    }
+
+    public Long getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Long expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/GeneralMonitoringEventItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/GeneralMonitoringEventItem.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.telemetry.dynamo.entity;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
+import java.util.Locale;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
@@ -17,6 +18,7 @@ public class GeneralMonitoringEventItem {
 
     public static final String GSI1_NAME = "GSI1";
     public static final long TTL_SECONDS = 30L * 24 * 60 * 60;
+    private static final int GSI1_TIMESTAMP_WIDTH = 19;
 
     private String pk;
     private String sk;
@@ -64,8 +66,15 @@ public class GeneralMonitoringEventItem {
         return "SESSION#" + trainingSessionId;
     }
 
+    // occurredAt을 그대로 이어붙이면 자릿수가 다른 값끼리 사전순 정렬이 시간순과 어긋난다
+    // (예: "9" > "10"). ObservationItem.buildGsi1Sk와 동일하게 고정 폭 0-padding으로
+    // 문자열 정렬이 항상 시간순과 일치하도록 한다. occurredAt은 음수가 아닌 epoch millis만 온다.
     public static String buildGsi1Sk(long occurredAt, String eventId) {
-        return "EVENT#" + occurredAt + "#" + eventId;
+        return "EVENT#" + String.format(
+                Locale.ROOT,
+                "%0" + GSI1_TIMESTAMP_WIDTH + "d",
+                occurredAt
+        ) + "#" + eventId;
     }
 
     @DynamoDbPartitionKey

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/GeneralMonitoringEventType.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/GeneralMonitoringEventType.java
@@ -1,0 +1,8 @@
+package com.saferoute.domain.telemetry.dynamo.entity;
+
+// 혼잡 이벤트(CongestionEventType)와 별도로, BE가 관측값으로부터 직접 판정해서 만드는
+// 일반 모니터링 이벤트의 종류. Pi가 이 이벤트들을 위한 별도 API를 호출하지는 않는다.
+public enum GeneralMonitoringEventType {
+    AI_ANALYSIS_STARTED,
+    ROUTE_DEVIATION_DETECTED
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepository.java
@@ -1,0 +1,114 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventItem;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+
+@Repository
+public class GeneralMonitoringEventRepository {
+
+    private static final Expression ITEM_NOT_EXISTS = Expression.builder()
+            .expression("attribute_not_exists(#pk)")
+            .putExpressionName("#pk", "pk")
+            .build();
+
+    private final DynamoDbTable<GeneralMonitoringEventItem> table;
+    private final DynamoDbIndex<GeneralMonitoringEventItem> gsi1;
+
+    public GeneralMonitoringEventRepository(
+            DynamoDbEnhancedClient enhancedClient,
+            @Value("${aws.dynamodb.table-name}") String tableName,
+            @Value("${aws.dynamodb.gsi1-name:GSI1}") String gsi1Name
+    ) {
+        this.table = enhancedClient.table(tableName, TableSchema.fromBean(GeneralMonitoringEventItem.class));
+        this.gsi1 = table.index(gsi1Name);
+    }
+
+    // eventId를 결정적으로 생성해 넘기면(예: 세션+CCTV+이벤트타입 조합) 이 조건부 put 하나가
+    // "세션+CCTV당 정확히 한 번" 같은 멱등 규칙을 그대로 보장한다. 별도의 마커 아이템이나
+    // 인메모리 상태를 두지 않는다.
+    public IdempotentSaveResult<GeneralMonitoringEventItem> saveIfAbsent(GeneralMonitoringEventItem item) {
+        PutItemEnhancedRequest<GeneralMonitoringEventItem> request =
+                PutItemEnhancedRequest.builder(GeneralMonitoringEventItem.class)
+                        .item(item)
+                        .conditionExpression(ITEM_NOT_EXISTS)
+                        .build();
+
+        try {
+            table.putItem(request);
+            return IdempotentSaveResult.created(item);
+        } catch (ConditionalCheckFailedException exception) {
+            return findByEventId(item.getEventId())
+                    .map(IdempotentSaveResult::existing)
+                    .orElseThrow(() -> exception);
+        }
+    }
+
+    public Optional<GeneralMonitoringEventItem> findByEventId(String eventId) {
+        GetItemEnhancedRequest request = GetItemEnhancedRequest.builder()
+                .key(Key.builder()
+                        .partitionValue(GeneralMonitoringEventItem.buildPk(eventId))
+                        .sortValue("META")
+                        .build())
+                .consistentRead(true)
+                .build();
+        return Optional.ofNullable(table.getItem(request));
+    }
+
+    // 이벤트 타임라인 조회 전용: CongestionEventRepository.findPageBySessionId와 동일한 패턴으로
+    // 최신순 커서 페이지네이션 + cctvCode DynamoDB FilterExpression을 적용한다. Limit을 요청 단위와
+    // 스트림 단위 양쪽에 걸어, cctvCode로 걸러진 만큼 SDK가 다음 물리 페이지를 계속 읽어오게 한다.
+    public List<GeneralMonitoringEventItem> findPageBySessionId(
+            String trainingSessionId,
+            String cctvCode,
+            int limit,
+            Long beforeOccurredAt,
+            String beforeEventId
+    ) {
+        validateLimit(limit);
+        QueryConditional queryConditional = beforeOccurredAt == null
+                ? QueryConditional.keyEqualTo(Key.builder()
+                        .partitionValue(GeneralMonitoringEventItem.buildGsi1Pk(trainingSessionId))
+                        .build())
+                : QueryConditional.sortLessThan(Key.builder()
+                        .partitionValue(GeneralMonitoringEventItem.buildGsi1Pk(trainingSessionId))
+                        .sortValue(GeneralMonitoringEventItem.buildGsi1Sk(beforeOccurredAt, beforeEventId))
+                        .build());
+        QueryEnhancedRequest.Builder requestBuilder = QueryEnhancedRequest.builder()
+                .queryConditional(queryConditional)
+                .scanIndexForward(false)
+                .limit(limit);
+        if (cctvCode != null) {
+            requestBuilder.filterExpression(Expression.builder()
+                    .expression("#cctvCode = :cctvCode")
+                    .putExpressionName("#cctvCode", "cctvCode")
+                    .putExpressionValue(":cctvCode", AttributeValue.fromS(cctvCode))
+                    .build());
+        }
+
+        return gsi1.query(requestBuilder.build()).stream()
+                .flatMap(page -> page.items().stream())
+                .limit(limit)
+                .toList();
+    }
+
+    private void validateLimit(int limit) {
+        if (limit <= 0) {
+            throw new IllegalArgumentException("limit은 0보다 커야합니다.");
+        }
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringEventResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringEventResponse.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.training.dto;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.evacuation.recalculation.entity.RouteRecalculation;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventItem;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "이벤트 타임라인 항목")
@@ -40,6 +41,19 @@ public record MonitoringEventResponse(
                 type,
                 type.severity(item.getCongestionLevel()),
                 item.getDetectedAt(),
+                item.getCctvCode(),
+                item.getCongestionLevel(),
+                type.message(item.getCctvCode(), item.getCongestionLevel())
+        );
+    }
+
+    public static MonitoringEventResponse fromGeneralEvent(GeneralMonitoringEventItem item) {
+        MonitoringEventType type = MonitoringEventType.from(item.getEventType());
+        return new MonitoringEventResponse(
+                item.getEventId(),
+                type,
+                type.severity(item.getCongestionLevel()),
+                item.getOccurredAt(),
                 item.getCctvCode(),
                 item.getCongestionLevel(),
                 type.message(item.getCctvCode(), item.getCongestionLevel())

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringEventType.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringEventType.java
@@ -3,11 +3,10 @@ package com.saferoute.domain.training.dto;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationStatus;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventType;
 
 // 이벤트 타임라인(GET /api/v1/sessions/{sessionId}/monitoring/events)에 노출되는 이벤트 종류.
 // 심각도와 사용자 표시 문구를 종류별로 이 열거형이 직접 정의한다 (이슈 #144).
-//
-// AI 분석 시작/경로 이탈/위험 구역 진입은 아직 Pi/AI 쪽 이벤트 수신 계약이 없어 이 타임라인에 포함하지 않는다.
 public enum MonitoringEventType {
     CONGESTION_STARTED {
         @Override
@@ -87,6 +86,28 @@ public enum MonitoringEventType {
         public String message(String cctvCode, CongestionLevel level) {
             return "경로 재탐색 취소 · " + cctvCode;
         }
+    },
+    AI_ANALYSIS_STARTED {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return MonitoringEventSeverity.INFO;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "AI 분석 시작 · " + cctvCode;
+        }
+    },
+    ROUTE_DEVIATION_DETECTED {
+        @Override
+        public MonitoringEventSeverity severity(CongestionLevel level) {
+            return MonitoringEventSeverity.WARNING;
+        }
+
+        @Override
+        public String message(String cctvCode, CongestionLevel level) {
+            return "경로 이탈 감지 · " + cctvCode;
+        }
     };
 
     public abstract MonitoringEventSeverity severity(CongestionLevel level);
@@ -98,6 +119,13 @@ public enum MonitoringEventType {
             case CONGESTION_STARTED -> CONGESTION_STARTED;
             case CONGESTION_LEVEL_UP -> CONGESTION_LEVEL_UP;
             case CONGESTION_ENDED -> CONGESTION_ENDED;
+        };
+    }
+
+    public static MonitoringEventType from(GeneralMonitoringEventType generalMonitoringEventType) {
+        return switch (generalMonitoringEventType) {
+            case AI_ANALYSIS_STARTED -> AI_ANALYSIS_STARTED;
+            case ROUTE_DEVIATION_DETECTED -> ROUTE_DEVIATION_DETECTED;
         };
     }
 

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -11,6 +11,7 @@ import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
@@ -54,6 +55,7 @@ public class TrainingMonitoringService {
     private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final ObservationRepository observationRepository;
     private final CongestionEventRepository congestionEventRepository;
+    private final GeneralMonitoringEventRepository generalMonitoringEventRepository;
     private final CurrentCctvStateRepository currentCctvStateRepository;
     private final RouteRecalculationRepository routeRecalculationRepository;
     private final S3PresignedUrlService s3PresignedUrlService;
@@ -177,15 +179,16 @@ public class TrainingMonitoringService {
         return new MonitoringFrameListResponse(sessionId, cctvId, frames, nextCursor, hasNext);
     }
 
-    // 혼잡 감지 이벤트(CongestionEventItem)와 경로 재탐색 이벤트(RouteRecalculation)를 발생 시각
-    // 최신순으로 합쳐 커서 페이지네이션한다. 관측값(ObservationItem)은 5초 주기 스냅샷이라
-    // 타임라인에 넣으면 너무 촘촘해져서 제외한다 - "이벤트"로 부를 만한 STARTED/LEVEL_UP/ENDED
-    // 전환만 대상으로 한다. 재탐색 한 건은 요청 시점과(있다면) 해소 시점 두 항목으로 나뉠 수 있다.
+    // 혼잡 감지 이벤트(CongestionEventItem), 경로 재탐색 이벤트(RouteRecalculation), 일반 모니터링
+    // 이벤트(GeneralMonitoringEventItem - AI 분석 시작/경로 이탈 감지)를 발생 시각 최신순으로 합쳐
+    // 커서 페이지네이션한다. 관측값(ObservationItem)은 5초 주기 스냅샷이라 타임라인에 넣으면 너무
+    // 촘촘해져서 제외한다 - "이벤트"로 부를 만한 것들만 대상으로 한다. 재탐색 한 건은 요청 시점과
+    // (있다면) 해소 시점 두 항목으로 나뉠 수 있다.
     //
-    // 혼잡 이벤트(DynamoDB)는 세션당 수백 건까지도 쌓일 수 있어 커서 페이지네이션 + cctvCode
-    // DB 필터가 필요하다. 재탐색 이벤트(PostgreSQL)는 쿨다운으로 발생 빈도가 낮아 매 요청마다
-    // 전량 조회해도 무리가 없으므로 별도 페이지네이션 없이 가져온 뒤, 혼잡 이벤트와 동일한 커서
-    // 경계로 걸러 중복 없이 병합한다.
+    // 혼잡 이벤트/일반 모니터링 이벤트(둘 다 DynamoDB)는 세션당 수백 건까지도 쌓일 수 있어 커서
+    // 페이지네이션 + cctvCode DB 필터가 필요하다. 재탐색 이벤트(PostgreSQL)는 쿨다운으로 발생
+    // 빈도가 낮아 매 요청마다 전량 조회해도 무리가 없으므로 별도 페이지네이션 없이 가져온 뒤,
+    // 다른 두 소스와 동일한 커서 경계로 걸러 중복 없이 병합한다.
     public MonitoringEventListResponse getEvents(
             UUID sessionId, String cctvCode, int limit, String cursor, String email
     ) {
@@ -202,6 +205,12 @@ public class TrainingMonitoringService {
                 .map(MonitoringEventResponse::fromCongestionEvent)
                 .toList();
 
+        List<MonitoringEventResponse> generalEvents = generalMonitoringEventRepository
+                .findPageBySessionId(sessionId.toString(), cctvCode, limit + 1, beforeOccurredAt, beforeEventId)
+                .stream()
+                .map(MonitoringEventResponse::fromGeneralEvent)
+                .toList();
+
         List<MonitoringEventResponse> allRecalculationEvents = new ArrayList<>();
         routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(sessionId).stream()
                 .filter(recalculation -> matchesCctv(recalculation.getCctvCode(), cctvCode))
@@ -212,8 +221,10 @@ public class TrainingMonitoringService {
                         .filter(event -> isBeforeCursor(event, beforeOccurredAt, beforeEventId))
                         .toList();
 
-        List<MonitoringEventResponse> merged = new ArrayList<>(congestionEvents.size() + recalculationEvents.size());
+        List<MonitoringEventResponse> merged = new ArrayList<>(
+                congestionEvents.size() + generalEvents.size() + recalculationEvents.size());
         merged.addAll(congestionEvents);
+        merged.addAll(generalEvents);
         merged.addAll(recalculationEvents);
         merged.sort(EVENT_ORDER);
 

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepositoryTest.java
@@ -1,0 +1,152 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventType;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+
+@ExtendWith(MockitoExtension.class)
+class GeneralMonitoringEventRepositoryTest {
+
+    private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+
+    @Mock
+    private DynamoDbEnhancedClient enhancedClient;
+    @Mock
+    private DynamoDbTable<GeneralMonitoringEventItem> table;
+    @Mock
+    private DynamoDbIndex<GeneralMonitoringEventItem> gsi1;
+
+    private GeneralMonitoringEventRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        when(enhancedClient.table(eq("saferoute-telemetry"), any(TableSchema.class))).thenReturn(table);
+        when(table.index("GSI1")).thenReturn(gsi1);
+        repository = new GeneralMonitoringEventRepository(enhancedClient, "saferoute-telemetry", "GSI1");
+    }
+
+    @Test
+    void eventId가_처음이면_조건부로_저장한다() {
+        GeneralMonitoringEventItem item = item("ai-analysis-started:session:CCTV_001", 1_000L);
+        ArgumentCaptor<PutItemEnhancedRequest<GeneralMonitoringEventItem>> captor = requestCaptor();
+
+        IdempotentSaveResult<GeneralMonitoringEventItem> result = repository.saveIfAbsent(item);
+
+        org.mockito.Mockito.verify(table).putItem(captor.capture());
+        assertThat(captor.getValue().conditionExpression().expression())
+                .isEqualTo("attribute_not_exists(#pk)");
+        assertThat(result.created()).isTrue();
+    }
+
+    @Test
+    void 같은_eventId면_기존_이벤트를_반환하고_덮어쓰지_않는다() {
+        GeneralMonitoringEventItem incoming = item("ai-analysis-started:session:CCTV_001", 2_000L);
+        GeneralMonitoringEventItem existing = item("ai-analysis-started:session:CCTV_001", 1_000L);
+        doThrow(ConditionalCheckFailedException.builder().message("duplicate").build())
+                .when(table).putItem(any(PutItemEnhancedRequest.class));
+        when(table.getItem(any(software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest.class)))
+                .thenReturn(existing);
+
+        IdempotentSaveResult<GeneralMonitoringEventItem> result = repository.saveIfAbsent(incoming);
+
+        assertThat(result.created()).isFalse();
+        assertThat(result.item()).isSameAs(existing);
+    }
+
+    @Test
+    void 이벤트_타임라인은_최신순으로_조회한다() {
+        GeneralMonitoringEventItem newest = item("event-1", 2_000L);
+        GeneralMonitoringEventItem oldest = item("event-2", 1_000L);
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(GeneralMonitoringEventItem.class)
+                        .items(List.of(newest, oldest)).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        List<GeneralMonitoringEventItem> result = repository.findPageBySessionId(
+                SESSION_ID.toString(), null, 10, null, null);
+
+        org.mockito.Mockito.verify(gsi1).query(captor.capture());
+        assertThat(captor.getValue().scanIndexForward()).isFalse();
+        assertThat(captor.getValue().limit()).isEqualTo(10);
+        assertThat(captor.getValue().filterExpression()).isNull();
+        assertThat(result).containsExactly(newest, oldest);
+    }
+
+    @Test
+    void cctvCode가_있으면_필터_익스프레션을_적용한다() {
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(GeneralMonitoringEventItem.class)
+                        .items(List.of()).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        repository.findPageBySessionId(SESSION_ID.toString(), "CCTV_001", 10, null, null);
+
+        org.mockito.Mockito.verify(gsi1).query(captor.capture());
+        assertThat(captor.getValue().filterExpression()).isNotNull();
+        assertThat(captor.getValue().filterExpression().expression())
+                .isEqualTo("#cctvCode = :cctvCode");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":cctvCode").s())
+                .isEqualTo("CCTV_001");
+    }
+
+    @Test
+    void cursor가_있으면_해당_시각_이전_이벤트만_조회한다() {
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(GeneralMonitoringEventItem.class)
+                        .items(List.of()).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        repository.findPageBySessionId(SESSION_ID.toString(), null, 10, 2_000L, "event-1");
+
+        org.mockito.Mockito.verify(gsi1).query(captor.capture());
+        assertThat(captor.getValue().queryConditional()
+                .expression(TableSchema.fromBean(GeneralMonitoringEventItem.class), GeneralMonitoringEventItem.GSI1_NAME)
+                .expressionValues().values())
+                .extracting(value -> value.s())
+                .contains("EVENT#2000#event-1");
+    }
+
+    @Test
+    void limit이_0이하면_거부한다() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> repository.findPageBySessionId(SESSION_ID.toString(), null, 0, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ArgumentCaptor<PutItemEnhancedRequest<GeneralMonitoringEventItem>> requestCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(PutItemEnhancedRequest.class);
+    }
+
+    private GeneralMonitoringEventItem item(String eventId, long occurredAt) {
+        return GeneralMonitoringEventItem.create(
+                eventId, SESSION_ID.toString(), "CCTV_001",
+                GeneralMonitoringEventType.AI_ANALYSIS_STARTED, occurredAt, null
+        );
+    }
+}

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepositoryTest.java
@@ -128,7 +128,7 @@ class GeneralMonitoringEventRepositoryTest {
                 .expression(TableSchema.fromBean(GeneralMonitoringEventItem.class), GeneralMonitoringEventItem.GSI1_NAME)
                 .expressionValues().values())
                 .extracting(value -> value.s())
-                .contains("EVENT#2000#event-1");
+                .contains("EVENT#0000000000000002000#event-1");
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/training/dto/MonitoringEventResponseTest.java
+++ b/src/test/java/com/saferoute/domain/training/dto/MonitoringEventResponseTest.java
@@ -1,0 +1,47 @@
+package com.saferoute.domain.training.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventType;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class MonitoringEventResponseTest {
+
+    private static final String SESSION_ID = UUID.randomUUID().toString();
+
+    @Test
+    void AI_분석_시작_이벤트는_INFO_심각도와_고정_문구를_갖는다() {
+        GeneralMonitoringEventItem item = GeneralMonitoringEventItem.create(
+                "ai-analysis-started:" + SESSION_ID + ":CCTV_001",
+                SESSION_ID, "CCTV_001", GeneralMonitoringEventType.AI_ANALYSIS_STARTED, 1_000L, null
+        );
+
+        MonitoringEventResponse response = MonitoringEventResponse.fromGeneralEvent(item);
+
+        assertThat(response.type()).isEqualTo(MonitoringEventType.AI_ANALYSIS_STARTED);
+        assertThat(response.severity()).isEqualTo(MonitoringEventSeverity.INFO);
+        assertThat(response.congestionLevel()).isNull();
+        assertThat(response.occurredAt()).isEqualTo(1_000L);
+        assertThat(response.cctvCode()).isEqualTo("CCTV_001");
+        assertThat(response.message()).isEqualTo("AI 분석 시작 · CCTV_001");
+    }
+
+    @Test
+    void 경로_이탈_감지_이벤트는_WARNING_심각도와_고정_문구를_갖는다() {
+        GeneralMonitoringEventItem item = GeneralMonitoringEventItem.create(
+                UUID.randomUUID().toString(),
+                SESSION_ID, "CCTV_002", GeneralMonitoringEventType.ROUTE_DEVIATION_DETECTED, 2_000L,
+                CongestionLevel.CROWDED
+        );
+
+        MonitoringEventResponse response = MonitoringEventResponse.fromGeneralEvent(item);
+
+        assertThat(response.type()).isEqualTo(MonitoringEventType.ROUTE_DEVIATION_DETECTED);
+        assertThat(response.severity()).isEqualTo(MonitoringEventSeverity.WARNING);
+        assertThat(response.congestionLevel()).isEqualTo(CongestionLevel.CROWDED);
+        assertThat(response.message()).isEqualTo("경로 이탈 감지 · CCTV_002");
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -20,10 +20,13 @@ import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
@@ -79,6 +82,8 @@ class TrainingMonitoringServiceTest {
     @Mock
     private CongestionEventRepository congestionEventRepository;
     @Mock
+    private GeneralMonitoringEventRepository generalMonitoringEventRepository;
+    @Mock
     private CurrentCctvStateRepository currentCctvStateRepository;
     @Mock
     private RouteRecalculationRepository routeRecalculationRepository;
@@ -99,6 +104,7 @@ class TrainingMonitoringServiceTest {
                 latestMonitoringCaptureRepository,
                 observationRepository,
                 congestionEventRepository,
+                generalMonitoringEventRepository,
                 currentCctvStateRepository,
                 routeRecalculationRepository,
                 s3PresignedUrlService,
@@ -845,6 +851,68 @@ class TrainingMonitoringServiceTest {
     }
 
     @Test
+    void 일반_모니터링_이벤트도_시각_최신순으로_합쳐_반환한다() {
+        stubSession(TrainingStatus.RUNNING);
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
+                .willReturn(List.of());
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of());
+        GeneralMonitoringEventItem aiAnalysisStarted = generalEvent(
+                "CCTV_001", GeneralMonitoringEventType.AI_ANALYSIS_STARTED, 1_000L);
+        given(generalMonitoringEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
+                .willReturn(List.of(aiAnalysisStarted));
+
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, 20, null, EMAIL);
+
+        assertThat(response.events())
+                .extracting(MonitoringEventResponse::type, MonitoringEventResponse::occurredAt)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.AI_ANALYSIS_STARTED, 1_000L)
+                );
+    }
+
+    @Test
+    void cctvCode를_일반_모니터링_이벤트_조회_조건으로도_전달한다() {
+        stubSession(TrainingStatus.RUNNING);
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), "CCTV_001", 21, null, null))
+                .willReturn(List.of());
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of());
+        given(generalMonitoringEventRepository
+                .findPageBySessionId(SESSION_ID.toString(), "CCTV_001", 21, null, null))
+                .willReturn(List.of());
+
+        service.getEvents(SESSION_ID, "CCTV_001", 20, null, EMAIL);
+
+        verify(generalMonitoringEventRepository)
+                .findPageBySessionId(SESSION_ID.toString(), "CCTV_001", 21, null, null);
+    }
+
+    @Test
+    void 혼잡_이벤트와_일반_모니터링_이벤트가_섞여도_시각순으로_정렬된다() {
+        stubSession(TrainingStatus.RUNNING);
+        CongestionEventItem congestionEvent = congestionEventItem(
+                "CCTV_001", CongestionEventType.CONGESTION_STARTED, 2_000L, CongestionLevel.CROWDED);
+        given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
+                .willReturn(List.of(congestionEvent));
+        given(routeRecalculationRepository.findAllByTrainingSession_IdOrderByRequestedAtDesc(SESSION_ID))
+                .willReturn(List.of());
+        GeneralMonitoringEventItem routeDeviation = generalEvent(
+                "CCTV_002", GeneralMonitoringEventType.ROUTE_DEVIATION_DETECTED, 3_000L);
+        given(generalMonitoringEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
+                .willReturn(List.of(routeDeviation));
+
+        MonitoringEventListResponse response = service.getEvents(SESSION_ID, null, 20, null, EMAIL);
+
+        assertThat(response.events())
+                .extracting(MonitoringEventResponse::type, MonitoringEventResponse::occurredAt)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.ROUTE_DEVIATION_DETECTED, 3_000L),
+                        org.assertj.core.groups.Tuple.tuple(MonitoringEventType.CONGESTION_STARTED, 2_000L)
+                );
+    }
+
+    @Test
     void 해소된_재탐색은_요청과_해소_두_이벤트로_나뉜다() {
         stubSession(TrainingStatus.RUNNING);
         given(congestionEventRepository.findPageBySessionId(SESSION_ID.toString(), null, 21, null, null))
@@ -963,6 +1031,12 @@ class TrainingMonitoringServiceTest {
         return CongestionEventItem.received(
                 UUID.randomUUID(), SESSION_ID, cctvCode, type, detectedAt,
                 5, 0.3, CongestionLevel.NORMAL, 0.5, level, 1L, null);
+    }
+
+    private GeneralMonitoringEventItem generalEvent(
+            String cctvCode, GeneralMonitoringEventType type, long occurredAt) {
+        return GeneralMonitoringEventItem.create(
+                UUID.randomUUID().toString(), SESSION_ID.toString(), cctvCode, type, occurredAt, null);
     }
 
     private RouteRecalculation recalculation(


### PR DESCRIPTION
## 요약
- AI 분석 시작(`AI_ANALYSIS_STARTED`), 경로 이탈 감지(`ROUTE_DEVIATION_DETECTED`) 이벤트를 혼잡 이벤트와 별도로 저장할 수 있는 `GeneralMonitoringEventItem`/`GeneralMonitoringEventRepository`를 추가했습니다.
- `GET /api/v1/sessions/{sessionId}/monitoring/events` 타임라인이 기존 혼잡 이벤트·경로 재탐색 이벤트에 더해 이 일반 모니터링 이벤트도 병합해 최신순 커서 페이지네이션으로 반환하도록 확장했습니다.
- 이 PR은 저장 모델·repository·타임라인 병합까지만 다룹니다. `AI_ANALYSIS_STARTED`/`ROUTE_DEVIATION_DETECTED`를 실제로 언제 생성할지 판정하는 로직과 WebSocket 발행은 후속 이슈에서 진행합니다.

## 변경 사항
- `GeneralMonitoringEventItem`, `GeneralMonitoringEventType` 추가 (기존 `CongestionEventItem`과 동일한 PK/GSI1 구조, TTL 30일)
- `GeneralMonitoringEventRepository` 추가 (`saveIfAbsent` 조건부 put 멱등 저장, `findPageBySessionId` 최신순 커서 조회 + cctvCode 필터)
- `MonitoringEventType`에 `AI_ANALYSIS_STARTED`, `ROUTE_DEVIATION_DETECTED` 값과 `from(GeneralMonitoringEventType)` 매핑 추가
- `MonitoringEventResponse.fromGeneralEvent(...)` 팩토리 추가
- `TrainingMonitoringService.getEvents()`가 세 번째 소스(일반 모니터링 이벤트)를 병합하도록 수정

## API 변경
- 외부 스키마 변경 없음. `GET /api/v1/sessions/{sessionId}/monitoring/events` 응답의 `type` 필드에 새 값(`AI_ANALYSIS_STARTED`, `ROUTE_DEVIATION_DETECTED`)이 추가로 나타날 수 있습니다.

## 테스트
- `GeneralMonitoringEventRepositoryTest`: 멱등 저장, 최신순 커서 조회, cctvCode 필터
- `MonitoringEventResponseTest`: 타입별 심각도/메시지 매핑
- `TrainingMonitoringServiceTest`: 혼잡/재탐색/일반 이벤트 3소스 병합 및 정렬, cctvCode 필터 전달
- `./gradlew test` 관련 테스트 전체 통과 확인

## 후속 작업
- AI 분석 시작 판정 로직
- 경로 이탈 감지 판정 로직
- WebSocket 발행 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - AI 분석 시작 및 경로 이탈 감지 이벤트를 모니터링 타임라인에 표시합니다.
  - 모니터링 이벤트를 발생 시각 최신순으로 통합 조회할 수 있습니다.
  - 세션 및 CCTV별 이벤트 조회와 페이지네이션을 지원합니다.
  - 동일 이벤트의 중복 저장을 방지합니다.

- **개선 사항**
  - 새 이벤트 유형별 심각도와 안내 메시지를 제공합니다.
  - 경로 재탐색 및 혼잡 이벤트와 함께 통합된 타임라인을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->