### PR TITLE
feat(device): CCTV 소프트 삭제 API 추가 - #218

### DIFF
--- a/src/main/java/com/saferoute/domain/device/controller/CctvController.java
+++ b/src/main/java/com/saferoute/domain/device/controller/CctvController.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -235,5 +236,24 @@ public class CctvController {
                 CctvSuccessCode.CCTV_DISABLED,
                 cctvService.disableCctv(cctvId, authentication.getName())
         ));
+    }
+
+    @Operation(
+            summary = "CCTV 삭제",
+            description = """
+                    CCTV를 소프트 삭제합니다. row는 남지만 삭제 시각이 기록되어 이후 목록/상세
+                    조회, 코드·디바이스 토큰 기반 인증 등 모든 조회에서 제외되므로 해당 CCTV(Pi)는
+                    더 이상 인증할 수 없습니다.
+
+                    code는 재사용되지 않는 순번 채번이라 삭제 후에도 같은 코드로 다시 등록되지
+                    않습니다. 요청자와 다른 학교 소속 CCTV는 찾을 수 없음으로 처리됩니다.
+                    """
+    )
+    @DeleteMapping("/{cctvId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCctv(
+            @PathVariable UUID cctvId,
+            Authentication authentication) {
+        cctvService.deleteCctv(cctvId, authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success(CctvSuccessCode.CCTV_DELETED, null));
     }
 }

--- a/src/main/java/com/saferoute/domain/device/entity/Cctv.java
+++ b/src/main/java/com/saferoute/domain/device/entity/Cctv.java
@@ -11,16 +11,20 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 // 설치 위치는 customNode가 관리하고, 실제 감시 영역은 CctvGridCell 매핑이 관리한다.
 // 혼잡도 반영 경로: CCTV code -> CctvGridCell -> FloorGridCell -> MapEdgeGridCell -> MapEdge
+// 소프트 삭제: deletedAt이 채워진 CCTV는 SQLRestriction으로 모든 조회(코드/토큰 인증 포함)에서
+// 자동 제외된다. code는 사용 후 재사용하지 않는 순번 채번이라 삭제된 row가 남아 있어도 무방하다.
 @Entity
 @Getter
 @Table(name = "cctvs")
 @EntityListeners(AuditingEntityListener.class)
+@SQLRestriction("deleted_at is null")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Cctv {
 
@@ -59,6 +63,9 @@ public class Cctv {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
     private Cctv(String code, String name, MapNode customNode) {
         validateCustomNode(customNode);
         this.code = code;
@@ -88,6 +95,11 @@ public class Cctv {
 
     public void enable() {
         this.enabled = true;
+    }
+
+    // 소프트 삭제. deletedAt 세팅 즉시 SQLRestriction으로 이후 모든 조회에서 제외된다.
+    public void delete() {
+        this.deletedAt = Instant.now();
     }
 
     public void issueDeviceToken(String deviceTokenHash) {

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -139,6 +139,12 @@ public class CctvService {
         return toResponse(cctv);
     }
 
+    @Transactional
+    public void deleteCctv(UUID cctvId, String email) {
+        Cctv cctv = findCctvForSchoolOrThrow(cctvId, email);
+        cctv.delete();
+    }
+
     private CctvResponse toResponse(Cctv cctv) {
         List<FloorGridCell> gridCells = cctvGridCellRepository
                 .findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(cctv.getId())

--- a/src/main/java/com/saferoute/global/api/response/CctvSuccessCode.java
+++ b/src/main/java/com/saferoute/global/api/response/CctvSuccessCode.java
@@ -16,7 +16,8 @@ public enum CctvSuccessCode implements BaseCode {
     CCTV_GRID_CELLS_FOUND(HttpStatus.OK, "CCTV_SUCCESS_005", "CCTV 감시 영역 조회에 성공했습니다."),
     CCTV_ENABLED(HttpStatus.OK, "CCTV_SUCCESS_006", "CCTV가 활성화되었습니다."),
     CCTV_DISABLED(HttpStatus.OK, "CCTV_SUCCESS_007", "CCTV가 비활성화되었습니다."),
-    CCTV_UPDATED(HttpStatus.OK, "CCTV_SUCCESS_008", "CCTV 정보가 수정되었습니다.");
+    CCTV_UPDATED(HttpStatus.OK, "CCTV_SUCCESS_008", "CCTV 정보가 수정되었습니다."),
+    CCTV_DELETED(HttpStatus.OK, "CCTV_SUCCESS_009", "CCTV가 삭제되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
+++ b/src/test/java/com/saferoute/domain/device/controller/CctvControllerTest.java
@@ -3,6 +3,8 @@ package com.saferoute.domain.device.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -192,6 +194,16 @@ class CctvControllerTest {
                         .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.enabled").value(false));
+    }
+
+    @Test
+    void deleteCctv_returnsOk() throws Exception {
+        mockMvc.perform(delete("/api/v1/cctvs/{cctvId}", cctvId)
+                        .principal(new UsernamePasswordAuthenticationToken(EMAIL, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("CCTV_SUCCESS_009"));
+
+        verify(cctvService).deleteCctv(cctvId, EMAIL);
     }
 
     private CctvResponse response(boolean enabled) {

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -201,6 +201,19 @@ class CctvServiceTest {
     }
 
     @Test
+    @DisplayName("CCTV 삭제 시 소프트 삭제 처리만 하고 별도 응답은 없다")
+    void deleteCctv_success() {
+        UUID cctvId = UUID.randomUUID();
+        Cctv cctv = cctv(cctvId);
+        given(cctvJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(cctvId, SCHOOL_NAME))
+                .willReturn(Optional.of(cctv));
+
+        cctvService.deleteCctv(cctvId, EMAIL);
+
+        verify(cctv).delete();
+    }
+
+    @Test
     @DisplayName("다른 기관 CCTV의 모든 변경 요청은 not-found로 거부한다")
     void mutations_otherSchool_throwNotFound() {
         UUID cctvId = UUID.randomUUID();
@@ -214,7 +227,8 @@ class CctvServiceTest {
                         new UpdateCctvRequest("변경 이름", 0.4, 0.6),
                         EMAIL),
                 () -> cctvService.enableCctv(cctvId, EMAIL),
-                () -> cctvService.disableCctv(cctvId, EMAIL)
+                () -> cctvService.disableCctv(cctvId, EMAIL),
+                () -> cctvService.deleteCctv(cctvId, EMAIL)
         );
 
         for (ThrowingCallable operation : operations) {


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #218
- Branch: feat/#218

## 주요 내용

- CCTV 소프트 삭제 API 추가 (`DELETE /api/v1/cctvs/{cctvId}`)
- `Cctv`에 `deletedAt` 필드와 `delete()` 도메인 메서드 추가, `@SQLRestriction("deleted_at is null")`로 삭제된 CCTV를 목록/상세 조회는 물론 코드·디바이스 토큰 기반 인증 쿼리에서도 자동 제외
- CCTV code는 재사용되지 않는 순번 채번이라 소프트 삭제 후에도 unique 제약과 충돌하지 않음
- `CctvSuccessCode.CCTV_DELETED` 추가, 서비스/컨트롤러 테스트 추가

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [x] CI가 정상적으로 작동하는지 확인했나요?