### PR TITLE
[feat] #214: 타임아웃 훈련 종료 상태를 ERROR와 구분

### DIFF
--- a/src/main/java/com/saferoute/domain/training/entity/ScenarioStatus.java
+++ b/src/main/java/com/saferoute/domain/training/entity/ScenarioStatus.java
@@ -7,5 +7,6 @@ public enum ScenarioStatus {
     READY,
     IN_PROGRESS,
     COMPLETED,
-    ERROR
+    ERROR,
+    TIMEOUT_FAILED
 }

--- a/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
+++ b/src/main/java/com/saferoute/domain/training/entity/TrainingScenario.java
@@ -172,6 +172,11 @@ public class TrainingScenario {
         this.status = ScenarioStatus.ERROR;
     }
 
+    // 10분 하드 타임아웃으로 훈련이 자동 종료된 경우. 리포트는 정상 생성되므로 ERROR와 구분한다.
+    public void markTimeoutFailed() {
+        this.status = ScenarioStatus.TIMEOUT_FAILED;
+    }
+
     // 응답용 getter
     public UUID getBuildingId() {
         return building != null ? building.getId() : null;

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -233,7 +233,7 @@ public class TrainingSessionService {
 
     for (TrainingSession session : timedOutSessions) {
       session.fail(Instant.now());
-      session.getScenario().markError();
+      session.getScenario().markTimeoutFailed();
     }
 
     timedOutSessions.stream()

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -586,7 +586,7 @@ class TrainingSessionServiceTest {
     // === failTimedOutSessions ===
 
     @Test
-    @DisplayName("10분 타임아웃을 넘긴 RUNNING 세션을 FAILED로 처리하고 이벤트를 발행하며 시나리오는 ERROR로 바뀐다")
+    @DisplayName("10분 타임아웃을 넘긴 RUNNING 세션을 FAILED로 처리하고 이벤트를 발행하며 시나리오는 TIMEOUT_FAILED로 바뀐다")
     void failTimedOutSessions_marksExpiredSessionsAsFailed() {
         TrainingScenario scenario = mock(TrainingScenario.class);
         given(scenario.getBuildingId()).willReturn(buildingId);
@@ -604,7 +604,7 @@ class TrainingSessionServiceTest {
 
         assertThat(timedOut.getStatus()).isEqualTo(TrainingStatus.FAILED);
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(timedOut);
-        verify(timedOut.getScenario(), times(1)).markError();
+        verify(timedOut.getScenario(), times(1)).markTimeoutFailed();
         verify(ioTLightService).resetToNormal(buildingId);
     }
 

--- a/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
+++ b/src/test/java/com/saferoute/domain/training/service/TrainingSessionServiceTest.java
@@ -605,6 +605,7 @@ class TrainingSessionServiceTest {
         assertThat(timedOut.getStatus()).isEqualTo(TrainingStatus.FAILED);
         verify(trainingEventPublisher, times(1)).publishTrainingStatusUpdatedAfterCommit(timedOut);
         verify(timedOut.getScenario(), times(1)).markTimeoutFailed();
+        verify(timedOut.getScenario(), never()).markError();
         verify(ioTLightService).resetToNormal(buildingId);
     }
 


### PR DESCRIPTION
## 📋 변경 사항

시나리오 목록에서 "10분 타임아웃으로 자동 종료된 훈련"이 관리자 강제 종료와 동일하게 `ScenarioStatus.ERROR`(뱃지: "훈련 실패")로 표시되어 구분이 안 되는 문제를 해결했습니다.

타임아웃 종료는 리포트가 정상적으로 생성되는 케이스인데도 "오류"처럼 보여서 혼란을 준다는 프론트 피드백을 반영했습니다. 기존 `ERROR`(강제 종료 등)는 그대로 두고, 타임아웃 케이스만 별도 값으로 분리했습니다.

- `ScenarioStatus`에 `TIMEOUT_FAILED` 추가 (`ERROR`는 유지, 강제 종료 관련 코드/테스트는 변경 없음)
- `TrainingScenario`에 `markTimeoutFailed()` 메서드 추가
- `TrainingSessionService.failTimedOutSessions()`에서 `markError()` 대신 `markTimeoutFailed()` 호출로 변경

## ✅ 체크리스트

- [x] `ScenarioStatus`에 `TIMEOUT_FAILED` 추가
- [x] `TrainingScenario`에 `markTimeoutFailed()` 메서드 추가
- [x] `TrainingSessionService.failTimedOutSessions()`에서 `markTimeoutFailed()` 호출로 변경
- [x] 관련 단위 테스트 수정 (`TrainingSessionServiceTest`)
- [ ] 프론트에 응답 값 변경사항(타임아웃 종료 시 `ERROR` → `TIMEOUT_FAILED`) 공유, 뱃지 문구를 "오류"가 아닌 "제한 시간 초과"류로 표현하도록 안내

## 📄 API 명세

- 시나리오 목록/단건 조회 API 응답의 `status` 필드에 `TIMEOUT_FAILED` 값 추가 (기존 `ERROR`는 그대로 유지, 강제 종료 등 다른 용도에 계속 사용)

## 🔗 참고

- 강제 종료(`force-end`) API 및 관련 코드는 이번 작업 범위에서 변경하지 않음
- Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 10분 제한 시간 초과로 자동 종료된 훈련을 일반 오류와 구분해 `시간 초과 실패` 상태로 표시합니다.

* **버그 수정**
  * 시간 초과 세션 처리 시나리오가 일반 오류로 기록되던 문제를 수정했습니다.
  * 시간 초과 상태 전이에 대한 검증을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->