### PR TITLE
fix(evacuation): 엣지 추가/노드 이동 시 MapEdgeGridCell 자동 재계산

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
@@ -32,6 +32,9 @@ public interface MapGraphRepository {
     // 엣지 단건 조회 (삭제 시 참조용)
     Optional<MapEdge> findEdgeById(UUID edgeId);
 
+    // 특정 노드에 연결된 엣지 전체 (노드 이동 시 grid cell 매핑 재계산 대상 조회용)
+    List<MapEdge> findEdgesConnectedToNode(UUID nodeId);
+
     // 노드 위치 및 EXIT 대상 여부 수정 (드래그 편집)
     MapNode updateNodePosition(MapNode node, double x, double y, boolean isExitTarget);
 

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
@@ -82,6 +82,11 @@ public class MapGraphRepositoryImpl implements MapGraphRepository {
     }
 
     @Override
+    public List<MapEdge> findEdgesConnectedToNode(UUID nodeId) {
+        return mapEdgeJpaRepository.findAllByFromNode_IdOrToNode_Id(nodeId, nodeId);
+    }
+
+    @Override
     public MapNode updateNodePosition(MapNode node, double x, double y, boolean isExitTarget) {
         node.moveTo(x, y);
         node.changeExitTarget(isExitTarget);

--- a/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
@@ -10,6 +10,7 @@ import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
 import com.saferoute.domain.evacuation.graph.repository.MapGraphRepository;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.EvacuationErrorCode;
@@ -30,6 +31,7 @@ public class MapGraphService {
     private final MapGraphRepository mapGraphRepository;
     private final FloorRepository floorRepository;
     private final SchoolContextService schoolContextService;
+    private final FloorGridService floorGridService;
 
     // 커스텀 편집 UI 초기 로딩용 - 층의 노드/엣지 전체 조회
     public FloorGraphResponse getFloorGraph(UUID floorId) {
@@ -79,6 +81,11 @@ public class MapGraphService {
         node.changeType(nextType);
         MapNode updated = mapGraphRepository.updateNodePosition(
                 node, request.x(), request.y(), nextExitTarget);
+        // 노드가 이동하면 여기 연결된 엣지들이 지나가는 셀도 달라지므로 grid cell 매핑을 다시 계산한다
+        // (FloorGridService.recomputeEdgeGridCells 참고 - 그리드 생성 시점에만 계산되던 매핑이
+        // 노드/엣지 편집 이후로 안 맞게 되는 문제를 막기 위함).
+        mapGraphRepository.findEdgesConnectedToNode(updated.getId())
+                .forEach(floorGridService::recomputeEdgeGridCells);
         return MapNodeResponse.from(updated);
     }
 
@@ -122,6 +129,9 @@ public class MapGraphService {
         MapNode toNode = findNodeOrThrow(request.toNodeId());
         MapEdge edge = mapGraphRepository.addEdge(
                 fromNode.getFloor(), fromNode, toNode, request.distance(), request.bidirectional());
+        // 그리드가 이미 생성된 층이면 새 엣지도 바로 grid cell에 매핑해둔다 - 안 그러면 그리드를
+        // 재생성하기 전까지 이 엣지는 CCTV 감시 구역과 연결이 안 돼 재탐색 트리거 대상에서 빠진다.
+        floorGridService.recomputeEdgeGridCells(edge);
         return MapEdgeResponse.from(edge);
     }
 

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/MapEdgeGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/MapEdgeGridCellRepository.java
@@ -16,4 +16,10 @@ public interface MapEdgeGridCellRepository extends JpaRepository<MapEdgeGridCell
     List<MapEdgeGridCell> findAllByGridCell_IdIn(List<UUID> gridCellIds);
 
     List<MapEdgeGridCell> findAllByMapEdge_Id(UUID mapEdgeId);
+
+    // 엣지 하나의 grid cell 매핑을 다시 계산하기 전, 기존 매핑을 지운다
+    // (엣지 추가/노드 이동으로 인한 재계산용 - FloorGridService.recomputeEdgeGridCells 참고).
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from MapEdgeGridCell m where m.mapEdge.id = :mapEdgeId")
+    int deleteAllByMapEdgeId(@Param("mapEdgeId") UUID mapEdgeId);
 }

--- a/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
@@ -197,6 +197,35 @@ public class FloorGridService {
         mapEdgeGridCellRepository.saveAll(mappings);
     }
 
+    // 엣지 하나의 grid cell 매핑만 다시 계산한다 (엣지 추가, 연결된 노드 이동 시 호출).
+    // 그리드가 아직 생성 안 된 층이면 매핑할 셀이 없으므로 조용히 넘어간다 - createOrRegenerateGrid가
+    // 호출될 때 그 시점의 전체 엣지를 기준으로 다시 계산해준다.
+    @Transactional
+    public void recomputeEdgeGridCells(MapEdge edge) {
+        Floor floor = edge.getFloor();
+        Integer rows = floor.getGridRows();
+        Integer columns = floor.getGridColumns();
+        if (rows == null || columns == null) {
+            return;
+        }
+
+        // 노드 이동으로 재계산되는 경우 기존 매핑(이전 경로가 지나던 셀)이 남아있으면 안 되므로 먼저 지운다.
+        mapEdgeGridCellRepository.deleteAllByMapEdgeId(edge.getId());
+
+        int fromCol = clamp((int) (edge.getFromNode().getX() * columns), columns);
+        int fromRow = clamp((int) (edge.getFromNode().getY() * rows), rows);
+        int toCol = clamp((int) (edge.getToNode().getX() * columns), columns);
+        int toRow = clamp((int) (edge.getToNode().getY() * rows), rows);
+
+        List<MapEdgeGridCell> mappings = new ArrayList<>();
+        for (int[] cellIdx : bresenhamLine(fromRow, fromCol, toRow, toCol)) {
+            floorGridCellRepository
+                    .findByFloor_IdAndRowIndexAndColumnIndex(floor.getId(), cellIdx[0], cellIdx[1])
+                    .ifPresent(cell -> mappings.add(MapEdgeGridCell.create(edge, cell)));
+        }
+        mapEdgeGridCellRepository.saveAll(mappings);
+    }
+
     private FloorGridCell[][] toGridArray(List<FloorGridCell> cells, int rows, int columns) {
         FloorGridCell[][] grid = new FloorGridCell[rows][columns];
         for (FloorGridCell cell : cells) {

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
@@ -22,6 +22,7 @@ import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
 import com.saferoute.domain.evacuation.graph.repository.MapGraphRepository;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.domain.user.service.SchoolContextService;
@@ -57,6 +58,9 @@ class MapGraphServiceTest {
 
     @Mock
     private SchoolContextService schoolContextService;
+
+    @Mock
+    private FloorGridService floorGridService;
 
     private final UUID floorId = UUID.randomUUID();
     private Floor floor;


### PR DESCRIPTION
## 요약

- 그리드가 이미 생성된 층에서 엣지를 추가하거나, 엣지에 연결된 노드를 이동시켜도 `MapEdgeGridCell`(grid cell ↔ MapEdge 매핑)이 갱신되지 않던 문제를 수정했습니다.
- 이 매핑은 지금까지 `FloorGridService.createOrRegenerateGrid()`(그리드 생성/재생성) 시점에만 계산되고 있어서, 그리드 생성 이후 도면을 편집하면 CCTV 감시 구역과 새/이동된 엣지 사이의 연결이 끊긴 채로 남아 재탐색(`RouteRecalculation`)이 트리거되지 않는 문제가 있었습니다 (`CongestionEventService.resolveAffectedEdges()`가 빈 리스트를 반환 → `GET /api/v1/route-recalculations`가 계속 빈 배열).

## 변경 사항

- `MapGraphRepository`/`MapGraphRepositoryImpl`: `findEdgesConnectedToNode(nodeId)` 추가
- `MapEdgeGridCellRepository`: `deleteAllByMapEdgeId` 추가 (재계산 전 기존 매핑 삭제)
- `FloorGridService`: `recomputeEdgeGridCells(MapEdge edge)` 추가 — 그리드가 있는 층이면 해당 엣지가 지나는 셀만 다시 계산해 매핑을 갱신, 그리드가 없으면 조용히 스킵
- `MapGraphService`
  - `createEdge()`: 엣지 생성 직후 신규 엣지의 grid cell 매핑 계산
  - `updateNodePosition()`: 노드 이동 직후 연결된 엣지 전체 재계산
- 엣지 삭제는 별도 처리 없음 — `MapEdgeGridCell`이 `MapEdge`에 대해 이미 DB 레벨 `ON DELETE CASCADE`로 걸려 있어 자동 정리됨

## Test plan

- [x] `./gradlew compileJava`
- [x] `./gradlew test --tests "*MapGraphService*" --tests "*FloorGridService*"`
- [x] `./gradlew test --tests "com.saferoute.domain.evacuation.*"`

Closes #220