### PR TITLE
fix(monitoring): GSI1 파티션 키 충돌로 인한 이벤트 타임라인 조회 500 에러 수정 - #210

### DIFF
--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepository.java
@@ -27,6 +27,13 @@ public class CongestionEventRepository {
 
     static final int DEFAULT_QUERY_LIMIT = 100;
 
+    // CongestionEventItem과 GeneralMonitoringEventItem은 같은 물리 테이블의 같은 GSI1을
+    // 공유하고, 둘 다 GSI1_PK를 "SESSION#{trainingSessionId}"로 만든다(단일 테이블 설계).
+    // GSI1로 세션 단위 조회를 할 때 이 접두사로 걸러내지 않으면 다른 아이템 타입까지 같이
+    // 반환되어, 그 아이템의 eventType 값을 CongestionEventType enum으로 역직렬화하려다
+    // IllegalArgumentException이 터진다(반대 방향도 마찬가지 - GeneralMonitoringEventRepository 참고).
+    private static final String PK_PREFIX = "CONGESTION_EVENT#";
+
     private static final Expression ITEM_NOT_EXISTS = Expression.builder()
             .expression("attribute_not_exists(#pk)")
             .putExpressionName("#pk", "pk")
@@ -82,6 +89,7 @@ public class CongestionEventRepository {
                 .queryConditional(QueryConditional.keyEqualTo(Key.builder()
                         .partitionValue(CongestionEventItem.buildGsi1Pk(trainingSessionId))
                         .build()))
+                .filterExpression(pkPrefixFilter())
                 .scanIndexForward(true)
                 .limit(limit)
                 .build();
@@ -112,22 +120,35 @@ public class CongestionEventRepository {
                         .partitionValue(CongestionEventItem.buildGsi1Pk(trainingSessionId))
                         .sortValue(CongestionEventItem.buildGsi1Sk(beforeDetectedAt, beforeEventId))
                         .build());
+        Expression filterExpression = cctvCode == null
+                ? pkPrefixFilter()
+                : Expression.builder()
+                        .expression("begins_with(#pk, :pkPrefix) AND #cctvCode = :cctvCode")
+                        .putExpressionName("#pk", "pk")
+                        .putExpressionName("#cctvCode", "cctvCode")
+                        .putExpressionValue(":pkPrefix", AttributeValue.fromS(PK_PREFIX))
+                        .putExpressionValue(":cctvCode", AttributeValue.fromS(cctvCode))
+                        .build();
         QueryEnhancedRequest.Builder requestBuilder = QueryEnhancedRequest.builder()
                 .queryConditional(queryConditional)
+                .filterExpression(filterExpression)
                 .scanIndexForward(false)
                 .limit(limit);
-        if (cctvCode != null) {
-            requestBuilder.filterExpression(Expression.builder()
-                    .expression("#cctvCode = :cctvCode")
-                    .putExpressionName("#cctvCode", "cctvCode")
-                    .putExpressionValue(":cctvCode", AttributeValue.fromS(cctvCode))
-                    .build());
-        }
 
         return gsi1.query(requestBuilder.build()).stream()
                 .flatMap(page -> page.items().stream())
                 .limit(limit)
                 .toList();
+    }
+
+    // GSI1을 공유하는 다른 아이템 타입(GeneralMonitoringEventItem)이 결과에 섞여 들어와
+    // 역직렬화에 실패하지 않도록, 이 리포지토리가 다루는 타입의 pk 접두사만 통과시킨다.
+    private Expression pkPrefixFilter() {
+        return Expression.builder()
+                .expression("begins_with(#pk, :pkPrefix)")
+                .putExpressionName("#pk", "pk")
+                .putExpressionValue(":pkPrefix", AttributeValue.fromS(PK_PREFIX))
+                .build();
     }
 
     public boolean updateEventStatus(

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepository.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepository.java
@@ -21,6 +21,13 @@ import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedExce
 @Repository
 public class GeneralMonitoringEventRepository {
 
+    // CongestionEventItem과 같은 물리 테이블의 같은 GSI1을 공유하고, 둘 다 GSI1_PK를
+    // "SESSION#{trainingSessionId}"로 만든다(단일 테이블 설계). GSI1로 세션 단위 조회를 할 때
+    // 이 접두사로 걸러내지 않으면 CongestionEventItem까지 같이 반환되어, 그 아이템의 eventType
+    // 값을 GeneralMonitoringEventType enum으로 역직렬화하려다 IllegalArgumentException이 터진다
+    // (반대 방향도 마찬가지 - CongestionEventRepository 참고).
+    private static final String PK_PREFIX = "MONITORING_EVENT#";
+
     private static final Expression ITEM_NOT_EXISTS = Expression.builder()
             .expression("attribute_not_exists(#pk)")
             .putExpressionName("#pk", "pk")
@@ -88,22 +95,35 @@ public class GeneralMonitoringEventRepository {
                         .partitionValue(GeneralMonitoringEventItem.buildGsi1Pk(trainingSessionId))
                         .sortValue(GeneralMonitoringEventItem.buildGsi1Sk(beforeOccurredAt, beforeEventId))
                         .build());
+        Expression filterExpression = cctvCode == null
+                ? pkPrefixFilter()
+                : Expression.builder()
+                        .expression("begins_with(#pk, :pkPrefix) AND #cctvCode = :cctvCode")
+                        .putExpressionName("#pk", "pk")
+                        .putExpressionName("#cctvCode", "cctvCode")
+                        .putExpressionValue(":pkPrefix", AttributeValue.fromS(PK_PREFIX))
+                        .putExpressionValue(":cctvCode", AttributeValue.fromS(cctvCode))
+                        .build();
         QueryEnhancedRequest.Builder requestBuilder = QueryEnhancedRequest.builder()
                 .queryConditional(queryConditional)
+                .filterExpression(filterExpression)
                 .scanIndexForward(false)
                 .limit(limit);
-        if (cctvCode != null) {
-            requestBuilder.filterExpression(Expression.builder()
-                    .expression("#cctvCode = :cctvCode")
-                    .putExpressionName("#cctvCode", "cctvCode")
-                    .putExpressionValue(":cctvCode", AttributeValue.fromS(cctvCode))
-                    .build());
-        }
 
         return gsi1.query(requestBuilder.build()).stream()
                 .flatMap(page -> page.items().stream())
                 .limit(limit)
                 .toList();
+    }
+
+    // GSI1을 공유하는 다른 아이템 타입(CongestionEventItem)이 결과에 섞여 들어와
+    // 역직렬화에 실패하지 않도록, 이 리포지토리가 다루는 타입의 pk 접두사만 통과시킨다.
+    private Expression pkPrefixFilter() {
+        return Expression.builder()
+                .expression("begins_with(#pk, :pkPrefix)")
+                .putExpressionName("#pk", "pk")
+                .putExpressionValue(":pkPrefix", AttributeValue.fromS(PK_PREFIX))
+                .build();
     }
 
     private void validateLimit(int limit) {

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/CongestionEventRepositoryTest.java
@@ -100,6 +100,10 @@ class CongestionEventRepositoryTest {
                 .expressionValues().values())
                 .extracting(value -> value.s())
                 .contains("SESSION#" + SESSION_ID);
+        assertThat(captor.getValue().filterExpression().expression())
+                .isEqualTo("begins_with(#pk, :pkPrefix)");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":pkPrefix").s())
+                .isEqualTo("CONGESTION_EVENT#");
         assertThat(result).containsExactly(first, second);
     }
 
