### PR TITLE
feat(monitoring): CCTV별 저장 프레임 수 조회 지원 - #205

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -23,6 +23,7 @@ import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateReposito
 import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationCountRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -59,6 +60,7 @@ public class CongestionObservationService {
     private static final String JPEG_SUFFIX = ".jpg";
 
     private final ObservationRepository observationRepository;
+    private final ObservationCountRepository observationCountRepository;
     private final GeneralMonitoringEventRepository generalMonitoringEventRepository;
     private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final CurrentCctvStateRepository currentCctvStateRepository;
@@ -115,6 +117,7 @@ public class CongestionObservationService {
         updateLatestMonitoringCapture(session.getId(), cctv.getCode(), request.capturedAt(), monitoringImageKey);
         tryCreateAiAnalysisStartedEvent(session.getId(), cctv.getCode(), request.capturedAt());
         routeDeviationService.evaluateObservation(cctv, saveResult.item());
+        tryIncrementObservationCount(saveResult, session.getId(), cctv.getCode());
 
         String processingOwner = UUID.randomUUID().toString();
         long processingStartedAt = Instant.now().toEpochMilli();
@@ -233,6 +236,24 @@ public class CongestionObservationService {
         } catch (RuntimeException exception) {
             log.error(
                     "AI_ANALYSIS_STARTED 이벤트 생성 중 오류: sessionId={}, cctvCode={}",
+                    sessionId, cctvCode, exception
+            );
+        }
+    }
+
+    // Observation이 이번에 새로 저장된 경우(중복 재시도가 아닌 경우)에만 세션+CCTV별 저장 개수 카운터를
+    // 1 증가시킨다. 실패해도 Observation 저장 자체(reportObservation() 전체)는 실패시키지 않는다.
+    private void tryIncrementObservationCount(
+            IdempotentSaveResult<ObservationItem> saveResult, UUID sessionId, String cctvCode
+    ) {
+        if (!saveResult.created()) {
+            return;
+        }
+        try {
+            observationCountRepository.increment(sessionId.toString(), cctvCode);
+        } catch (RuntimeException exception) {
+            log.error(
+                    "Observation 카운터 증가 중 오류: sessionId={}, cctvCode={}",
                     sessionId, cctvCode, exception
             );
         }

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationCountItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationCountItem.java
@@ -1,0 +1,49 @@
+package com.saferoute.domain.telemetry.dynamo.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+// 세션+CCTV별로 저장된 Observation 총 개수를 원자적 ADD로 관리하는 카운터 아이템.
+// 세션이 진행 중인 동안 계속 조회되는 값이라 TTL을 걸지 않는다(30일 TTL을 걸면 세션이
+// 길어질 경우 카운터가 Observation보다 먼저 만료될 수 있음).
+@DynamoDbBean
+public class ObservationCountItem {
+
+    private String pk;
+    private String sk;
+    private Long count;
+
+    public ObservationCountItem() {
+    }
+
+    public static String buildPk(String trainingSessionId, String cctvCode) {
+        return "OBSERVATION_COUNT#" + trainingSessionId + "#" + cctvCode;
+    }
+
+    @DynamoDbPartitionKey
+    public String getPk() {
+        return pk;
+    }
+
+    public void setPk(String pk) {
+        this.pk = pk;
+    }
+
+    @DynamoDbSortKey
+    public String getSk() {
+        return sk;
+    }
+
+    public void setSk(String sk) {
+        this.sk = sk;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    public void setCount(Long count) {
+        this.count = count;
+    }
+}

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationCountRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationCountRepository.java
@@ -1,0 +1,98 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationCountItem;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.Select;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+@Repository
+public class ObservationCountRepository {
+
+    private static final String SORT_KEY = "META";
+
+    private final DynamoDbClient dynamoDbClient;
+    private final DynamoDbTable<ObservationCountItem> table;
+    private final String tableName;
+    private final String gsi1Name;
+
+    public ObservationCountRepository(
+            DynamoDbClient dynamoDbClient,
+            DynamoDbEnhancedClient enhancedClient,
+            @Value("${aws.dynamodb.table-name}") String tableName,
+            @Value("${aws.dynamodb.gsi1-name:GSI1}") String gsi1Name
+    ) {
+        this.dynamoDbClient = dynamoDbClient;
+        this.table = enhancedClient.table(tableName, TableSchema.fromBean(ObservationCountItem.class));
+        this.tableName = tableName;
+        this.gsi1Name = gsi1Name;
+    }
+
+    // 세션+CCTV의 Observation 저장 개수를 1 증가시킨다. Enhanced Client는 임의의 update expression을
+    // 지원하지 않으므로, 저수준 DynamoDbClient로 ADD 원자 연산을 직접 호출한다 - 동시 요청이 들어와도
+    // 읽고-계산해서-쓰는 방식이 아니라 DynamoDB 서버 사이드에서 정확히 합산된다.
+    public void increment(String trainingSessionId, String cctvCode) {
+        Map<String, AttributeValue> key = Map.of(
+                "pk", AttributeValue.fromS(ObservationCountItem.buildPk(trainingSessionId, cctvCode)),
+                "sk", AttributeValue.fromS(SORT_KEY)
+        );
+        dynamoDbClient.updateItem(UpdateItemRequest.builder()
+                .tableName(tableName)
+                .key(key)
+                .updateExpression("ADD #count :incr")
+                .expressionAttributeNames(Map.of("#count", "count"))
+                .expressionAttributeValues(Map.of(":incr", AttributeValue.fromN("1")))
+                .build());
+    }
+
+    public Optional<Long> find(String trainingSessionId, String cctvCode) {
+        GetItemEnhancedRequest request = GetItemEnhancedRequest.builder()
+                .key(Key.builder()
+                        .partitionValue(ObservationCountItem.buildPk(trainingSessionId, cctvCode))
+                        .sortValue(SORT_KEY)
+                        .build())
+                .consistentRead(true)
+                .build();
+        return Optional.ofNullable(table.getItem(request)).map(ObservationCountItem::getCount);
+    }
+
+    // 카운터 아이템이 없는(이 기능 배포 이전에 생성된) 세션+CCTV 조합을 위한 fallback.
+    // Select=COUNT로 아이템 본문을 가져오지 않고 개수만 세어, ObservationItem의 GSI1 파티션
+    // (세션+CCTV 단위, buildGsi1Pk와 동일 기준) 전체를 순회한다.
+    public long countAllBySessionIdAndCctvCode(String trainingSessionId, String cctvCode) {
+        Map<String, AttributeValue> values = Map.of(
+                ":gsi1pk", AttributeValue.fromS(ObservationItem.buildGsi1Pk(trainingSessionId, cctvCode))
+        );
+
+        long total = 0;
+        Map<String, AttributeValue> lastEvaluatedKey = null;
+        do {
+            QueryRequest.Builder requestBuilder = QueryRequest.builder()
+                    .tableName(tableName)
+                    .indexName(gsi1Name)
+                    .keyConditionExpression("GSI1_PK = :gsi1pk")
+                    .expressionAttributeValues(values)
+                    .select(Select.COUNT);
+            if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty()) {
+                requestBuilder.exclusiveStartKey(lastEvaluatedKey);
+            }
+            QueryResponse response = dynamoDbClient.query(requestBuilder.build());
+            total += response.count();
+            lastEvaluatedKey = response.lastEvaluatedKey();
+        } while (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty());
+
+        return total;
+    }
+}

--- a/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/TrainingMonitoringController.java
@@ -532,7 +532,8 @@ public class TrainingMonitoringController {
                                                   }
                                                 ],
                                                 "nextCursor": "MTc4NzcyMjA5NTAwMA",
-                                                "hasNext": true
+                                                "hasNext": true,
+                                                "totalCount": 137
                                               }
                                             }
                                             """

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameListResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameListResponse.java
@@ -27,6 +27,9 @@ public record MonitoringFrameListResponse(
         String nextCursor,
 
         @Schema(description = "다음 페이지 존재 여부", example = "true")
-        boolean hasNext
+        boolean hasNext,
+
+        @Schema(description = "이 세션+CCTV 조합의 전체 저장 프레임(Observation) 개수", example = "137")
+        long totalCount
 ) {
 }

--- a/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingMonitoringService.java
@@ -13,6 +13,7 @@ import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepositor
 import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationCountRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
 import com.saferoute.domain.training.dto.CurrentCctvStateResponse;
@@ -54,6 +55,7 @@ public class TrainingMonitoringService {
     private final CctvJpaRepository cctvJpaRepository;
     private final LatestMonitoringCaptureRepository latestMonitoringCaptureRepository;
     private final ObservationRepository observationRepository;
+    private final ObservationCountRepository observationCountRepository;
     private final CongestionEventRepository congestionEventRepository;
     private final GeneralMonitoringEventRepository generalMonitoringEventRepository;
     private final CurrentCctvStateRepository currentCctvStateRepository;
@@ -176,7 +178,11 @@ public class TrainingMonitoringService {
                         items.get(items.size() - 1).getEventId())
                 : null;
 
-        return new MonitoringFrameListResponse(sessionId, cctvId, frames, nextCursor, hasNext);
+        long totalCount = observationCountRepository.find(sessionId.toString(), cctv.getCode())
+                .orElseGet(() -> observationCountRepository
+                        .countAllBySessionIdAndCctvCode(sessionId.toString(), cctv.getCode()));
+
+        return new MonitoringFrameListResponse(sessionId, cctvId, frames, nextCursor, hasNext, totalCount);
     }
 
     // 혼잡 감지 이벤트(CongestionEventItem), 경로 재탐색 이벤트(RouteRecalculation), 일반 모니터링

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -38,6 +38,7 @@ import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateReposito
 import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.IdempotentSaveResult;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationCountRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
@@ -65,6 +66,9 @@ class CongestionObservationServiceTest {
 
     @Mock
     private ObservationRepository observationRepository;
+
+    @Mock
+    private ObservationCountRepository observationCountRepository;
 
     @Mock
     private GeneralMonitoringEventRepository generalMonitoringEventRepository;
@@ -288,6 +292,7 @@ class CongestionObservationServiceTest {
         assertThat(result.created()).isFalse();
         verify(trainingEventPublisher, never()).publishCongestionUpdated(any(), any(), any());
         verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
+        verify(observationCountRepository, never()).increment(anyString(), anyString());
     }
 
     @Test
@@ -517,6 +522,38 @@ class CongestionObservationServiceTest {
         givenAffectedEdges();
         given(generalMonitoringEventRepository.saveIfAbsent(any()))
                 .willThrow(new RuntimeException("dynamo unavailable"));
+
+        var result = service.reportObservation(cctv, request(5.0));
+
+        assertThat(result.created()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Observation이 새로 저장되면 세션+CCTV별 카운터를 증가시킨다")
+    void reportObservation_incrementsObservationCountWhenNewlyCreated() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+
+        service.reportObservation(cctv, request(5.0));
+
+        verify(observationCountRepository).increment(sessionId.toString(), "CCTV_001");
+    }
+
+    @Test
+    @DisplayName("카운터 증가가 실패해도 Observation 저장 자체는 실패하지 않는다")
+    void reportObservation_swallowsExceptionFromObservationCountRepository() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+        org.mockito.Mockito.doThrow(new RuntimeException("dynamo unavailable"))
+                .when(observationCountRepository).increment(anyString(), anyString());
 
         var result = service.reportObservation(cctv, request(5.0));
 

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationCountRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/ObservationCountRepositoryTest.java
@@ -1,0 +1,112 @@
+package com.saferoute.domain.telemetry.dynamo.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationCountItem;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.Select;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ObservationCountRepositoryTest {
+
+    private static final String TABLE_NAME = "saferoute-telemetry";
+    private static final String GSI1_NAME = "GSI1";
+
+    @Mock
+    private DynamoDbClient dynamoDbClient;
+    @Mock
+    private DynamoDbEnhancedClient enhancedClient;
+    @Mock
+    private DynamoDbTable<ObservationCountItem> table;
+
+    private ObservationCountRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        when(enhancedClient.table(eq(TABLE_NAME), any(TableSchema.class))).thenReturn(table);
+        repository = new ObservationCountRepository(dynamoDbClient, enhancedClient, TABLE_NAME, GSI1_NAME);
+    }
+
+    @Test
+    void increment은_ADD_원자_연산으로_카운터를_1_증가시킨다() {
+        repository.increment("session-1", "CCTV_001");
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(dynamoDbClient).updateItem(captor.capture());
+        UpdateItemRequest request = captor.getValue();
+
+        assertThat(request.tableName()).isEqualTo(TABLE_NAME);
+        assertThat(request.key().get("pk").s()).isEqualTo("OBSERVATION_COUNT#session-1#CCTV_001");
+        assertThat(request.key().get("sk").s()).isEqualTo("META");
+        assertThat(request.updateExpression()).isEqualTo("ADD #count :incr");
+        assertThat(request.expressionAttributeValues().get(":incr").n()).isEqualTo("1");
+    }
+
+    @Test
+    void find은_카운터_아이템이_있으면_count를_반환한다() {
+        ObservationCountItem item = new ObservationCountItem();
+        item.setCount(137L);
+        given(table.getItem(any(GetItemEnhancedRequest.class))).willReturn(item);
+
+        Optional<Long> result = repository.find("session-1", "CCTV_001");
+
+        assertThat(result).contains(137L);
+    }
+
+    @Test
+    void find은_카운터_아이템이_없으면_빈_값을_반환한다() {
+        given(table.getItem(any(GetItemEnhancedRequest.class))).willReturn(null);
+
+        Optional<Long> result = repository.find("session-1", "CCTV_001");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void countAllBySessionIdAndCctvCode는_Select_COUNT로_페이지를_순회해_합산한다() {
+        QueryResponse firstPage = QueryResponse.builder()
+                .count(100)
+                .lastEvaluatedKey(Map.of("pk", AttributeValue.fromS("OBSERVATION#last-of-first-page")))
+                .build();
+        QueryResponse secondPage = QueryResponse.builder()
+                .count(37)
+                .lastEvaluatedKey(Map.of())
+                .build();
+        given(dynamoDbClient.query(any(QueryRequest.class))).willReturn(firstPage, secondPage);
+
+        long total = repository.countAllBySessionIdAndCctvCode("session-1", "CCTV_001");
+
+        assertThat(total).isEqualTo(137L);
+        ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(dynamoDbClient, org.mockito.Mockito.times(2)).query(captor.capture());
+        QueryRequest firstRequest = captor.getAllValues().get(0);
+        assertThat(firstRequest.tableName()).isEqualTo(TABLE_NAME);
+        assertThat(firstRequest.indexName()).isEqualTo(GSI1_NAME);
+        assertThat(firstRequest.select()).isEqualTo(Select.COUNT);
+        assertThat(firstRequest.exclusiveStartKey()).isNullOrEmpty();
+        QueryRequest secondRequest = captor.getAllValues().get(1);
+        assertThat(secondRequest.exclusiveStartKey())
+                .containsEntry("pk", AttributeValue.fromS("OBSERVATION#last-of-first-page"));
+    }
+}

--- a/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
+++ b/src/test/java/com/saferoute/domain/training/controller/TrainingMonitoringControllerTest.java
@@ -354,7 +354,7 @@ class TrainingMonitoringControllerTest {
         );
         given(trainingMonitoringService.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL))
                 .willReturn(new MonitoringFrameListResponse(
-                        SESSION_ID, CCTV_ID, List.of(frame), "next-cursor", true
+                        SESSION_ID, CCTV_ID, List.of(frame), "next-cursor", true, 137L
                 ));
 
         mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
@@ -377,13 +377,14 @@ class TrainingMonitoringControllerTest {
                 .andExpect(jsonPath("$.result.frames[0].density").value(0.42))
                 .andExpect(jsonPath("$.result.frames[0].congestionLevel").value("CROWDED"))
                 .andExpect(jsonPath("$.result.nextCursor").value("next-cursor"))
-                .andExpect(jsonPath("$.result.hasNext").value(true));
+                .andExpect(jsonPath("$.result.hasNext").value(true))
+                .andExpect(jsonPath("$.result.totalCount").value(137));
     }
 
     @Test
     void limit과_cursor_쿼리파라미터를_서비스에_그대로_전달한다() throws Exception {
         given(trainingMonitoringService.getFrames(SESSION_ID, CCTV_ID, 5, "prev-cursor", EMAIL))
-                .willReturn(new MonitoringFrameListResponse(SESSION_ID, CCTV_ID, List.of(), null, false));
+                .willReturn(new MonitoringFrameListResponse(SESSION_ID, CCTV_ID, List.of(), null, false, 0L));
 
         mockMvc.perform(get("/api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames",
                         SESSION_ID, CCTV_ID)

--- a/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingMonitoringServiceTest.java
@@ -28,6 +28,7 @@ import com.saferoute.domain.telemetry.dynamo.repository.CongestionEventRepositor
 import com.saferoute.domain.telemetry.dynamo.repository.CurrentCctvStateRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.GeneralMonitoringEventRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.LatestMonitoringCaptureRepository;
+import com.saferoute.domain.telemetry.dynamo.repository.ObservationCountRepository;
 import com.saferoute.domain.telemetry.dynamo.repository.ObservationRepository;
 import com.saferoute.domain.training.dto.CurrentCctvStateListResponse;
 import com.saferoute.domain.training.dto.CurrentCctvStateResponse;
@@ -80,6 +81,8 @@ class TrainingMonitoringServiceTest {
     @Mock
     private ObservationRepository observationRepository;
     @Mock
+    private ObservationCountRepository observationCountRepository;
+    @Mock
     private CongestionEventRepository congestionEventRepository;
     @Mock
     private GeneralMonitoringEventRepository generalMonitoringEventRepository;
@@ -103,6 +106,7 @@ class TrainingMonitoringServiceTest {
                 cctvJpaRepository,
                 latestMonitoringCaptureRepository,
                 observationRepository,
+                observationCountRepository,
                 congestionEventRepository,
                 generalMonitoringEventRepository,
                 currentCctvStateRepository,
@@ -793,6 +797,41 @@ class TrainingMonitoringServiceTest {
         assertThat(frame.imageUrl()).isNull();
         assertThat(frame.urlExpiresAt()).isNull();
         verify(s3PresignedUrlService, never()).createGetUrl(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 카운터_아이템이_있으면_그_값을_totalCount로_사용한다() {
+        stubSession(TrainingStatus.RUNNING);
+        frameCctv();
+        given(observationRepository.findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 21, null, null))
+                .willReturn(List.of());
+        given(observationCountRepository.find(SESSION_ID.toString(), "CCTV_001"))
+                .willReturn(Optional.of(137L));
+
+        MonitoringFrameListResponse response = service.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL);
+
+        assertThat(response.totalCount()).isEqualTo(137L);
+        verify(observationCountRepository, never())
+                .countAllBySessionIdAndCctvCode(org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 카운터_아이템이_없으면_전체_카운트_조회로_totalCount를_계산한다() {
+        stubSession(TrainingStatus.RUNNING);
+        frameCctv();
+        given(observationRepository.findPageBySessionIdAndCctvCode(
+                SESSION_ID.toString(), "CCTV_001", 21, null, null))
+                .willReturn(List.of());
+        given(observationCountRepository.find(SESSION_ID.toString(), "CCTV_001"))
+                .willReturn(Optional.empty());
+        given(observationCountRepository.countAllBySessionIdAndCctvCode(SESSION_ID.toString(), "CCTV_001"))
+                .willReturn(42L);
+
+        MonitoringFrameListResponse response = service.getFrames(SESSION_ID, CCTV_ID, 20, null, EMAIL);
+
+        assertThat(response.totalCount()).isEqualTo(42L);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #205
- Branch: feat/#205

## 주요 내용

- 신규 DynamoDB 카운터 아이템 `ObservationCountItem`(PK `OBSERVATION_COUNT#{sessionId}#{cctvCode}`, TTL 없음) 추가
- `ObservationCountRepository` 추가 — `increment()`는 저수준 `DynamoDbClient.updateItem()`으로 `ADD #count :incr` 원자 연산 수행(Enhanced Client의 `UpdateItemEnhancedRequest`는 임의의 update expression을 지원하지 않아 raw client 사용), `find()`는 카운터 조회, `countAllBySessionIdAndCctvCode()`는 카운터가 없는 과거 세션을 위한 `Select=COUNT` fallback(아이템 본문 없이 개수만 조회, 페이지 순회 합산)
- `CongestionObservationService.reportObservation()`에서 `saveIfAbsent` 결과가 **신규 생성**일 때만 `increment()` 호출(재시도 요청은 제외), 예외는 흡수해 Observation 저장 자체를 실패시키지 않음
- `MonitoringFrameListResponse`에 `totalCount`(long) 필드 추가, `TrainingMonitoringService.getFrames()`에서 카운터 값을 채움(없으면 fallback 계산, 결과를 역으로 backfill하지 않음)
- 기존 커서 페이지네이션(`limit`/`cursor`/`nextCursor`/`hasNext`) 로직은 그대로 유지, `totalCount`는 페이지 크기가 아닌 세션+CCTV 전체 개수
- `imageUrl`이 아직 없는(이미지 미연결) Observation도 동일하게 카운트에 포함

## 🌐 API 변경

- `GET /api/v1/sessions/{sessionId}/monitoring/cameras/{cctvId}/frames` 응답에 `totalCount`(number) 필드 추가. 기존 필드는 그대로 유지.

## ✅ Check List

- [x] 테스트 통과 (전체 681개)
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?