### PR TITLE
feat(evacuation): 유도등 반대 방향 CCTV 기반 경로 이탈 감지 - #204

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -10,6 +10,7 @@ import com.saferoute.domain.device.util.MonitoredAreaCalculator;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.evacuation.deviation.service.RouteDeviationService;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
@@ -66,6 +67,7 @@ public class CongestionObservationService {
     private final MapEdgeGridCellRepository mapEdgeGridCellRepository;
     private final CongestionConfigService congestionConfigService;
     private final RouteRecalculationService routeRecalculationService;
+    private final RouteDeviationService routeDeviationService;
     private final TrainingEventPublisher trainingEventPublisher;
 
     @Transactional
@@ -112,6 +114,7 @@ public class CongestionObservationService {
         validateEventIdentity(saveResult.item(), request, session.getId());
         updateLatestMonitoringCapture(session.getId(), cctv.getCode(), request.capturedAt(), monitoringImageKey);
         tryCreateAiAnalysisStartedEvent(session.getId(), cctv.getCode(), request.capturedAt());
+        routeDeviationService.evaluateObservation(cctv, saveResult.item());
 
         String processingOwner = UUID.randomUUID().toString();
         long processingStartedAt = Instant.now().toEpochMilli();

--- a/src/main/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationService.java
@@ -1,15 +1,22 @@
 package com.saferoute.domain.evacuation.deviation.service;
 
+import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.IoTLight;
 import com.saferoute.domain.device.entity.IoTLightDirection;
 import com.saferoute.domain.device.repository.CctvGridCellRepository;
 import com.saferoute.domain.device.repository.IoTLightJpaRepository;
 import com.saferoute.domain.evacuation.deviation.dto.RouteDeviationResponse;
 import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.LightDirectionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.entity.RouteDeviationState;
+import com.saferoute.domain.telemetry.dynamo.entity.RouteDeviationStateItem;
+import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LightDirectionEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.RouteDeviationStateRepository;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
@@ -24,6 +31,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,12 +39,19 @@ import org.springframework.transaction.annotation.Transactional;
 // 시간 축으로 조인해 경로 이탈률을 계산한다. CCTV 한 대는 headcount/밀집도만 보고하므로 개별 이동 경로까지는
 // 알 수 없지만, "좌/우 통로를 각각 감시하는 CCTV가 분리되어 있다"는 전제(데모 구성) 하에 어느 쪽 CCTV에서
 // 인원이 탐지됐는지를 실제 이동 방향의 대리 지표로 사용한다.
+//
+// evaluateObservation()은 위 리포트 집계와 별개로, Observation이 들어올 때마다 실시간으로 경로 이탈
+// 상태(RouteDeviationStateItem)를 갱신하고 NORMAL->DEVIATING 전환 시 ROUTE_DEVIATION_DETECTED
+// 일반 모니터링 이벤트를 생성한다. resolveCctvCodes/activeDirectionAt/모호 CCTV 제외 로직은
+// computeWindowStats와 동일한 기준을 공유하기 위해 그대로 재사용한다.
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RouteDeviationService {
 
     private static final int OBSERVATION_QUERY_LIMIT = 2000;
+    private static final int NORMAL_RECOVERY_ZERO_STREAK = 2;
 
     private final IoTLightJpaRepository iotLightJpaRepository;
     private final TrainingSessionRepository trainingSessionRepository;
@@ -45,6 +60,8 @@ public class RouteDeviationService {
     private final MapEdgeGridCellRepository mapEdgeGridCellRepository;
     private final CctvGridCellRepository cctvGridCellRepository;
     private final SchoolContextService schoolContextService;
+    private final RouteDeviationStateRepository routeDeviationStateRepository;
+    private final GeneralMonitoringEventRepository generalMonitoringEventRepository;
 
     public RouteDeviationResponse calculate(UUID lightId, UUID trainingSessionId, String email) {
         String schoolName = schoolContextService.getSchoolName(email);
@@ -92,6 +109,118 @@ public class RouteDeviationService {
 
         double deviationRate = total == 0 ? 0.0 : (double) deviated / total;
         return new SessionDeviationResult(total, deviated, deviationRate);
+    }
+
+    // Observation 하나가 들어올 때마다 이 CCTV를 좌/우 CCTV로 쓰는 모든 유도등에 대해 실시간으로
+    // 경로 이탈 여부를 판정한다. CongestionObservationService.reportObservation()에서 Observation이
+    // 유효하게 저장된 직후(처리 lease 선점 여부와 무관) 호출된다. 경로 재계산/유도등 제어는 호출하지 않는다.
+    // 예외는 여기서 흡수해 Observation 저장 자체(reportObservation() 전체)를 실패시키지 않는다.
+    @Transactional
+    public void evaluateObservation(Cctv cctv, ObservationItem observation) {
+        try {
+            UUID buildingId = cctv.getCustomNode().getFloor().getBuilding().getId();
+            List<IoTLight> lights = iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId);
+            for (IoTLight light : lights) {
+                if (light.isGuidanceConfigured()) {
+                    evaluateLight(light, observation);
+                }
+            }
+        } catch (RuntimeException exception) {
+            log.error(
+                    "경로 이탈 판정 중 오류: sessionId={}, cctvCode={}",
+                    observation.getTrainingSessionId(), observation.getCctvCode(), exception
+            );
+        }
+    }
+
+    // 유도등 하나에 대해, 이번 Observation이 "안내 반대편 CCTV의 신호"인지 판단하고 상태 전환을 시도한다.
+    private void evaluateLight(IoTLight light, ObservationItem observation) {
+        String cctvCode = observation.getCctvCode();
+        Set<String> leftCctvCodes = resolveCctvCodes(light.getLeftEdge().getId());
+        Set<String> rightCctvCodes = resolveCctvCodes(light.getRightEdge().getId());
+        Set<String> ambiguous = intersect(leftCctvCodes, rightCctvCodes);
+        if (ambiguous.contains(cctvCode)) {
+            return;
+        }
+        leftCctvCodes.removeAll(ambiguous);
+        rightCctvCodes.removeAll(ambiguous);
+
+        boolean isLeftCctv = leftCctvCodes.contains(cctvCode);
+        boolean isRightCctv = rightCctvCodes.contains(cctvCode);
+        if (!isLeftCctv && !isRightCctv) {
+            return;
+        }
+
+        List<LightDirectionEventItem> directionEvents = lightDirectionEventRepository
+                .findAllBySessionIdAndLightCode(observation.getTrainingSessionId(), light.getCode());
+        IoTLightDirection activeDirection = activeDirectionAt(directionEvents, observation.getCapturedAt());
+        if (activeDirection == null || activeDirection == IoTLightDirection.BOTH
+                || activeDirection == IoTLightDirection.OFF) {
+            return;
+        }
+
+        boolean isOppositeSideSignal = (activeDirection == IoTLightDirection.LEFT && isRightCctv)
+                || (activeDirection == IoTLightDirection.RIGHT && isLeftCctv);
+        if (!isOppositeSideSignal) {
+            return;
+        }
+
+        boolean deviationSignal = observation.getAvgHeadcount() != null && observation.getAvgHeadcount() > 0;
+        applyTransition(observation.getTrainingSessionId(), light.getId(), cctvCode, deviationSignal,
+                observation.getCapturedAt());
+    }
+
+    // 유도등+세션별 상태를 읽어 다음 상태를 계산한 뒤, capturedAt 기준 조건부 쓰기로 원자적으로 반영한다.
+    // 조건부 쓰기가 성공하고 NORMAL -> DEVIATING 전환이 일어난 경우에만 이벤트를 생성한다.
+    private void applyTransition(
+            String trainingSessionId, UUID lightId, String cctvCode, boolean deviationSignal, long capturedAt
+    ) {
+        Optional<RouteDeviationStateItem> existing = routeDeviationStateRepository.find(trainingSessionId, lightId);
+        RouteDeviationState currentState = existing.map(RouteDeviationStateItem::getState)
+                .orElse(RouteDeviationState.NORMAL);
+        int currentZeroStreak = existing.map(RouteDeviationStateItem::getZeroStreak).orElse(0);
+        Long lastProcessedCapturedAt = existing.map(RouteDeviationStateItem::getLastProcessedCapturedAt)
+                .orElse(null);
+        if (lastProcessedCapturedAt != null && capturedAt <= lastProcessedCapturedAt) {
+            return;
+        }
+
+        RouteDeviationState nextState = currentState;
+        int nextZeroStreak = currentZeroStreak;
+        boolean transitionedToDeviating = false;
+        if (deviationSignal) {
+            nextZeroStreak = 0;
+            if (currentState == RouteDeviationState.NORMAL) {
+                nextState = RouteDeviationState.DEVIATING;
+                transitionedToDeviating = true;
+            }
+        } else {
+            nextZeroStreak = currentZeroStreak + 1;
+            if (currentState == RouteDeviationState.DEVIATING && nextZeroStreak >= NORMAL_RECOVERY_ZERO_STREAK) {
+                nextState = RouteDeviationState.NORMAL;
+                nextZeroStreak = 0;
+            }
+        }
+
+        RouteDeviationStateItem nextItem =
+                RouteDeviationStateItem.create(trainingSessionId, lightId, nextState, nextZeroStreak, capturedAt);
+        boolean written = routeDeviationStateRepository.saveIfNewer(nextItem);
+        if (written && transitionedToDeviating) {
+            createRouteDeviationDetectedEvent(trainingSessionId, cctvCode, capturedAt);
+        }
+    }
+
+    // 전환마다 새 eventId를 발급한다 - 상태 전환 자체가 조건부 쓰기로 최대 1회만 성공하므로 중복 생성 위험이 없다.
+    private void createRouteDeviationDetectedEvent(String trainingSessionId, String cctvCode, long occurredAt) {
+        GeneralMonitoringEventItem item = GeneralMonitoringEventItem.create(
+                UUID.randomUUID().toString(),
+                trainingSessionId,
+                cctvCode,
+                GeneralMonitoringEventType.ROUTE_DEVIATION_DETECTED,
+                occurredAt,
+                null
+        );
+        generalMonitoringEventRepository.saveIfAbsent(item);
     }
 
     // 유도등 하나에 대해 (관측 구간 수, 이탈 구간 수)를 계산, 경로가 지나는 CCTV를 특정할 수 없으면 empty.

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/RouteDeviationState.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/RouteDeviationState.java
@@ -1,0 +1,7 @@
+package com.saferoute.domain.telemetry.dynamo.entity;
+
+// 유도등+세션 단위의 실시간 경로 이탈 상태. RouteDeviationStateItem에 저장된다.
+public enum RouteDeviationState {
+    NORMAL,
+    DEVIATING
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/RouteDeviationStateItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/RouteDeviationStateItem.java
@@ -1,0 +1,117 @@
+package com.saferoute.domain.telemetry.dynamo.entity;
+
+import java.util.UUID;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+// 유도등+세션 단위 실시간 경로 이탈 판정 상태. 인메모리 상태를 두지 않고 매 Observation마다
+// 이 아이템을 읽고 조건부로 갱신하는 방식으로, 서버 재시작/동시 요청에도 일관된 상태를 유지한다.
+// lastProcessedCapturedAt은 지연 도착/과거 시각의 Observation이 최신 상태를 되돌리지 않도록 막는
+// 조건부 쓰기(capturedAt > lastProcessedCapturedAt)의 기준값이다.
+@DynamoDbBean
+public class RouteDeviationStateItem {
+
+    public static final long TTL_SECONDS = 30L * 24 * 60 * 60;
+
+    private String pk;
+    private String sk;
+    private String trainingSessionId;
+    private String lightId;
+    private RouteDeviationState state;
+    private Integer zeroStreak;
+    private Long lastProcessedCapturedAt;
+    private Long expiresAt;
+
+    public RouteDeviationStateItem() {
+    }
+
+    public static RouteDeviationStateItem create(
+            String trainingSessionId,
+            UUID lightId,
+            RouteDeviationState state,
+            int zeroStreak,
+            long lastProcessedCapturedAt
+    ) {
+        RouteDeviationStateItem item = new RouteDeviationStateItem();
+        item.trainingSessionId = trainingSessionId;
+        item.lightId = lightId.toString();
+        item.state = state;
+        item.zeroStreak = zeroStreak;
+        item.lastProcessedCapturedAt = lastProcessedCapturedAt;
+        item.expiresAt = Math.floorDiv(lastProcessedCapturedAt, 1_000L) + TTL_SECONDS;
+        item.pk = buildPk(trainingSessionId, item.lightId);
+        item.sk = "META";
+        return item;
+    }
+
+    public static String buildPk(String trainingSessionId, String lightId) {
+        return "ROUTE_DEVIATION_STATE#" + trainingSessionId + "#" + lightId;
+    }
+
+    @DynamoDbPartitionKey
+    public String getPk() {
+        return pk;
+    }
+
+    public void setPk(String pk) {
+        this.pk = pk;
+    }
+
+    @DynamoDbSortKey
+    public String getSk() {
+        return sk;
+    }
+
+    public void setSk(String sk) {
+        this.sk = sk;
+    }
+
+    public String getTrainingSessionId() {
+        return trainingSessionId;
+    }
+
+    public void setTrainingSessionId(String trainingSessionId) {
+        this.trainingSessionId = trainingSessionId;
+    }
+
+    public String getLightId() {
+        return lightId;
+    }
+
+    public void setLightId(String lightId) {
+        this.lightId = lightId;
+    }
+
+    public RouteDeviationState getState() {
+        return state;
+    }
+
+    public void setState(RouteDeviationState state) {
+        this.state = state;
+    }
+
+    public Integer getZeroStreak() {
+        return zeroStreak;
+    }
+
+    public void setZeroStreak(Integer zeroStreak) {
+        this.zeroStreak = zeroStreak;
+    }
+
+    public Long getLastProcessedCapturedAt() {
+        return lastProcessedCapturedAt;
+    }
+
+    public void setLastProcessedCapturedAt(Long lastProcessedCapturedAt) {
+        this.lastProcessedCapturedAt = lastProcessedCapturedAt;
+    }
+
+    public Long getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Long expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/RouteDeviationStateRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/RouteDeviationStateRepository.java
@@ -1,0 +1,66 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import com.saferoute.domain.telemetry.dynamo.entity.RouteDeviationStateItem;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+
+@Repository
+public class RouteDeviationStateRepository {
+
+    private final DynamoDbTable<RouteDeviationStateItem> table;
+
+    public RouteDeviationStateRepository(
+            DynamoDbEnhancedClient enhancedClient,
+            @Value("${aws.dynamodb.table-name}") String tableName
+    ) {
+        this.table = enhancedClient.table(tableName, TableSchema.fromBean(RouteDeviationStateItem.class));
+    }
+
+    public Optional<RouteDeviationStateItem> find(String trainingSessionId, UUID lightId) {
+        GetItemEnhancedRequest request = GetItemEnhancedRequest.builder()
+                .key(Key.builder()
+                        .partitionValue(RouteDeviationStateItem.buildPk(trainingSessionId, lightId.toString()))
+                        .sortValue("META")
+                        .build())
+                .consistentRead(true)
+                .build();
+        return Optional.ofNullable(table.getItem(request));
+    }
+
+    // incoming.lastProcessedCapturedAt이 저장된 값보다 클 때만 성공하는 조건부 쓰기.
+    // 상태 전환(NORMAL/DEVIATING)과 lastProcessedCapturedAt 갱신을 하나의 원자적 쓰기로 묶어,
+    // 지연 도착/과거 시각의 Observation이 최신 상태를 되돌리지 않도록 막는다.
+    public boolean saveIfNewer(RouteDeviationStateItem incoming) {
+        Expression condition = Expression.builder()
+                .expression("attribute_not_exists(#lastProcessedCapturedAt) OR #lastProcessedCapturedAt < :incoming")
+                .putExpressionName("#lastProcessedCapturedAt", "lastProcessedCapturedAt")
+                .putExpressionValue(
+                        ":incoming",
+                        AttributeValue.fromN(Long.toString(incoming.getLastProcessedCapturedAt()))
+                )
+                .build();
+        PutItemEnhancedRequest<RouteDeviationStateItem> request =
+                PutItemEnhancedRequest.builder(RouteDeviationStateItem.class)
+                        .item(incoming)
+                        .conditionExpression(condition)
+                        .build();
+
+        try {
+            table.putItem(request);
+            return true;
+        } catch (ConditionalCheckFailedException exception) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -27,6 +27,7 @@ import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
 import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.deviation.service.RouteDeviationService;
 import com.saferoute.domain.evacuation.recalculation.entity.RecalculationTriggerType;
 import com.saferoute.domain.evacuation.recalculation.service.RouteRecalculationService;
 import com.saferoute.domain.floor.entity.Floor;
@@ -88,6 +89,9 @@ class CongestionObservationServiceTest {
 
     @Mock
     private RouteRecalculationService routeRecalculationService;
+
+    @Mock
+    private RouteDeviationService routeDeviationService;
 
     @Mock
     private TrainingEventPublisher trainingEventPublisher;
@@ -305,6 +309,7 @@ class CongestionObservationServiceTest {
 
         verify(observationRepository, never()).claimProcessing(anyString(), anyString(), anyLong(), anyLong());
         verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
+        verify(routeDeviationService, never()).evaluateObservation(any(), any());
     }
 
     @Test
@@ -440,6 +445,24 @@ class CongestionObservationServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", CongestionErrorCode.MONITORING_IMAGE_IDENTITY_MISMATCH);
 
         verify(observationRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("유효한 Observation을 저장하면 경로 이탈 판정을 시도한다")
+    void reportObservation_triesToEvaluateRouteDeviation() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+
+        service.reportObservation(cctv, request(5.0));
+
+        verify(routeDeviationService).evaluateObservation(eq(cctv), argThat(item ->
+                item.getTrainingSessionId().equals(sessionId.toString())
+                        && item.getCctvCode().equals("CCTV_001")
+        ));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationServiceTest.java
@@ -4,10 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.device.entity.Cctv;
 import com.saferoute.domain.device.entity.CctvGridCell;
@@ -23,10 +27,15 @@ import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
 import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
 import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
 import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.telemetry.dynamo.entity.GeneralMonitoringEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.LightDirectionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import com.saferoute.domain.telemetry.dynamo.entity.RouteDeviationState;
+import com.saferoute.domain.telemetry.dynamo.entity.RouteDeviationStateItem;
+import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LightDirectionEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.RouteDeviationStateRepository;
 import com.saferoute.domain.training.entity.TrainingScenario;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.repository.TrainingSessionRepository;
@@ -41,6 +50,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -76,14 +86,24 @@ class RouteDeviationServiceTest {
     @Mock
     private SchoolContextService schoolContextService;
 
+    @Mock
+    private RouteDeviationStateRepository routeDeviationStateRepository;
+
+    @Mock
+    private GeneralMonitoringEventRepository generalMonitoringEventRepository;
+
     private Floor floor;
     private final UUID lightId = UUID.randomUUID();
     private final UUID sessionId = UUID.randomUUID();
+    private final UUID buildingId = UUID.randomUUID();
 
     @BeforeEach
     void setUp() {
         floor = mock(Floor.class);
-        given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
+        Building building = mock(Building.class);
+        org.mockito.Mockito.lenient().when(building.getId()).thenReturn(buildingId);
+        org.mockito.Mockito.lenient().when(floor.getBuilding()).thenReturn(building);
+        org.mockito.Mockito.lenient().when(schoolContextService.getSchoolName(EMAIL)).thenReturn(SCHOOL_NAME);
     }
 
     private MapNode node(String code, NodeType type) {
@@ -394,5 +414,205 @@ class RouteDeviationServiceTest {
         assertThat(result.totalObservedWindows()).isZero();
         assertThat(result.deviatedWindows()).isZero();
         assertThat(result.deviationRate()).isEqualTo(0.0);
+    }
+
+    // === evaluateObservation (Observation 수신마다 실시간 경로 이탈 판정) ===
+
+    private void mapLightToDistinctCctvs(IoTLight light) {
+        FloorGridCell leftCell = gridCell();
+        FloorGridCell rightCell = gridCell();
+        Cctv leftCctv = cctv("CCTV_LEFT");
+        Cctv rightCctv = cctv("CCTV_RIGHT");
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(light.getLeftEdge().getId()))
+                .willReturn(List.of(MapEdgeGridCell.create(light.getLeftEdge(), leftCell)));
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(light.getRightEdge().getId()))
+                .willReturn(List.of(MapEdgeGridCell.create(light.getRightEdge(), rightCell)));
+        given(cctvGridCellRepository.findAllByGridCell_IdIn(List.of(leftCell.getId())))
+                .willReturn(List.of(mapping(leftCctv, leftCell)));
+        given(cctvGridCellRepository.findAllByGridCell_IdIn(List.of(rightCell.getId())))
+                .willReturn(List.of(mapping(rightCctv, rightCell)));
+    }
+
+    private Cctv incomingCctv() {
+        return cctv("REPORTING_CCTV");
+    }
+
+    @Test
+    @DisplayName("안내 반대편 CCTV에서 사람이 감지되면 NORMAL -> DEVIATING 전환하고 이벤트를 생성한다")
+    void evaluateObservation_transitionsToDeviatingOnOppositeSideDetection() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId())).willReturn(Optional.empty());
+        given(routeDeviationStateRepository.saveIfNewer(any())).willReturn(true);
+
+        ObservationItem observation = observation("CCTV_RIGHT", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        ArgumentCaptor<RouteDeviationStateItem> stateCaptor = ArgumentCaptor.forClass(RouteDeviationStateItem.class);
+        verify(routeDeviationStateRepository).saveIfNewer(stateCaptor.capture());
+        assertThat(stateCaptor.getValue().getState()).isEqualTo(RouteDeviationState.DEVIATING);
+        assertThat(stateCaptor.getValue().getZeroStreak()).isZero();
+        assertThat(stateCaptor.getValue().getLastProcessedCapturedAt()).isEqualTo(5_000L);
+
+        verify(generalMonitoringEventRepository).saveIfAbsent(argThat(item ->
+                item.getEventType() == GeneralMonitoringEventType.ROUTE_DEVIATION_DETECTED
+                        && item.getTrainingSessionId().equals(sessionId.toString())
+                        && item.getCctvCode().equals("CCTV_RIGHT")
+                        && item.getOccurredAt() == 5_000L
+        ));
+    }
+
+    @Test
+    @DisplayName("안내 방향 쪽 CCTV에서 감지되면 상태를 바꾸지 않는다")
+    void evaluateObservation_guidedSideDetection_doesNotChangeState() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+
+        ObservationItem observation = observation("CCTV_LEFT", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository, never()).find(anyString(), any());
+        verify(routeDeviationStateRepository, never()).saveIfNewer(any());
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("유도 방향이 BOTH이면 판단하지 않는다")
+    void evaluateObservation_bothDirection_skipsJudgement() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.BOTH, 1_000L)));
+
+        ObservationItem observation = observation("CCTV_RIGHT", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository, never()).saveIfNewer(any());
+    }
+
+    @Test
+    @DisplayName("유도등 방향 이력이 없으면 판단하지 않는다")
+    void evaluateObservation_noDirectionHistory_skipsJudgement() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of());
+
+        ObservationItem observation = observation("CCTV_RIGHT", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository, never()).saveIfNewer(any());
+    }
+
+    @Test
+    @DisplayName("좌우 양쪽에 모호하게 매핑된 CCTV는 판단하지 않는다")
+    void evaluateObservation_ambiguousCctv_skipsJudgement() {
+        IoTLight light = lightWithGuidance();
+        FloorGridCell sharedCell = gridCell();
+        Cctv sharedCctv = cctv("CCTV_SHARED");
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(light.getLeftEdge().getId()))
+                .willReturn(List.of(MapEdgeGridCell.create(light.getLeftEdge(), sharedCell)));
+        given(mapEdgeGridCellRepository.findAllByMapEdge_Id(light.getRightEdge().getId()))
+                .willReturn(List.of(MapEdgeGridCell.create(light.getRightEdge(), sharedCell)));
+        given(cctvGridCellRepository.findAllByGridCell_IdIn(List.of(sharedCell.getId())))
+                .willReturn(List.of(mapping(sharedCctv, sharedCell)));
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+
+        ObservationItem observation = observation("CCTV_SHARED", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(lightDirectionEventRepository, never()).findAllBySessionIdAndLightCode(anyString(), anyString());
+        verify(routeDeviationStateRepository, never()).saveIfNewer(any());
+    }
+
+    @Test
+    @DisplayName("이미 DEVIATING 상태에서 반대편 신호가 반복돼도 이벤트를 재생성하지 않는다")
+    void evaluateObservation_alreadyDeviating_doesNotRecreateEvent() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+        RouteDeviationStateItem existing = RouteDeviationStateItem.create(
+                sessionId.toString(), light.getId(), RouteDeviationState.DEVIATING, 0, 3_000L);
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId()))
+                .willReturn(Optional.of(existing));
+        given(routeDeviationStateRepository.saveIfNewer(any())).willReturn(true);
+
+        ObservationItem observation = observation("CCTV_RIGHT", 2.0, 6_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository).saveIfNewer(argThat(item ->
+                item.getState() == RouteDeviationState.DEVIATING && item.getLastProcessedCapturedAt() == 6_000L));
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("반대편 0명 관측이 2회 연속되면 NORMAL로 복귀한다")
+    void evaluateObservation_twoConsecutiveZeroCounts_recoversToNormal() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+        RouteDeviationStateItem existing = RouteDeviationStateItem.create(
+                sessionId.toString(), light.getId(), RouteDeviationState.DEVIATING, 1, 5_000L);
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId()))
+                .willReturn(Optional.of(existing));
+        given(routeDeviationStateRepository.saveIfNewer(any())).willReturn(true);
+
+        ObservationItem observation = observation("CCTV_RIGHT", 0.0, 9_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository).saveIfNewer(argThat(item ->
+                item.getState() == RouteDeviationState.NORMAL
+                        && item.getZeroStreak() == 0
+                        && item.getLastProcessedCapturedAt() == 9_000L));
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("lastProcessedCapturedAt보다 과거이거나 같은 시각의 지연 도착 Observation은 무시한다")
+    void evaluateObservation_staleCapturedAt_ignored() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+        RouteDeviationStateItem existing = RouteDeviationStateItem.create(
+                sessionId.toString(), light.getId(), RouteDeviationState.NORMAL, 0, 5_000L);
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId()))
+                .willReturn(Optional.of(existing));
+
+        ObservationItem observation = observation("CCTV_RIGHT", 3.0, 4_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository, never()).saveIfNewer(any());
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("조건부 쓰기가 경합으로 실패하면(오래된 상태 기반 전환) 이벤트를 생성하지 않는다")
+    void evaluateObservation_conditionalWriteLost_doesNotCreateEvent() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId())).willReturn(Optional.empty());
+        given(routeDeviationStateRepository.saveIfNewer(any())).willReturn(false);
+
+        ObservationItem observation = observation("CCTV_RIGHT", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
     }
 }

