### PR TITLE
[fix] #201: 리포트 병목 횟수 집계 기준 통일

### DIFF
--- a/src/main/java/com/saferoute/domain/report/dto/ReportResponse.java
+++ b/src/main/java/com/saferoute/domain/report/dto/ReportResponse.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.report.dto;
 
 import com.saferoute.domain.report.entity.Grade;
 import com.saferoute.domain.report.entity.TrainingReport;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.Builder;
@@ -18,6 +19,13 @@ public class ReportResponse {
   private Integer participantCount;
   private Integer survivorCount;
   private BigDecimal survivalRate;
+  @Schema(
+      description = "병목(혼잡) 발생 횟수. 혼잡 이벤트의 상태 전환 개수가 아니라, 실제로 병목 구간이 "
+          + "시작된 횟수를 의미한다 - CONGESTION_STARTED이면서 최종 판정된 congestionLevel이 "
+          + "CROWDED 또는 VERY_CROWDED인 경우만 1회로 집계하며, 같은 구간의 CONGESTION_LEVEL_UP/"
+          + "CONGESTION_ENDED는 포함하지 않는다.",
+      example = "3"
+  )
   private Integer bottleneckCount;
   private Integer bottleneckScore;
   private Double deviationRate;

--- a/src/main/java/com/saferoute/domain/report/service/TrainingReportService.java
+++ b/src/main/java/com/saferoute/domain/report/service/TrainingReportService.java
@@ -33,10 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TrainingReportService {
 
-  // 세션 하나에서 나올 수 있는 병목 이벤트 수의 실질적 상한. DynamoDB 쿼리는 한 번에 다 끌어와야 정확한
-  // 횟수를 셀 수 있어, 기본 페이지 제한(100)보다 넉넉하게 잡는다.
-  private static final int BOTTLENECK_QUERY_LIMIT = 5_000;
-
   private final TrainingReportRepository trainingReportRepository;
   private final TrainingSessionRepository trainingSessionRepository;
   private final CongestionEventRepository congestionEventRepository;
@@ -75,9 +71,9 @@ public class TrainingReportService {
     BigDecimal survivalRate = TrainingReportScoreCalculator.survivalRate(
         request.survivorCount(), request.participantCount());
 
-    int bottleneckCount = congestionEventRepository
-        .findAllBySessionId(sessionId.toString(), BOTTLENECK_QUERY_LIMIT)
-        .size();
+    // 병목은 CONGESTION_STARTED이면서 congestionLevel이 CROWDED/VERY_CROWDED로 판정된 경우만
+    // "병목 구간이 시작된 횟수"로 센다 - LEVEL_UP/ENDED는 같은 구간의 상태 변화라 제외한다.
+    int bottleneckCount = congestionEventRepository.countBottlenecksBySessionId(sessionId.toString());
     int bottleneckScore = TrainingReportScoreCalculator.bottleneckScore(bottleneckCount, evacuationSec);
 
     SessionDeviationResult deviation = routeDeviationService.calculateForSession(sessionId, email);

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
@@ -1,6 +1,8 @@
 package com.saferoute.domain.telemetry.dynamo.repository;
 
+import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.EventProcessingStatus;
 import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
 import java.util.List;
@@ -30,6 +32,18 @@ public class CongestionEventRepository {
     private static final Expression ITEM_NOT_EXISTS = Expression.builder()
             .expression("attribute_not_exists(#pk)")
             .putExpressionName("#pk", "pk")
+            .build();
+
+    // 리포트의 병목 횟수(bottleneckCount) 집계 기준: CONGESTION_STARTED이면서 BE가 최종 판정한
+    // congestionLevel이 CROWDED/VERY_CROWDED인 이벤트만 "병목 구간이 시작된 횟수"로 센다.
+    // CONGESTION_LEVEL_UP/CONGESTION_ENDED는 같은 병목 구간의 상태 변화일 뿐이라 제외한다.
+    private static final Expression BOTTLENECK_FILTER = Expression.builder()
+            .expression("#eventType = :started AND (#congestionLevel = :crowded OR #congestionLevel = :veryCrowded)")
+            .putExpressionName("#eventType", "eventType")
+            .putExpressionName("#congestionLevel", "congestionLevel")
+            .putExpressionValue(":started", AttributeValue.fromS(CongestionEventType.CONGESTION_STARTED.name()))
+            .putExpressionValue(":crowded", AttributeValue.fromS(CongestionLevel.CROWDED.name()))
+            .putExpressionValue(":veryCrowded", AttributeValue.fromS(CongestionLevel.VERY_CROWDED.name()))
             .build();
 
     private final DynamoDbTable<CongestionEventItem> table;
@@ -90,6 +104,23 @@ public class CongestionEventRepository {
                 .flatMap(page -> page.items().stream())
                 .limit(limit)
                 .toList();
+    }
+
+    // 리포트 전용 병목 횟수 집계: 임의의 상한 없이 세션 파티션 전체를 순회하며 서버 사이드
+    // FilterExpression(BOTTLENECK_FILTER)을 통과한 아이템만 센다. Limit을 걸지 않으므로 SDK가
+    // 필터로 줄어든 만큼 다음 물리 페이지를 자동으로 더 읽어와, 5,000건 같은 고정 상한 때문에
+    // 일부 병목이 집계에서 누락되는 일이 없다.
+    public int countBottlenecksBySessionId(String trainingSessionId) {
+        QueryEnhancedRequest request = QueryEnhancedRequest.builder()
+                .queryConditional(QueryConditional.keyEqualTo(Key.builder()
+                        .partitionValue(CongestionEventItem.buildGsi1Pk(trainingSessionId))
+                        .build()))
+                .filterExpression(BOTTLENECK_FILTER)
+                .build();
+
+        return (int) gsi1.query(request).stream()
+                .flatMap(page -> page.items().stream())
+                .count();
     }
 
     // 이벤트 타임라인 조회 전용: 최신순으로 커서 페이지네이션하며, cctvCode 필터를 DynamoDB

--- a/src/test/java/com/saferoute/domain/report/service/TrainingReportServiceTest.java
+++ b/src/test/java/com/saferoute/domain/report/service/TrainingReportServiceTest.java
@@ -155,8 +155,8 @@ class TrainingReportServiceTest {
         given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME))
                 .willReturn(Optional.of(session));
         given(trainingReportRepository.existsByTrainingSession_Id(sessionId)).willReturn(false);
-        given(congestionEventRepository.findAllBySessionId(sessionId.toString(), 5_000))
-                .willReturn(Collections.emptyList());
+        given(congestionEventRepository.countBottlenecksBySessionId(sessionId.toString()))
+                .willReturn(0);
         given(routeDeviationService.calculateForSession(sessionId, EMAIL))
                 .willReturn(new SessionDeviationResult(10, 0, 0.0));
         given(trainingReportChartService.buildCumulativeEvacuation(session, 50))
@@ -185,6 +185,36 @@ class TrainingReportServiceTest {
         ArgumentCaptor<TrainingReport> captor = ArgumentCaptor.forClass(TrainingReport.class);
         verify(trainingReportRepository).saveAndFlush(captor.capture());
         assertThat(captor.getValue().getTrainingSession()).isEqualTo(session);
+    }
+
+    @Test
+    @DisplayName("bottleneckCount는 저장소가 집계한 병목 횟수를 그대로 사용한다")
+    void generate_usesRepositoryBottleneckCountAsIs() {
+        Instant startedAt = Instant.parse("2026-01-01T00:00:00Z");
+        Instant endedAt = startedAt.plusSeconds(300);
+        TrainingSession session = endedSession(300, startedAt, endedAt);
+        given(trainingSessionRepository.findByIdAndScenario_Building_SchoolName(sessionId, SCHOOL_NAME))
+                .willReturn(Optional.of(session));
+        given(trainingReportRepository.existsByTrainingSession_Id(sessionId)).willReturn(false);
+        given(congestionEventRepository.countBottlenecksBySessionId(sessionId.toString()))
+                .willReturn(7);
+        given(routeDeviationService.calculateForSession(sessionId, EMAIL))
+                .willReturn(new SessionDeviationResult(10, 0, 0.0));
+        given(trainingReportChartService.buildCumulativeEvacuation(session, 50))
+                .willReturn(Collections.emptyList());
+        given(trainingReportChartService.buildZoneDensities(session))
+                .willReturn(Collections.emptyList());
+        given(trainingReportChartService.buildRecentEvacuationTimes(buildingId, 300))
+                .willReturn(Collections.emptyList());
+        given(trainingReportRepository.saveAndFlush(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        ReportResponse response = trainingReportService.generate(
+                sessionId, new GenerateReportRequest(50, 50), EMAIL);
+
+        assertThat(response.getBottleneckCount()).isEqualTo(7);
+        verify(congestionEventRepository).countBottlenecksBySessionId(sessionId.toString());
+        verify(congestionEventRepository, never())
+                .findAllBySessionId(any(), org.mockito.ArgumentMatchers.anyInt());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepositoryTest.java
@@ -165,6 +165,66 @@ class CongestionEventRepositoryTest {
     }
 
     @Test
+    void 병목_집계는_CROWDED_VERY_CROWDED_CONGESTION_STARTED만_센다() {
+        CongestionEventItem crowdedStarted = item(
+                "started-crowded", 1_000L, CongestionEventType.CONGESTION_STARTED, CongestionLevel.CROWDED);
+        CongestionEventItem veryCrowdedStarted = item(
+                "started-very-crowded", 2_000L, CongestionEventType.CONGESTION_STARTED, CongestionLevel.VERY_CROWDED);
+        // FilterExpression은 이미 통과한 아이템만 넘어온다고 가정하고 스텁한다 - 실제 필터 자체는
+        // 아래 필터_익스프레션_검증 테스트에서 별도로 확인한다.
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(CongestionEventItem.class)
+                        .items(List.of(crowdedStarted, veryCrowdedStarted)).build()).iterator())
+        );
+
+        int count = repository.countBottlenecksBySessionId(SESSION_ID.toString());
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void 병목_집계는_필터_익스프레션으로_STARTED와_CROWDED_이상만_요청한다() {
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(Page.builder(CongestionEventItem.class)
+                        .items(List.of()).build()).iterator())
+        );
+        ArgumentCaptor<QueryEnhancedRequest> captor = ArgumentCaptor.forClass(QueryEnhancedRequest.class);
+
+        repository.countBottlenecksBySessionId(SESSION_ID.toString());
+
+        verify(gsi1).query(captor.capture());
+        assertThat(captor.getValue().limit()).isNull();
+        assertThat(captor.getValue().filterExpression().expression())
+                .isEqualTo("#eventType = :started AND (#congestionLevel = :crowded OR #congestionLevel = :veryCrowded)");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":started").s())
+                .isEqualTo("CONGESTION_STARTED");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":crowded").s())
+                .isEqualTo("CROWDED");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":veryCrowded").s())
+                .isEqualTo("VERY_CROWDED");
+    }
+
+    @Test
+    void 병목_집계는_고정_상한_없이_여러_물리_페이지를_모두_순회한다() {
+        List<CongestionEventItem> firstPageItems = java.util.stream.IntStream.range(0, 3)
+                .mapToObj(i -> item("started-" + i, i, CongestionEventType.CONGESTION_STARTED, CongestionLevel.CROWDED))
+                .toList();
+        List<CongestionEventItem> secondPageItems = java.util.stream.IntStream.range(3, 5)
+                .mapToObj(i -> item("started-" + i, i, CongestionEventType.CONGESTION_STARTED, CongestionLevel.CROWDED))
+                .toList();
+        when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
+                PageIterable.create(() -> List.of(
+                        Page.builder(CongestionEventItem.class).items(firstPageItems).build(),
+                        Page.builder(CongestionEventItem.class).items(secondPageItems).build()
+                ).iterator())
+        );
+
+        int count = repository.countBottlenecksBySessionId(SESSION_ID.toString());
+
+        assertThat(count).isEqualTo(5);
+    }
+
+    @Test
     void 이벤트를_RECEIVED_PROCESSING_PROCESSED_순서로_변경한다() {
         ArgumentCaptor<UpdateItemEnhancedRequest<CongestionEventItem>> captor = updateCaptor();
 
@@ -253,11 +313,16 @@ class CongestionEventRepositoryTest {
     }
 
     private CongestionEventItem item(String eventId, long detectedAt) {
+        return item(eventId, detectedAt, CongestionEventType.CONGESTION_STARTED, CongestionLevel.CROWDED);
+    }
+
+    private CongestionEventItem item(
+            String eventId, long detectedAt, CongestionEventType eventType, CongestionLevel congestionLevel) {
         return CongestionEventItem.received(
                 UUID.nameUUIDFromBytes(eventId.getBytes(StandardCharsets.UTF_8)), SESSION_ID,
-                "CCTV_001", CongestionEventType.CONGESTION_STARTED,
+                "CCTV_001", eventType,
                 detectedAt, 9, 4.5, CongestionLevel.CROWDED, 4.5,
-                CongestionLevel.CROWDED, 1L, null
+                congestionLevel, 1L, null
         );
     }
 }


