### PR TITLE
fix(evacuation): 재탐색 후보가 활성 경로와 동일하면 중복 PENDING 생성 방지

### DIFF
--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -110,7 +110,14 @@ public class RouteRecalculationService {
             throw exception;
         }
 
-        savePending(session, triggerEdge, cctvCode, triggerType, level, density, previous, candidate);
+        List<UUID> candidateNodeIds = candidate.path().stream().map(MapNode::getId).toList();
+        if (candidateNodeIds.equals(previous.nodeIds())) {
+            // 혼잡이 지속되는 동안 관측값마다 반복 트리거돼도(CongestionObservationService 참고),
+            // 이미 반영된 경로와 후보가 같으면 동일한 PENDING을 계속 새로 만들 필요가 없다.
+            return;
+        }
+
+        savePending(session, triggerEdge, cctvCode, triggerType, level, density, previous, candidate, candidateNodeIds);
     }
 
     // VERY_CROWDED만 완전 제외한다 - 배율만으로는 다른 대안이 훨씬 나쁠 때 여전히 그 엣지를
@@ -196,8 +203,7 @@ public class RouteRecalculationService {
 
     private void savePending(TrainingSession session, MapEdge triggerEdge, String cctvCode,
             RecalculationTriggerType triggerType, CongestionLevel level, double density,
-            RouteSnapshot previous, EvacuationRoute candidate) {
-        List<UUID> candidateNodeIds = candidate.path().stream().map(node -> node.getId()).toList();
+            RouteSnapshot previous, EvacuationRoute candidate, List<UUID> candidateNodeIds) {
         RouteRecalculation recalculation = save(RouteRecalculation.createPending(
                 session, triggerEdge, cctvCode, triggerType, level, density,
                 previous.nodeIds(), previous.totalWeight(), candidateNodeIds, candidate.totalWeight()));

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -256,6 +256,28 @@ class RouteRecalculationServiceTest {
     }
 
     @Test
+    @DisplayName("STARTED/LEVEL_UP 후보 경로가 이미 승인된 활성 경로와 동일하면 새 승인 요청을 만들지 않는다")
+    void trigger_skipsWhenCandidateMatchesActiveRoute() {
+        givenNoExistingPending();
+        UUID sharedNodeId = UUID.randomUUID();
+        RouteRecalculation approvedDetour = approvedRecalculation(List.of(sharedNodeId), 20.0);
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
+                session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED))
+                .willReturn(Optional.of(approvedDetour));
+
+        MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
+        ReflectionTestUtils.setField(exitNode, "id", sharedNodeId);
+        EvacuationRoute candidateRoute = new EvacuationRoute(List.of(exitNode), 20.0);
+        given(evacuationRouteService.findShortestRoute(any(), any(), anySet(), any())).willReturn(candidateRoute);
+
+        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+                RecalculationTriggerType.LEVEL_UP, "CCTV_001", 3.5);
+
+        verify(routeRecalculationRepository, never()).save(any());
+        verify(trainingEventPublisher, never()).publishRouteRecalculationRequestedAfterCommit(any());
+    }
+
+    @Test
     @DisplayName("ENDED인데 승인된 우회 경로가 없으면 복구할 게 없어 아무것도 하지 않는다")
     void trigger_ended_doesNothingWithoutApprovedDetour() {
         givenNoExistingPending();


### PR DESCRIPTION
## 요약

- 혼잡도가 CROWDED 이상으로 계속 유지되는 동안, 이미 승인(APPROVED)된 것과 동일한 우회 경로로 재탐색 승인 대기(PENDING) 항목이 계속 중복 생성되던 문제를 수정했습니다.
- `RouteRecalculationService.trigger()`는 "같은 세션+엣지에 이미 PENDING이 있고 레벨이 같으면" 중복을 걸러내지만, 그 PENDING이 승인/거절되어 사라진 뒤에는 이 가드가 통하지 않았습니다. `CongestionObservationService`는 Pi의 5초 관측값을 항상 LEVEL_UP 트리거로 취급해 `trigger()`를 반복 호출하므로, 혼잡이 지속되는 한 5초마다 (이미 반영된 것과 동일한) 새 후보가 계산되어 그대로 저장되고 있었습니다.
- 혼잡 종료 시 복구 후보를 만드는 `triggerRecovery()`에는 이미 후보-활성경로 동일성 검사가 있었는데(`RouteRecalculationService.java` 참고), STARTED/LEVEL_UP 경로에는 대응하는 검사가 빠져 있어 비대칭이었습니다.

## 변경 사항

- `RouteRecalculationService.trigger()`: 후보 경로의 노드 id 목록이 현재 활성 경로(`previous`)와 동일하면 `savePending()`을 호출하지 않고 반환하도록 가드 추가 (`triggerRecovery()`의 기존 패턴과 동일).
- `savePending()`: 후보 노드 id 목록을 매번 다시 계산하지 않도록 `trigger()`에서 이미 계산한 값을 파라미터로 전달하게 시그니처 변경.

## Test plan

- [x] `./gradlew compileJava`
- [x] `./gradlew test --tests "*RouteRecalculationService*"` (신규 케이스: `trigger_skipsWhenCandidateMatchesActiveRoute`)
- [x] `./gradlew test --tests "com.saferoute.domain.evacuation.*" --tests "com.saferoute.domain.congestion.*"`

Closes #222