--- a/src/test/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/deviation/service/RouteDeviationServiceTest.java
@@ -615,4 +615,109 @@ class RouteDeviationServiceTest {
 
         verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
     }
+
+    @Test
+    @DisplayName("유도 방향이 RIGHT일 때 왼쪽 CCTV에서 사람이 감지되면 DEVIATING으로 전환한다")
+    void evaluateObservation_rightDirection_leftCctvDetection_transitionsToDeviating() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.RIGHT, 1_000L)));
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId())).willReturn(Optional.empty());
+        given(routeDeviationStateRepository.saveIfNewer(any())).willReturn(true);
+
+        ObservationItem observation = observation("CCTV_LEFT", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository).saveIfNewer(argThat(item ->
+                item.getState() == RouteDeviationState.DEVIATING && item.getLastProcessedCapturedAt() == 5_000L));
+        verify(generalMonitoringEventRepository).saveIfAbsent(argThat(item ->
+                item.getEventType() == GeneralMonitoringEventType.ROUTE_DEVIATION_DETECTED
+                        && item.getCctvCode().equals("CCTV_LEFT")));
+    }
+
+    @Test
+    @DisplayName("유도 방향이 OFF이면 판단하지 않는다")
+    void evaluateObservation_offDirection_skipsJudgement() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.OFF, 1_000L)));
+
+        ObservationItem observation = observation("CCTV_RIGHT", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository, never()).saveIfNewer(any());
+    }
+
+    @Test
+    @DisplayName("반대편 0명 관측이 1회만 수신되면 아직 DEVIATING 상태를 유지한다")
+    void evaluateObservation_singleZeroCount_staysDeviating() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+        RouteDeviationStateItem existing = RouteDeviationStateItem.create(
+                sessionId.toString(), light.getId(), RouteDeviationState.DEVIATING, 0, 5_000L);
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId()))
+                .willReturn(Optional.of(existing));
+        given(routeDeviationStateRepository.saveIfNewer(any())).willReturn(true);
+
+        ObservationItem observation = observation("CCTV_RIGHT", 0.0, 9_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository).saveIfNewer(argThat(item ->
+                item.getState() == RouteDeviationState.DEVIATING
+                        && item.getZeroStreak() == 1
+                        && item.getLastProcessedCapturedAt() == 9_000L));
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
+    }
+
+    @Test
+    @DisplayName("NORMAL로 복귀한 뒤 다시 이탈하면 새 이벤트를 생성한다")
+    void evaluateObservation_deviatesAgainAfterRecovery_createsNewEvent() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+        // 복구 직후(zeroStreak 리셋된) NORMAL 상태에서 다시 반대편 신호가 들어온 경우.
+        RouteDeviationStateItem recovered = RouteDeviationStateItem.create(
+                sessionId.toString(), light.getId(), RouteDeviationState.NORMAL, 0, 10_000L);
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId()))
+                .willReturn(Optional.of(recovered));
+        given(routeDeviationStateRepository.saveIfNewer(any())).willReturn(true);
+
+        ObservationItem observation = observation("CCTV_RIGHT", 3.0, 12_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository).saveIfNewer(argThat(item ->
+                item.getState() == RouteDeviationState.DEVIATING && item.getLastProcessedCapturedAt() == 12_000L));
+        verify(generalMonitoringEventRepository).saveIfAbsent(argThat(item ->
+                item.getEventType() == GeneralMonitoringEventType.ROUTE_DEVIATION_DETECTED
+                        && item.getOccurredAt() == 12_000L));
+    }
+
+    @Test
+    @DisplayName("lastProcessedCapturedAt과 정확히 같은 시각의 Observation은 재처리하지 않는다")
+    void evaluateObservation_sameCapturedAtAsLastProcessed_ignored() {
+        IoTLight light = lightWithGuidance();
+        mapLightToDistinctCctvs(light);
+        given(iotLightJpaRepository.findAllByCustomNode_Floor_Building_Id(buildingId)).willReturn(List.of(light));
+        given(lightDirectionEventRepository.findAllBySessionIdAndLightCode(sessionId.toString(), light.getCode()))
+                .willReturn(List.of(directionEvent(light, IoTLightDirection.LEFT, 1_000L)));
+        RouteDeviationStateItem existing = RouteDeviationStateItem.create(
+                sessionId.toString(), light.getId(), RouteDeviationState.NORMAL, 0, 5_000L);
+        given(routeDeviationStateRepository.find(sessionId.toString(), light.getId()))
+                .willReturn(Optional.of(existing));
+
+        ObservationItem observation = observation("CCTV_RIGHT", 3.0, 5_000L);
+        routeDeviationService.evaluateObservation(incomingCctv(), observation);
+
+        verify(routeDeviationStateRepository, never()).saveIfNewer(any());
+        verify(generalMonitoringEventRepository, never()).saveIfAbsent(any());
+    }
 }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #204