@@ -119,7 +123,12 @@ class CongestionEventRepositoryTest {
         verify(gsi1).query(captor.capture());
         assertThat(captor.getValue().scanIndexForward()).isFalse();
         assertThat(captor.getValue().limit()).isEqualTo(10);
-        assertThat(captor.getValue().filterExpression()).isNull();
+        // GSI1을 공유하는 GeneralMonitoringEventItem이 섞여 들어와 역직렬화가 실패하지 않도록,
+        // cctvCode 필터가 없어도 pk 접두사 필터는 항상 적용돼야 한다.
+        assertThat(captor.getValue().filterExpression().expression())
+                .isEqualTo("begins_with(#pk, :pkPrefix)");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":pkPrefix").s())
+                .isEqualTo("CONGESTION_EVENT#");
         assertThat(captor.getValue().queryConditional()
                 .expression(TableSchema.fromBean(CongestionEventItem.class), CongestionEventItem.GSI1_NAME)
                 .expressionValues().values())
@@ -129,7 +138,7 @@ class CongestionEventRepositoryTest {
     }
 
     @Test
-    void cctvCode가_있으면_필터_익스프레션을_적용한다() {
+    void cctvCode가_있으면_pk_접두사_필터와_함께_적용한다() {
         when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
                 PageIterable.create(() -> List.of(Page.builder(CongestionEventItem.class)
                         .items(List.of()).build()).iterator())
@@ -141,7 +150,9 @@ class CongestionEventRepositoryTest {
         verify(gsi1).query(captor.capture());
         assertThat(captor.getValue().filterExpression()).isNotNull();
         assertThat(captor.getValue().filterExpression().expression())
-                .isEqualTo("#cctvCode = :cctvCode");
+                .isEqualTo("begins_with(#pk, :pkPrefix) AND #cctvCode = :cctvCode");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":pkPrefix").s())
+                .isEqualTo("CONGESTION_EVENT#");
         assertThat(captor.getValue().filterExpression().expressionValues().get(":cctvCode").s())
                 .isEqualTo("CCTV_001");
     }

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepositoryTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/repository/GeneralMonitoringEventRepositoryTest.java
@@ -91,12 +91,17 @@ class GeneralMonitoringEventRepositoryTest {
         org.mockito.Mockito.verify(gsi1).query(captor.capture());
         assertThat(captor.getValue().scanIndexForward()).isFalse();
         assertThat(captor.getValue().limit()).isEqualTo(10);
-        assertThat(captor.getValue().filterExpression()).isNull();
+        // GSI1을 공유하는 CongestionEventItem이 섞여 들어와 역직렬화가 실패하지 않도록,
+        // cctvCode 필터가 없어도 pk 접두사 필터는 항상 적용돼야 한다.
+        assertThat(captor.getValue().filterExpression().expression())
+                .isEqualTo("begins_with(#pk, :pkPrefix)");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":pkPrefix").s())
+                .isEqualTo("MONITORING_EVENT#");
         assertThat(result).containsExactly(newest, oldest);
     }
 
     @Test
