### PR TITLE
feat(congestion): 첫 Observation 기반 AI 분석 시작 이벤트 생성 - #203

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -14,9 +14,12 @@ import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTrigger
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.telemetry.dynamo.entity.CurrentCctvStateItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.LatestMonitoringCaptureItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
@@ -27,6 +30,7 @@ import com.saferoute.global.api.error.CongestionErrorCode;
 import com.saferoute.global.api.error.TrainingErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.infrastructure.websocket.service.TrainingEventPublisher;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -54,6 +58,7 @@ public class CongestionObservationService {
     private static final String JPEG_SUFFIX = ".jpg";
 
     private final ObservationRepository observationRepository;
+    private final GeneralMonitoringEventRepository generalMonitoringEventRepository;
     private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final CurrentCctvStateRepository currentCctvStateRepository;
     private final TrainingSessionRepository trainingSessionRepository;
@@ -106,6 +111,7 @@ public class CongestionObservationService {
         IdempotentSaveResult<ObservationItem> saveResult = observationRepository.saveIfAbsent(item);
         validateEventIdentity(saveResult.item(), request, session.getId());
         updateLatestMonitoringCapture(session.getId(), cctv.getCode(), request.capturedAt(), monitoringImageKey);
+        tryCreateAiAnalysisStartedEvent(session.getId(), cctv.getCode(), request.capturedAt());
 
         String processingOwner = UUID.randomUUID().toString();
         long processingStartedAt = Instant.now().toEpochMilli();
@@ -200,6 +206,32 @@ public class CongestionObservationService {
         );
         if (!latestMonitoringCaptureRepository.updateIfLatest(capture)) {
             log.debug("더 최신 캡처가 있어 모니터링 포인터 갱신을 건너뜀: cctvCode={}", cctvCode);
+        }
+    }
+
+    // 세션+CCTV 조합의 첫 유효 Observation 저장 시점에 AI_ANALYSIS_STARTED 일반 모니터링 이벤트를 생성한다.
+    // eventId를 세션+CCTV+이벤트타입으로부터 결정적으로 만들어 attribute_not_exists 조건부 put에 태우면,
+    // 이 저장 시도 하나만으로 "세션+CCTV당 정확히 한 번" 생성을 보장할 수 있다 (별도 마커/플래그 불필요).
+    // 실패해도 Observation 저장 자체(reportObservation 전체)는 실패시키지 않는다.
+    private void tryCreateAiAnalysisStartedEvent(UUID sessionId, String cctvCode, long capturedAt) {
+        try {
+            String eventId = UUID.nameUUIDFromBytes(
+                    ("AI_ANALYSIS_STARTED:" + sessionId + ":" + cctvCode).getBytes(StandardCharsets.UTF_8)
+            ).toString();
+            GeneralMonitoringEventItem item = GeneralMonitoringEventItem.create(
+                    eventId,
+                    sessionId.toString(),
+                    cctvCode,
+                    GeneralMonitoringEventType.AI_ANALYSIS_STARTED,
+                    capturedAt,
+                    null
+            );
+            generalMonitoringEventRepository.saveIfAbsent(item);
+        } catch (RuntimeException exception) {
+            log.error(
+                    "AI_ANALYSIS_STARTED 이벤트 생성 중 오류: sessionId={}, cctvCode={}",
+                    sessionId, cctvCode, exception
+            );
         }
     }
 

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -304,6 +304,22 @@ class CongestionObservationServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.EVENT_IDENTITY_MISMATCH);
 
         verify(observationRepository, never()).claimProcessing(anyString(), anyString(), anyLong(), anyLong());
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("Observation 저장 자체가 실패하면 AI_ANALYSIS_STARTED 이벤트 생성을 시도하지 않는다")
+    void reportObservation_doesNotTryToCreateAiAnalysisStartedEventWhenObservationSaveFails() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        given(observationRepository.saveIfAbsent(any())).willThrow(new RuntimeException("dynamo unavailable"));
+
+        assertThatThrownBy(() -> service.reportObservation(cctv, request(5.0)))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -30,8 +30,11 @@ import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
 import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
@@ -61,6 +64,9 @@ class CongestionObservationServiceTest {
 
     @Mock
     private ObservationRepository observationRepository;
+
+    @Mock
+    private GeneralMonitoringEventRepository generalMonitoringEventRepository;
 
     @Mock
     private LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
@@ -418,5 +424,63 @@ class CongestionObservationServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORING_IMAGE_IDENTITY_MISMATCH);
 
         verify(observationRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("유효한 Observation을 저장하면 AI_ANALYSIS_STARTED 이벤트 생성을 시도한다")
+    void reportObservation_triesToCreateAiAnalysisStartedEvent() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+
+        service.reportObservation(cctv, request(5.0));
+
+        verify(generalMonitoringEventRepository).saveIfAbsent(argThat(item ->
+                item.getTrainingSessionId().equals(sessionId.toString())
+                        && item.getCctvCode().equals("CCTV_001")
+                        && item.getEventType() == GeneralMonitoringEventType.AI_ANALYSIS_STARTED
+                        && item.getOccurredAt() == 2_000L
+                        && item.getCongestionLevel() == null
+        ));
+    }
+
+    @Test
+    @DisplayName("같은 세션+CCTV로 여러 번 호출해도 AI_ANALYSIS_STARTED 이벤트 eventId는 항상 같다 (결정적 생성)")
+    void reportObservation_generatesDeterministicEventIdForAiAnalysisStartedEvent() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+
+        service.reportObservation(cctv, request(5.0));
+        service.reportObservation(cctv, request(7.0));
+
+        org.mockito.ArgumentCaptor<GeneralMonitoringEventItem> captor =
+                org.mockito.ArgumentCaptor.forClass(GeneralMonitoringEventItem.class);
+        verify(generalMonitoringEventRepository, times(2)).saveIfAbsent(captor.capture());
+        List<GeneralMonitoringEventItem> saved = captor.getAllValues();
+        assertThat(saved.get(0).getEventId()).isEqualTo(saved.get(1).getEventId());
+    }
+
+    @Test
+    @DisplayName("AI_ANALYSIS_STARTED 이벤트 저장이 실패해도 Observation 저장 자체는 실패하지 않는다")
+    void reportObservation_swallowsExceptionFromGeneralMonitoringEventRepository() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+        given(generalMonitoringEventRepository.saveIfAbsent(any()))
+                .willThrow(new RuntimeException("dynamo unavailable"));
+
+        var result = service.reportObservation(cctv, request(5.0));
+
+        assertThat(result.created()).isTrue();
     }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #203
- Branch: feat/#203

## 주요 내용

- 세션+CCTV 조합의 첫 유효 Observation 저장 시점에 BE가 직접 `AI_ANALYSIS_STARTED` 일반 모니터링 이벤트를 생성하도록 `CongestionObservationService.reportObservation()`에 훅 추가
- eventId를 `"AI_ANALYSIS_STARTED:{sessionId}:{cctvCode}"`로부터 결정적으로 생성해, DynamoDB 조건부 put(`attribute_not_exists`) 하나만으로 세션+CCTV당 정확히 한 번 생성되도록 보장 (별도 마커/플래그 없음)
- `GeneralMonitoringEventRepository.saveIfAbsent` 호출은 try/catch로 감싸 예외를 흡수 — 실패해도 Observation 저장 자체(`reportObservation()` 전체)는 실패시키지 않음
- 모델명/모델 버전 필드는 이번 이슈 범위에서 제외

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?