### PR TITLE
fix(congestion): CCTV 실시간 상태 WebSocket 정합성 및 중복 발행 제거 - #192

### DIFF
--- a/docs/websocket-events.md
+++ b/docs/websocket-events.md
@@ -1,0 +1,87 @@
+# WebSocket 이벤트 계약 (혼잡도)
+
+연결 endpoint: `/ws`
+구독 topic: `/topic/training-sessions/{sessionId}`
+
+## 발행 단위 원칙
+
+- CCTV 1 Observation = `CONGESTION_UPDATED` 1건
+- 즉시 혼잡 상태 전환 1건 = `CONGESTION_EVENT_RECEIVED` 1건
+- 영향받는 Edge 개수만큼 같은 메시지를 반복 발행하지 않는다
+- 영향받는 Edge는 `affectedEdgeIds` 배열로 한 번에 전달한다 (Edge가 없으면 빈 배열, `null`과 혼용하지 않는다)
+- Edge별 경로 재탐색 계산(`RouteRecalculationService.trigger`)은 발행 단위와 무관하게 영향받는 Edge마다 개별 실행한다
+
+## `CONGESTION_UPDATED`
+
+`CongestionObservationService.reportObservation()` 처리 후 발행된다.
+
+```json
+{
+  "type": "CONGESTION_UPDATED",
+  "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+  "data": {
+    "eventId": "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11",
+    "affectedEdgeIds": [
+      "4d5e3a7f-9154-4afb-9967-a552003994cf"
+    ],
+    "cctvCode": "CCTV_001",
+    "avgHeadcount": 8.6,
+    "peakHeadcount": 12,
+    "density": 0.42,
+    "congestionLevel": "CROWDED",
+    "windowStart": 1787722090000,
+    "windowEnd": 1787722095000,
+    "capturedAt": 1787722095000,
+    "configVersion": 3,
+    "hasMonitoringImage": true
+  }
+}
+```
+
+## `CONGESTION_EVENT_RECEIVED`
+
+`CongestionEventService.reportCongestionEvent()` 처리 후 발행된다 (즉시 혼잡 진입/상승/종료 이벤트).
+
+```json
+{
+  "type": "CONGESTION_EVENT_RECEIVED",
+  "sessionId": "d669294e-55e1-4c00-bf67-229d89b76948",
+  "data": {
+    "eventId": "3c9f7e2a-3b39-4f0a-9f0a-6a2b6b1f5a11",
+    "affectedEdgeIds": [
+      "4d5e3a7f-9154-4afb-9967-a552003994cf"
+    ],
+    "cctvCode": "CCTV_001",
+    "eventType": "CONGESTION_STARTED",
+    "density": 3.4,
+    "congestionLevel": "CROWDED",
+    "detectedAt": 1787722095000,
+    "imageUploadStatus": "PENDING"
+  }
+}
+```
+
+## REST와 WebSocket 필드 대응
+
+| REST `current-states` | WebSocket | 의미 |
+|---|---|---|
+| `cctvCode` | `cctvCode` | CCTV 식별자 |
+| `avgHeadcount` | `avgHeadcount` | 최근 분석 구간 평균 인원 |
+| `peakHeadcount` | `peakHeadcount` | 최근 분석 구간 최대 인원 |
+| `density` | `density` | BE가 계산한 밀집도 |
+| `congestionLevel` | `congestionLevel` | BE가 판정한 최종 혼잡 단계 |
+| `lastDetectedAt` | `capturedAt` | 해당 상태의 대표 관측 시각 |
+| `configVersion` | `configVersion` | 적용된 혼잡 설정 버전 |
+
+기존 REST 호환성을 위해 `lastDetectedAt`과 `capturedAt`의 필드명 자체는 통일하지 않고 대응 관계만 문서화한다.
+
+## 이미지 처리 정책
+
+- WebSocket payload에는 이미지의 presigned URL을 포함하지 않는다 (만료 시간이 있는 URL을 별도 갱신 없이 오래 들고 있을 수 없기 때문).
+- `hasMonitoringImage=true`인 이벤트를 받으면 프론트가 카메라 또는 프레임 조회 REST API를 재호출해서 새 presigned URL을 받아야 한다.
+- REST 응답의 `frameId`와 이 payload의 `eventId`를 비교하면 같은 프레임인지 확인할 수 있다.
+- 이미지 URL이 만료되었거나 403이 반환되면 REST API를 다시 호출한다.
+
+## 중복 방어
+
+백엔드가 CCTV/이벤트당 1회 발행을 보장하더라도, 프론트는 `eventId` 기준 중복 제거를 유지해야 한다. REST 최초 조회와 WebSocket 연결 사이의 경합, WebSocket 재연결, 메시지 재수신, 화면 재진입 등으로 같은 이벤트가 다시 보일 수 있기 때문이다.

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -209,16 +209,12 @@ public class CongestionEventService {
         });
     }
 