-    void cctvCode가_있으면_필터_익스프레션을_적용한다() {
+    void cctvCode가_있으면_pk_접두사_필터와_함께_적용한다() {
         when(gsi1.query(any(QueryEnhancedRequest.class))).thenReturn(
                 PageIterable.create(() -> List.of(Page.builder(GeneralMonitoringEventItem.class)
                         .items(List.of()).build()).iterator())
@@ -108,7 +113,9 @@ class GeneralMonitoringEventRepositoryTest {
         org.mockito.Mockito.verify(gsi1).query(captor.capture());
         assertThat(captor.getValue().filterExpression()).isNotNull();
         assertThat(captor.getValue().filterExpression().expression())
-                .isEqualTo("#cctvCode = :cctvCode");
+                .isEqualTo("begins_with(#pk, :pkPrefix) AND #cctvCode = :cctvCode");
+        assertThat(captor.getValue().filterExpression().expressionValues().get(":pkPrefix").s())
+                .isEqualTo("MONITORING_EVENT#");
         assertThat(captor.getValue().filterExpression().expressionValues().get(":cctvCode").s())
                 .isEqualTo("CCTV_001");
     }


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #210
- Branch: fix/#210

## 주요 내용

- `CongestionEventItem`과 `GeneralMonitoringEventItem`이 같은 물리 DynamoDB 테이블의 같은 GSI1 인덱스를 공유하는데, 둘 다 `buildGsi1Pk(trainingSessionId)`가 `"SESSION#" + trainingSessionId`로 완전히 동일해서 GSI1_PK가 충돌했다.
- `CongestionEventRepository.findPageBySessionId()`/`findAllBySessionId()`가 GSI1을 세션 단위로 쿼리하면 같은 세션의 `GeneralMonitoringEventItem`도 함께 반환되는데, 이걸 전부 `CongestionEventItem` 빈으로 역직렬화하려다 `eventType` 값(예: `AI_ANALYSIS_STARTED`)이 `CongestionEventType` enum에 없어서 `IllegalArgumentException` → 500.
- 양방향 문제라 `GeneralMonitoringEventRepository.findPageBySessionId()`도 동일한 이유로 세션에 혼잡 이벤트가 있으면 반대 방향으로 크래시났다.
- 각 repository의 세션 단위 GSI1 쿼리에 자기 타입의 `pk` 접두사(`CONGESTION_EVENT#` / `MONITORING_EVENT#`)로 `begins_with` FilterExpression을 추가해, DynamoDB 서버 사이드에서 다른 타입의 아이템이 아예 반환되지 않도록 수정했다. 기존 `cctvCode` 필터와는 AND로 결합된다.

## 🐞 재현 조건

세션에 혼잡 이벤트(`CongestionEventItem`)와 일반 모니터링 이벤트(`GeneralMonitoringEventItem`, #202/#203/#204)가 둘 다 존재하는 상태에서 `GET /api/v1/sessions/{sessionId}/monitoring/events` 호출 시 500.

## ✅ Check List

- [x] 테스트 통과 (전체 681개)
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?