- Branch: feat/#204

## 주요 내용

- Observation 수신마다 유도등 안내 방향과 반대편 CCTV의 탐지 여부를 비교해 실시간으로 경로 이탈 상태(NORMAL/DEVIATING)를 판정하는 `RouteDeviationService.evaluateObservation(Cctv, ObservationItem)` 추가
- `RouteDeviationStateItem`/`RouteDeviationStateRepository` 신규 — 유도등+세션별 상태를 DynamoDB에 저장하고, `capturedAt > lastProcessedCapturedAt` 조건부 쓰기로 지연 도착/과거 시각의 Observation이 최신 상태를 되돌리지 않도록 방어
- 리포트 집계(`computeWindowStats`)와 동일한 CCTV 좌/우 매핑 판정 기준(모호 CCTV 제외 포함)을 `resolveCctvCodes`/`intersect`/`activeDirectionAt` 재사용으로 공유
- `NORMAL -> DEVIATING` 전환 시에만 `ROUTE_DEVIATION_DETECTED` 일반 모니터링 이벤트 생성, 반대편 0명 관측 2회 연속 시 `NORMAL`로 복귀
- `CongestionObservationService.reportObservation()`에서 #203의 `AI_ANALYSIS_STARTED` 훅과 같은 지점(처리 lease 선점 여부와 무관)에서 호출
- 경로 재계산/유도등 제어 서비스는 의존성으로 주입하지 않아 호출 불가능(코드 구조로 보장), 예외는 내부에서 흡수해 Observation 저장 자체를 실패시키지 않음

## ✅ Check List

- [x] 테스트 통과 (전체 668개)
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?