-    // Edge가 없으면(감시 영역에 아직 GridCell/Edge 매핑이 안 된 CCTV) edgeId 없이 한 번만 발행해
-    // 대시보드가 최소한 CCTV 단위 이벤트는 볼 수 있게 한다.
+    // 즉시 혼잡 상태 전환 1건 = CONGESTION_EVENT_RECEIVED 1건 발행 원칙을 지키기 위해 영향받는 Edge
+    // 전체를 배열로 담아 한 번만 발행한다 (이슈 #192). Edge가 없으면(감시 영역에 아직 GridCell/Edge
+    // 매핑이 안 된 CCTV) 빈 목록으로 발행해 대시보드가 최소한 CCTV 단위 이벤트는 볼 수 있게 한다.
     private void publishCongestionEventReceived(UUID sessionId, List<MapEdge> affectedEdges, CongestionEventItem item) {
-        if (affectedEdges.isEmpty()) {
-            trainingEventPublisher.publishCongestionEventReceived(sessionId, null, item);
-            return;
-        }
-        for (MapEdge edge : affectedEdges) {
-            trainingEventPublisher.publishCongestionEventReceived(sessionId, edge.getId(), item);
-        }
+        List<UUID> affectedEdgeIds = affectedEdges.stream().map(MapEdge::getId).distinct().toList();
+        trainingEventPublisher.publishCongestionEventReceived(sessionId, affectedEdgeIds, item);
     }
 
     private void completeProcessing(String eventId) {

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -359,8 +359,8 @@ public class CongestionObservationService {
     // 한 번만 발행한다 (이슈 #192). Edge가 없으면(감시 영역에 아직 GridCell/Edge 매핑이 안 된 CCTV)
     // 빈 목록으로 발행해 대시보드가 최소한 CCTV 단위 관측값은 볼 수 있게 한다.
     private void publishCongestionUpdated(UUID sessionId, List<MapEdge> affectedEdges, ObservationItem item) {
-        List<UUID> edgeIds = affectedEdges.stream().map(MapEdge::getId).toList();
-        trainingEventPublisher.publishCongestionUpdated(sessionId, edgeIds, item);
+        List<UUID> affectedEdgeIds = affectedEdges.stream().map(MapEdge::getId).distinct().toList();
+        trainingEventPublisher.publishCongestionUpdated(sessionId, affectedEdgeIds, item);
     }
 
     private void completeProcessing(String eventId, String processingOwner) {

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -355,16 +355,12 @@ public class CongestionObservationService {
         });
     }
 
-    // Edge가 없으면(감시 영역에 아직 GridCell/Edge 매핑이 안 된 CCTV) edgeId 없이 한 번만 발행해
-    // 대시보드가 최소한 CCTV 단위 관측값은 볼 수 있게 한다.
+    // CCTV당 1 Observation = 1 WebSocket 이벤트 원칙을 지키기 위해 영향받는 Edge 전체를 배열로 담아
+    // 한 번만 발행한다 (이슈 #192). Edge가 없으면(감시 영역에 아직 GridCell/Edge 매핑이 안 된 CCTV)
+    // 빈 목록으로 발행해 대시보드가 최소한 CCTV 단위 관측값은 볼 수 있게 한다.
     private void publishCongestionUpdated(UUID sessionId, List<MapEdge> affectedEdges, ObservationItem item) {
-        if (affectedEdges.isEmpty()) {
-            trainingEventPublisher.publishCongestionUpdated(sessionId, null, item);
-            return;
-        }
-        for (MapEdge edge : affectedEdges) {
-            trainingEventPublisher.publishCongestionUpdated(sessionId, edge.getId(), item);
-        }
+        List<UUID> edgeIds = affectedEdges.stream().map(MapEdge::getId).toList();
+        trainingEventPublisher.publishCongestionUpdated(sessionId, edgeIds, item);
     }
 
     private void completeProcessing(String eventId, String processingOwner) {

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventData.java
@@ -6,11 +6,13 @@ import java.util.List;
 import java.util.UUID;
 
 // 프론트가 카드 단위로 갱신 대상을 식별할 수 있도록 eventId/cctvCode/capturedAt/hasMonitoringImage를 포함한다 (이슈 #142).
-// CCTV당 1 Observation = 1 이벤트 발행 원칙을 지키기 위해 영향받는 Edge 전체를 edgeIds 배열로 담는다 (이슈 #192).
-// REST 응답(ObservationResponse)과 필드명을 맞춰 density를 함께 포함한다 (이슈 #192).
+// CCTV당 1 Observation = 1 이벤트 발행 원칙을 지키기 위해 영향받는 Edge 전체를 affectedEdgeIds 배열로 담는다
+// (Edge가 없으면 빈 배열이며 null을 섞어 쓰지 않는다). 배열 안 Edge ID는 중복 없이 담는다 (이슈 #192).
+// REST current-states 응답과 필드명을 맞춰 density/configVersion을 함께 포함한다. capturedAt은 REST의
+// lastDetectedAt에 대응한다 - REST 호환성을 위해 필드명 자체는 맞추지 않고 대응 관계만 문서화한다 (이슈 #192).
 public record CongestionEventData(
         UUID eventId,
-        List<UUID> edgeIds,
+        List<UUID> affectedEdgeIds,
         String cctvCode,
         Double avgHeadcount,
         Integer peakHeadcount,
@@ -19,15 +21,17 @@ public record CongestionEventData(
         Long windowStart,
         Long windowEnd,
         Long capturedAt,
+        Long configVersion,
         // 이미지는 presigned URL 만료 문제로 WebSocket payload에 직접 포함하지 않는다.
-        // true면 프론트가 프레임 조회 REST API를 재호출해서 이미지를 받아야 한다 (이슈 #192).
+        // true면 프론트가 카메라/프레임 조회 REST API를 재호출해서 새 presigned URL을 받아야 한다.
+        // REST의 frameId와 이 payload의 eventId를 비교하면 같은 프레임인지 확인할 수 있다 (이슈 #192).
         boolean hasMonitoringImage
 ) {
 
-    public static CongestionEventData from(List<UUID> edgeIds, ObservationItem item) {
+    public static CongestionEventData from(List<UUID> affectedEdgeIds, ObservationItem item) {
         return new CongestionEventData(
                 UUID.fromString(item.getEventId()),
-                edgeIds,
+                affectedEdgeIds.stream().distinct().toList(),
                 item.getCctvCode(),
                 item.getAvgHeadcount(),
                 item.getPeakHeadcount(),
@@ -36,6 +40,7 @@ public record CongestionEventData(
                 item.getWindowStart(),
                 item.getWindowEnd(),
                 item.getCapturedAt(),
+                item.getConfigVersion(),
                 item.getMonitoringImageKey() != null && !item.getMonitoringImageKey().isBlank()
         );
     }

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventData.java
@@ -2,29 +2,36 @@ package com.saferoute.infrastructure.websocket.dto;
 
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import java.util.List;
 import java.util.UUID;
 
 // 프론트가 카드 단위로 갱신 대상을 식별할 수 있도록 eventId/cctvCode/capturedAt/hasMonitoringImage를 포함한다 (이슈 #142).
+// CCTV당 1 Observation = 1 이벤트 발행 원칙을 지키기 위해 영향받는 Edge 전체를 edgeIds 배열로 담는다 (이슈 #192).
+// REST 응답(ObservationResponse)과 필드명을 맞춰 density를 함께 포함한다 (이슈 #192).
 public record CongestionEventData(
         UUID eventId,
-        UUID edgeId,
+        List<UUID> edgeIds,
         String cctvCode,
         Double avgHeadcount,
         Integer peakHeadcount,
+        Double density,
         CongestionLevel congestionLevel,
         Long windowStart,
         Long windowEnd,
         Long capturedAt,
+        // 이미지는 presigned URL 만료 문제로 WebSocket payload에 직접 포함하지 않는다.
+        // true면 프론트가 프레임 조회 REST API를 재호출해서 이미지를 받아야 한다 (이슈 #192).
         boolean hasMonitoringImage
 ) {
 
-    public static CongestionEventData from(UUID edgeId, ObservationItem item) {
+    public static CongestionEventData from(List<UUID> edgeIds, ObservationItem item) {
         return new CongestionEventData(
                 UUID.fromString(item.getEventId()),
-                edgeId,
+                edgeIds,
                 item.getCctvCode(),
                 item.getAvgHeadcount(),
                 item.getPeakHeadcount(),
+                item.getDensity(),
                 item.getCongestionLevel(),
                 item.getWindowStart(),
                 item.getWindowEnd(),

--- a/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventReceivedData.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/dto/CongestionEventReceivedData.java
@@ -4,11 +4,14 @@ import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
 import com.saferoute.domain.telemetry.dynamo.entity.ImageUploadStatus;
+import java.util.List;
 import java.util.UUID;
 
+// 즉시 혼잡 상태 전환 1건당 이 메시지 1건만 발행한다. 영향받는 Edge가 여러 개여도 반복 발행하지 않고
+// affectedEdgeIds 배열에 중복 없이 담는다 (Edge가 없으면 빈 배열, null과 혼용하지 않는다) (이슈 #192).
 public record CongestionEventReceivedData(
         String eventId,
-        UUID edgeId,
+        List<UUID> affectedEdgeIds,
         String cctvCode,
         CongestionEventType eventType,
         Double density,
@@ -17,10 +20,10 @@ public record CongestionEventReceivedData(
         ImageUploadStatus imageUploadStatus
 ) {
 
-    public static CongestionEventReceivedData from(UUID edgeId, CongestionEventItem item) {
+    public static CongestionEventReceivedData from(List<UUID> affectedEdgeIds, CongestionEventItem item) {
         return new CongestionEventReceivedData(
                 item.getEventId(),
-                edgeId,
+                affectedEdgeIds.stream().distinct().toList(),
                 item.getCctvCode(),
                 item.getEventType(),
                 item.getDensity(),

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -140,19 +140,19 @@ public class TrainingEventPublisher {
 
     // 혼잡 이벤트 수신 시 즉시 발행한다 (DynamoDB 저장은 DB 트랜잭션과 무관하므로 AfterCommit 버전을 두지 않는다).
     // CCTV당 1 Observation = 1 이벤트 발행 원칙에 따라 영향받는 Edge 전체를 한 번에 담아 한 번만 발행한다 (이슈 #192).
-    public void publishCongestionUpdated(UUID sessionId, List<UUID> edgeIds, ObservationItem item) {
+    public void publishCongestionUpdated(UUID sessionId, List<UUID> affectedEdgeIds, ObservationItem item) {
         TrainingEventMessage<CongestionEventData> message = TrainingEventMessage.of(
                 TrainingEventType.CONGESTION_UPDATED,
                 sessionId,
-                CongestionEventData.from(edgeIds, item)
+                CongestionEventData.from(affectedEdgeIds, item)
         );
 
         messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
 
         log.debug(
-                "혼잡도 이벤트 발행: sessionId={}, edgeIds={}, level={}",
+                "혼잡도 이벤트 발행: sessionId={}, affectedEdgeIds={}, level={}",
                 sessionId,
-                edgeIds,
+                affectedEdgeIds,
                 item.getCongestionLevel()
         );
     }

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -139,19 +139,20 @@ public class TrainingEventPublisher {
     }
 
     // 혼잡 이벤트 수신 시 즉시 발행한다 (DynamoDB 저장은 DB 트랜잭션과 무관하므로 AfterCommit 버전을 두지 않는다).
-    public void publishCongestionUpdated(UUID sessionId, UUID edgeId, ObservationItem item) {
+    // CCTV당 1 Observation = 1 이벤트 발행 원칙에 따라 영향받는 Edge 전체를 한 번에 담아 한 번만 발행한다 (이슈 #192).
+    public void publishCongestionUpdated(UUID sessionId, List<UUID> edgeIds, ObservationItem item) {
         TrainingEventMessage<CongestionEventData> message = TrainingEventMessage.of(
                 TrainingEventType.CONGESTION_UPDATED,
                 sessionId,
-                CongestionEventData.from(edgeId, item)
+                CongestionEventData.from(edgeIds, item)
         );
 
         messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
 
         log.debug(
-                "혼잡도 이벤트 발행: sessionId={}, edgeId={}, level={}",
+                "혼잡도 이벤트 발행: sessionId={}, edgeIds={}, level={}",
                 sessionId,
-                edgeId,
+                edgeIds,
                 item.getCongestionLevel()
         );
     }

--- a/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
+++ b/src/main/java/com/saferoute/infrastructure/websocket/service/TrainingEventPublisher.java
@@ -175,19 +175,20 @@ public class TrainingEventPublisher {
     // 즉시 혼잡 이벤트 수신/처리 시 발행한다. CongestionEventService가 발행 성공 여부에 따라
     // DynamoDB 처리 상태(PROCESSED/FAILED)를 직접 갱신해야 해서, 다른 AfterCommit 헬퍼처럼 실패를
     // 로그로 삼키지 않고 그대로 던진다 - 호출자가 afterCommit 트랜잭션 동기화를 직접 관리한다.
-    public void publishCongestionEventReceived(UUID sessionId, UUID edgeId, CongestionEventItem item) {
+    // 즉시 혼잡 상태 전환 1건당 1회만 발행한다 - 영향받는 Edge는 affectedEdgeIds 배열로 한 번에 담는다 (이슈 #192).
+    public void publishCongestionEventReceived(UUID sessionId, List<UUID> affectedEdgeIds, CongestionEventItem item) {
         TrainingEventMessage<CongestionEventReceivedData> message = TrainingEventMessage.of(
                 TrainingEventType.CONGESTION_EVENT_RECEIVED,
                 sessionId,
-                CongestionEventReceivedData.from(edgeId, item)
+                CongestionEventReceivedData.from(affectedEdgeIds, item)
         );
 
         messagingTemplate.convertAndSend(SESSION_TOPIC_PREFIX + sessionId, message);
 
         log.debug(
-                "즉시 혼잡 이벤트 발행: sessionId={}, edgeId={}, eventId={}, level={}",
+                "즉시 혼잡 이벤트 발행: sessionId={}, affectedEdgeIds={}, eventId={}, level={}",
                 sessionId,
-                edgeId,
+                affectedEdgeIds,
                 item.getEventId(),
                 item.getCongestionLevel()
         );

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -218,17 +217,20 @@ class CongestionEventServiceTest {
     }
 
     @Test
-    @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하고 각각 발행한다")
-    void reportCongestionEvent_triggersRecalculationForEachAffectedEdge() {
+    @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하되 발행은 이벤트당 한 번만 한다")
+    void reportCongestionEvent_triggersRecalculationForEachAffectedEdgeButPublishesOnce() {
         TrainingSession session = mock(TrainingSession.class);
         given(session.getId()).willReturn(sessionId);
         given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
                 sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
         givenSaveCreatesItem();
         givenProcessingClaimed();
-        MapEdge edgeA = edge(UUID.randomUUID());
-        MapEdge edgeB = edge(UUID.randomUUID());
+        UUID edgeAId = UUID.randomUUID();
+        UUID edgeBId = UUID.randomUUID();
+        MapEdge edgeA = edge(edgeAId);
+        MapEdge edgeB = edge(edgeBId);
         givenAffectedEdges(edgeA, edgeB);
+        List<UUID> expectedEdgeIds = List.of(edgeAId, edgeBId);
 
         // headcount=13 -> density=3.25 -> CROWDED
         service.reportCongestionEvent(cctv, request(13));
@@ -237,13 +239,13 @@ class CongestionEventServiceTest {
                 eq(RecalculationTriggerType.STARTED), eq("CCTV_001"), anyDouble());
         verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED),
                 eq(RecalculationTriggerType.STARTED), eq("CCTV_001"), anyDouble());
-        verify(trainingEventPublisher, times(2))
-                .publishCongestionEventReceived(eq(sessionId), any(), any());
+        verify(trainingEventPublisher, times(1))
+                .publishCongestionEventReceived(eq(sessionId), eq(expectedEdgeIds), any());
     }
 
     @Test
-    @DisplayName("매핑된 Edge가 없으면 edgeId 없이 한 번만 발행하고 재탐색은 트리거하지 않는다")
-    void reportCongestionEvent_noMappedEdges_publishesOnceWithoutEdgeId() {
+    @DisplayName("매핑된 Edge가 없으면 빈 affectedEdgeIds로 한 번만 발행하고 재탐색은 트리거하지 않는다")
+    void reportCongestionEvent_noMappedEdges_publishesOnceWithEmptyEdgeIds() {
         TrainingSession session = mock(TrainingSession.class);
         given(session.getId()).willReturn(sessionId);
         given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
@@ -257,7 +259,7 @@ class CongestionEventServiceTest {
         service.reportCongestionEvent(cctv, request(13));
 
         verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
-        verify(trainingEventPublisher).publishCongestionEventReceived(eq(sessionId), isNull(), any());
+        verify(trainingEventPublisher).publishCongestionEventReceived(eq(sessionId), eq(List.of()), any());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -217,6 +217,24 @@ class CongestionEventServiceTest {
     }
 
     @Test
+    @DisplayName("영향받는 Edge가 하나면 그 Edge 하나만 담아 한 번 발행한다")
+    void reportCongestionEvent_singleAffectedEdge_publishesOnceWithThatEdge() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenSaveCreatesItem();
+        givenProcessingClaimed();
+        UUID edgeAId = UUID.randomUUID();
+        givenAffectedEdges(edge(edgeAId));
+
+        service.reportCongestionEvent(cctv, request(13));
+
+        verify(trainingEventPublisher, times(1)).publishCongestionEventReceived(
+                eq(sessionId), eq(List.of(edgeAId)), any());
+    }
+
+    @Test
     @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하되 발행은 이벤트당 한 번만 한다")
     void reportCongestionEvent_triggersRecalculationForEachAffectedEdgeButPublishesOnce() {
         TrainingSession session = mock(TrainingSession.class);

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -263,6 +263,24 @@ class CongestionObservationServiceTest {
     }
 
     @Test
+    @DisplayName("같은 Edge가 여러 GridCell 매핑을 통해 중복으로 조회돼도 발행 payload에는 한 번만 담는다")
+    void reportObservation_dedupesAffectedEdgeIds() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        UUID edgeAId = UUID.randomUUID();
+        MapEdge edgeA = edge(edgeAId);
+        givenAffectedEdges(edgeA, edgeA);
+
+        service.reportObservation(cctv, request(5.0));
+
+        verify(trainingEventPublisher).publishCongestionUpdated(
+                eq(sessionId), eq(List.of(edgeAId)), any());
+    }
+
+    @Test
     @DisplayName("매핑된 Edge가 없으면 빈 edgeIds로 한 번만 발행하고 재탐색은 트리거하지 않는다")
     void reportObservation_noMappedEdges_publishesOnceWithEmptyEdgeIds() {
         TrainingSession session = mock(TrainingSession.class);

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -238,16 +237,19 @@ class CongestionObservationServiceTest {
     }
 
     @Test
-    @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하고 각각 발행한다")
-    void reportObservation_triggersRecalculationForEachAffectedEdge() {
+    @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하되 발행은 CCTV당 한 번만 한다")
+    void reportObservation_triggersRecalculationForEachAffectedEdgeButPublishesOnce() {
         TrainingSession session = mock(TrainingSession.class);
         given(session.getId()).willReturn(sessionId);
         given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
                 sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
         givenProcessingClaimed();
-        MapEdge edgeA = edge(UUID.randomUUID());
-        MapEdge edgeB = edge(UUID.randomUUID());
+        UUID edgeAId = UUID.randomUUID();
+        UUID edgeBId = UUID.randomUUID();
+        MapEdge edgeA = edge(edgeAId);
+        MapEdge edgeB = edge(edgeBId);
         givenAffectedEdges(edgeA, edgeB);
+        List<UUID> expectedEdgeIds = List.of(edgeAId, edgeBId);
 
         // avgHeadcount=13 -> density=3.25 -> CROWDED
         service.reportObservation(cctv, request(13.0));
@@ -256,12 +258,13 @@ class CongestionObservationServiceTest {
                 eq(RecalculationTriggerType.LEVEL_UP), eq("CCTV_001"), anyDouble());
         verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED),
                 eq(RecalculationTriggerType.LEVEL_UP), eq("CCTV_001"), anyDouble());
-        verify(trainingEventPublisher, times(2)).publishCongestionUpdated(eq(sessionId), any(), any());
+        verify(trainingEventPublisher, times(1)).publishCongestionUpdated(
+                eq(sessionId), eq(expectedEdgeIds), any());
     }
 
     @Test
-    @DisplayName("매핑된 Edge가 없으면 edgeId 없이 한 번만 발행하고 재탐색은 트리거하지 않는다")
-    void reportObservation_noMappedEdges_publishesOnceWithoutEdgeId() {
+    @DisplayName("매핑된 Edge가 없으면 빈 edgeIds로 한 번만 발행하고 재탐색은 트리거하지 않는다")
+    void reportObservation_noMappedEdges_publishesOnceWithEmptyEdgeIds() {
         TrainingSession session = mock(TrainingSession.class);
         given(session.getId()).willReturn(sessionId);
         given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
@@ -274,7 +277,7 @@ class CongestionObservationServiceTest {
         service.reportObservation(cctv, request(13.0));
 
         verify(routeRecalculationService, never()).trigger(any(), any(), any(), any(), any(), anyDouble());
-        verify(trainingEventPublisher).publishCongestionUpdated(eq(sessionId), isNull(), any());
+        verify(trainingEventPublisher).publishCongestionUpdated(eq(sessionId), eq(List.of()), any());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -237,6 +237,23 @@ class CongestionObservationServiceTest {
     }
 
     @Test
+    @DisplayName("영향받는 Edge가 하나면 그 Edge 하나만 담아 한 번 발행한다")
+    void reportObservation_singleAffectedEdge_publishesOnceWithThatEdge() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        UUID edgeAId = UUID.randomUUID();
+        givenAffectedEdges(edge(edgeAId));
+
+        service.reportObservation(cctv, request(5.0));
+
+        verify(trainingEventPublisher, times(1)).publishCongestionUpdated(
+                eq(sessionId), eq(List.of(edgeAId)), any());
+    }
+
+    @Test
     @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하되 발행은 CCTV당 한 번만 한다")
     void reportObservation_triggersRecalculationForEachAffectedEdgeButPublishesOnce() {
         TrainingSession session = mock(TrainingSession.class);

--- a/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventDataTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventDataTest.java
@@ -32,8 +32,8 @@ class CongestionEventDataTest {
     }
 
     @Test
-    @DisplayName("영향받는 Edge 전체를 edgeIds 배열로, density를 포함해서 매핑한다 (REST ObservationResponse와 필드 일치)")
-    void from_mapsAllEdgesAndDensity() {
+    @DisplayName("영향받는 Edge 전체를 affectedEdgeIds 배열로, density/configVersion을 포함해서 매핑한다 (REST ObservationResponse와 필드 일치)")
+    void from_mapsAllEdgesAndDensityAndConfigVersion() {
         ObservationItem item = observationItem(null);
         UUID edgeA = UUID.randomUUID();
         UUID edgeB = UUID.randomUUID();
@@ -42,13 +42,14 @@ class CongestionEventDataTest {
         ObservationResponse restResponse = ObservationResponse.from(item);
 
         assertThat(data.eventId()).isEqualTo(UUID.fromString(item.getEventId()));
-        assertThat(data.edgeIds()).containsExactly(edgeA, edgeB);
+        assertThat(data.affectedEdgeIds()).containsExactly(edgeA, edgeB);
         assertThat(data.cctvCode()).isEqualTo(restResponse.cctvCode());
         assertThat(data.avgHeadcount()).isEqualTo(restResponse.avgHeadcount());
         assertThat(data.peakHeadcount()).isEqualTo(restResponse.peakHeadcount());
         assertThat(data.density()).isEqualTo(restResponse.density());
         assertThat(data.congestionLevel()).isEqualTo(restResponse.congestionLevel());
         assertThat(data.capturedAt()).isEqualTo(restResponse.capturedAt());
+        assertThat(data.configVersion()).isEqualTo(restResponse.configVersion());
     }
 
     @Test
@@ -58,7 +59,18 @@ class CongestionEventDataTest {
 
         CongestionEventData data = CongestionEventData.from(List.of(), item);
 
-        assertThat(data.edgeIds()).isEmpty();
+        assertThat(data.affectedEdgeIds()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 Edge ID가 중복으로 들어와도 한 번만 담는다")
+    void from_dedupesEdgeIds() {
+        ObservationItem item = observationItem(null);
+        UUID edgeA = UUID.randomUUID();
+
+        CongestionEventData data = CongestionEventData.from(List.of(edgeA, edgeA), item);
+
+        assertThat(data.affectedEdgeIds()).containsExactly(edgeA);
     }
 
     @Test

--- a/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventDataTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventDataTest.java
@@ -1,0 +1,73 @@
+package com.saferoute.infrastructure.websocket.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.congestion.dto.response.ObservationResponse;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CongestionEventDataTest {
+
+    private ObservationItem observationItem(String monitoringImageKey) {
+        return ObservationItem.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                "CCTV_001",
+                8.6,
+                12,
+                25,
+                0.42,
+                CongestionLevel.CROWDED,
+                1_000L,
+                2_000L,
+                2_000L,
+                monitoringImageKey,
+                1L
+        );
+    }
+
+    @Test
+    @DisplayName("영향받는 Edge 전체를 edgeIds 배열로, density를 포함해서 매핑한다 (REST ObservationResponse와 필드 일치)")
+    void from_mapsAllEdgesAndDensity() {
+        ObservationItem item = observationItem(null);
+        UUID edgeA = UUID.randomUUID();
+        UUID edgeB = UUID.randomUUID();
+
+        CongestionEventData data = CongestionEventData.from(List.of(edgeA, edgeB), item);
+        ObservationResponse restResponse = ObservationResponse.from(item);
+
+        assertThat(data.eventId()).isEqualTo(UUID.fromString(item.getEventId()));
+        assertThat(data.edgeIds()).containsExactly(edgeA, edgeB);
+        assertThat(data.cctvCode()).isEqualTo(restResponse.cctvCode());
+        assertThat(data.avgHeadcount()).isEqualTo(restResponse.avgHeadcount());
+        assertThat(data.peakHeadcount()).isEqualTo(restResponse.peakHeadcount());
+        assertThat(data.density()).isEqualTo(restResponse.density());
+        assertThat(data.congestionLevel()).isEqualTo(restResponse.congestionLevel());
+        assertThat(data.capturedAt()).isEqualTo(restResponse.capturedAt());
+    }
+
+    @Test
+    @DisplayName("영향받는 Edge가 없으면 빈 목록으로 매핑한다")
+    void from_mapsEmptyEdgeList() {
+        ObservationItem item = observationItem(null);
+
+        CongestionEventData data = CongestionEventData.from(List.of(), item);
+
+        assertThat(data.edgeIds()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("monitoringImageKey가 있으면 hasMonitoringImage=true, 없으면 false로 매핑한다")
+    void from_mapsHasMonitoringImage() {
+        ObservationItem withImage = observationItem("training/session/monitoring/CCTV_001/2000.jpg");
+        ObservationItem withoutImage = observationItem(null);
+
+        assertThat(CongestionEventData.from(List.of(), withImage).hasMonitoringImage()).isTrue();
+        assertThat(CongestionEventData.from(List.of(), withoutImage).hasMonitoringImage()).isFalse();
+    }
+}

--- a/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventDataTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventDataTest.java
@@ -2,6 +2,7 @@ package com.saferoute.infrastructure.websocket.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.congestion.dto.response.ObservationResponse;
 import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class CongestionEventDataTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private ObservationItem observationItem(String monitoringImageKey) {
         return ObservationItem.create(
@@ -81,5 +84,32 @@ class CongestionEventDataTest {
 
         assertThat(CongestionEventData.from(List.of(), withImage).hasMonitoringImage()).isTrue();
         assertThat(CongestionEventData.from(List.of(), withoutImage).hasMonitoringImage()).isFalse();
+    }
+
+    @Test
+    @DisplayName("JSON 직렬화 시 affectedEdgeIds 필드로 담기고, 예전 단일 edgeId 필드는 남지 않는다")
+    void serializesToJsonWithAffectedEdgeIdsAndNoLegacyEdgeIdField() throws Exception {
+        ObservationItem item = observationItem(null);
+        UUID edgeA = UUID.randomUUID();
+        CongestionEventData data = CongestionEventData.from(List.of(edgeA), item);
+
+        var json = objectMapper.readTree(objectMapper.writeValueAsString(data));
+
+        assertThat(json.has("affectedEdgeIds")).isTrue();
+        assertThat(json.get("affectedEdgeIds").isArray()).isTrue();
+        assertThat(json.get("affectedEdgeIds").get(0).asText()).isEqualTo(edgeA.toString());
+        assertThat(json.has("edgeId")).isFalse();
+        assertThat(json.get("density").asDouble()).isEqualTo(item.getDensity());
+        assertThat(json.get("configVersion").asLong()).isEqualTo(item.getConfigVersion());
+    }
+
+    @Test
+    @DisplayName("영향받는 Edge가 없어도 affectedEdgeIds는 null이 아닌 빈 배열로 직렬화된다")
+    void serializesEmptyEdgeListAsJsonArrayNotNull() throws Exception {
+        var json = objectMapper.readTree(objectMapper.writeValueAsString(
+                CongestionEventData.from(List.of(), observationItem(null))));
+
+        assertThat(json.get("affectedEdgeIds").isArray()).isTrue();
+        assertThat(json.get("affectedEdgeIds")).isEmpty();
     }
 }

--- a/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventReceivedDataTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventReceivedDataTest.java
@@ -2,6 +2,7 @@ package com.saferoute.infrastructure.websocket.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saferoute.domain.congestion.entity.CongestionLevel;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
 import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class CongestionEventReceivedDataTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private CongestionEventItem congestionEventItem() {
         return CongestionEventItem.received(
@@ -65,5 +68,19 @@ class CongestionEventReceivedDataTest {
                 CongestionEventReceivedData.from(List.of(edgeA, edgeA), congestionEventItem());
 
         assertThat(data.affectedEdgeIds()).containsExactly(edgeA);
+    }
+
+    @Test
+    @DisplayName("JSON 직렬화 시 affectedEdgeIds 필드로 담기고, 예전 단일 edgeId 필드는 남지 않는다")
+    void serializesToJsonWithAffectedEdgeIdsAndNoLegacyEdgeIdField() throws Exception {
+        UUID edgeA = UUID.randomUUID();
+        CongestionEventReceivedData data = CongestionEventReceivedData.from(List.of(edgeA), congestionEventItem());
+
+        var json = objectMapper.readTree(objectMapper.writeValueAsString(data));
+
+        assertThat(json.has("affectedEdgeIds")).isTrue();
+        assertThat(json.get("affectedEdgeIds").isArray()).isTrue();
+        assertThat(json.get("affectedEdgeIds").get(0).asText()).isEqualTo(edgeA.toString());
+        assertThat(json.has("edgeId")).isFalse();
     }
 }

--- a/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventReceivedDataTest.java
+++ b/src/test/java/com/saferoute/infrastructure/websocket/dto/CongestionEventReceivedDataTest.java
@@ -1,0 +1,69 @@
+package com.saferoute.infrastructure.websocket.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventItem;
+import com.saferoute.domain.telemetry.dynamo.entity.CongestionEventType;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CongestionEventReceivedDataTest {
+
+    private CongestionEventItem congestionEventItem() {
+        return CongestionEventItem.received(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "CCTV_001",
+                CongestionEventType.CONGESTION_STARTED,
+                2_000L,
+                13,
+                4.5,
+                CongestionLevel.CROWDED,
+                3.25,
+                CongestionLevel.CROWDED,
+                1L,
+                null
+        );
+    }
+
+    @Test
+    @DisplayName("영향받는 Edge 전체를 affectedEdgeIds 배열로 매핑한다")
+    void from_mapsAllEdges() {
+        CongestionEventItem item = congestionEventItem();
+        UUID edgeA = UUID.randomUUID();
+        UUID edgeB = UUID.randomUUID();
+
+        CongestionEventReceivedData data = CongestionEventReceivedData.from(List.of(edgeA, edgeB), item);
+
+        assertThat(data.eventId()).isEqualTo(item.getEventId());
+        assertThat(data.affectedEdgeIds()).containsExactly(edgeA, edgeB);
+        assertThat(data.cctvCode()).isEqualTo(item.getCctvCode());
+        assertThat(data.eventType()).isEqualTo(item.getEventType());
+        assertThat(data.density()).isEqualTo(item.getDensity());
+        assertThat(data.congestionLevel()).isEqualTo(item.getCongestionLevel());
+        assertThat(data.detectedAt()).isEqualTo(item.getDetectedAt());
+        assertThat(data.imageUploadStatus()).isEqualTo(item.getImageUploadStatus());
+    }
+
+    @Test
+    @DisplayName("영향받는 Edge가 없으면 빈 목록으로 매핑한다")
+    void from_mapsEmptyEdgeList() {
+        CongestionEventReceivedData data = CongestionEventReceivedData.from(List.of(), congestionEventItem());
+
+        assertThat(data.affectedEdgeIds()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 Edge ID가 중복으로 들어와도 한 번만 담는다")
+    void from_dedupesEdgeIds() {
+        UUID edgeA = UUID.randomUUID();
+
+        CongestionEventReceivedData data =
+                CongestionEventReceivedData.from(List.of(edgeA, edgeA), congestionEventItem());
+
+        assertThat(data.affectedEdgeIds()).containsExactly(edgeA);
+    }
+}


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #192
- Branch: feat/#192

## 주요 내용

- `CONGESTION_UPDATED` payload에 `density`, `configVersion` 추가 (REST `current-states` 응답과 필드 의미 일치)
- `CONGESTION_UPDATED`/`CONGESTION_EVENT_RECEIVED` 모두 단일 `edgeId` → `affectedEdgeIds` 배열로 변경, 중복 Edge ID 제거
- 하나의 Observation/즉시 혼잡 이벤트가 여러 Edge에 걸쳐도 WebSocket 메시지를 CCTV·이벤트당 1회만 발행하도록 수정 (기존에는 Edge마다 반복 발행)
- 경로 재탐색 트리거는 기존처럼 영향받는 Edge마다 개별 실행 (WebSocket 발행 단위 변경과 무관하게 유지)
- 이미지 미포함 정책, `capturedAt`↔`lastDetectedAt` 대응 관계를 필드 주석 및 `docs/websocket-events.md`에 문서화

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?