### PR DESCRIPTION
## 문제
`TrainingReportService.generate()`가 세션의 혼잡 이벤트(`CongestionEventItem`)를 타입 구분 없이
`findAllBySessionId(sessionId, 5_000)`로 전량 조회해 개수만 세고 있었습니다.
- `CONGESTION_STARTED`/`CONGESTION_LEVEL_UP`/`CONGESTION_ENDED`가 모두 섞여서 카운트됨 → 병목 1구간이 3회로 잡힐 수 있음
- `NORMAL`/`CAUTION`으로 저장된 `CONGESTION_STARTED`도 그대로 카운트됨
- 5,000건 고정 상한이 있어 그 이상 쌓이면 집계가 잘림

## 변경 사항
- `CongestionEventRepository.countBottlenecksBySessionId(trainingSessionId)` 추가
  - `eventType = CONGESTION_STARTED AND congestionLevel IN (CROWDED, VERY_CROWDED)`를 DynamoDB `FilterExpression`으로 적용
  - `Limit`을 걸지 않아 세션 파티션 전체를 순회 (고정 상한 없음)
- `TrainingReportService.generate()`의 `bottleneckCount` 계산을 이 메서드 결과로 교체, `BOTTLENECK_QUERY_LIMIT` 상수 제거
- `ReportResponse.bottleneckCount`에 Swagger 설명 추가 (상태 전환 개수가 아니라 실제 병목 시작 횟수임을 명시)

## API 변경
- 외부 API 스키마 변경 없음. `bottleneckCount` 필드명·타입은 그대로, 계산 방식만 정확해집니다.

## 테스트
- `CongestionEventRepositoryTest`: 필터 익스프레션 검증(STARTED + CROWDED/VERY_CROWDED만), 여러 물리 페이지를 고정 상한 없이 모두 순회하는지 검증
- `TrainingReportServiceTest`: `countBottlenecksBySessionId` 결과를 그대로 사용하는지, 기존 `findAllBySessionId(limit)` 경로를 더 이상 호출하지 않는지 검증
- `./gradlew test` — report/telemetry 관련 스위트 전부 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 훈련 리포트의 병목 횟수 집계 정확도가 향상되었습니다.
  * 혼잡 시작 이벤트 중 ‘혼잡’ 또는 ‘매우 혼잡’ 상태만 병목 구간으로 집계합니다.
  * 대량의 이벤트가 있는 세션에서도 전체 데이터를 기준으로 병목 횟수를 산출합니다.
  * 리포트 API 문서에 병목 횟수의 집계 기준이 명확히 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->