### PR TITLE
[Feat] #224: 노드/엣지 관련 오류 수정 및 기능 추가(노드 최종 탈출구 지정 오류, 문 노드 지정 로직 등)

### DIFF
--- a/src/main/java/com/saferoute/domain/device/entity/LightCommand.java
+++ b/src/main/java/com/saferoute/domain/device/entity/LightCommand.java
@@ -16,6 +16,8 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -41,6 +43,7 @@ public class LightCommand {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "light_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private IoTLight light;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/controller/MapGraphEditController.java
@@ -3,6 +3,7 @@ package com.saferoute.domain.evacuation.controller;
 import com.saferoute.domain.evacuation.graph.dto.request.CreateMapEdgeRequest;
 import com.saferoute.domain.evacuation.graph.dto.request.CreateMapNodeRequest;
 import com.saferoute.domain.evacuation.graph.dto.request.UpdateMapNodePositionRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.UpdateMapNodeStartCandidateRequest;
 import com.saferoute.domain.evacuation.graph.dto.response.MapEdgeResponse;
 import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
 import com.saferoute.domain.evacuation.graph.service.MapGraphService;
@@ -85,6 +86,26 @@ public class MapGraphEditController {
             @Valid @RequestBody UpdateMapNodePositionRequest request
     ) {
         return ResponseEntity.ok(ApiResponse.success(mapGraphService.updateNodePosition(nodeId, request)));
+    }
+
+    @Operation(
+            summary = "DOOR 노드 시작 후보 여부 토글",
+            description = """
+                    DOOR 타입 노드가 시나리오 대피 설정(훈련 시작점 선택)에서 START 노드와 함께
+                    후보로 인식되도록 isStartCandidate를 켜거나 끕니다. 위치(x, y)나 타입에는
+                    영향을 주지 않고 이 플래그만 변경합니다.
+
+                    DOOR 타입이 아닌 노드에 요청하면 거부됩니다(400). 노드 타입이 나중에
+                    DOOR가 아닌 다른 타입으로 바뀌면 이 플래그는 자동으로 false로 초기화됩니다.
+                    """
+    )
+    @PatchMapping("/nodes/{nodeId}/start-candidate")
+    public ResponseEntity<ApiResponse<MapNodeResponse>> updateStartCandidate(
+            @PathVariable UUID nodeId,
+            @Valid @RequestBody UpdateMapNodeStartCandidateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                mapGraphService.updateStartCandidate(nodeId, request.isStartCandidate())));
     }
 
     @Operation(

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/UpdateMapNodeStartCandidateRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/UpdateMapNodeStartCandidateRequest.java
@@ -1,4 +1,6 @@
 package com.saferoute.domain.evacuation.graph.dto.request;
 
-// DOOR 타입 노드의 시작 후보 여부만 위치/타입과 별개로 토글할 때 사용
-public record UpdateMapNodeStartCandidateRequest(boolean isStartCandidate) {}
+import jakarta.validation.constraints.NotNull;
+
+// DOOR 타입 노드의 시작 후보 여부만 위치/타입과 별개로 토글할 때 사용.
+public record UpdateMapNodeStartCandidateRequest(@NotNull Boolean isStartCandidate) {}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/UpdateMapNodeStartCandidateRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/request/UpdateMapNodeStartCandidateRequest.java
@@ -1,0 +1,4 @@
+package com.saferoute.domain.evacuation.graph.dto.request;
+
+// DOOR 타입 노드의 시작 후보 여부만 위치/타입과 별개로 토글할 때 사용
+public record UpdateMapNodeStartCandidateRequest(boolean isStartCandidate) {}

--- a/src/main/java/com/saferoute/domain/evacuation/graph/dto/response/MapNodeResponse.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/dto/response/MapNodeResponse.java
@@ -11,7 +11,8 @@ public record MapNodeResponse(
         String name,
         double x,
         double y,
-        boolean isExitTarget
+        boolean isExitTarget,
+        boolean isStartCandidate
 ) {
     public static MapNodeResponse from(MapNode node) {
         return new MapNodeResponse(
@@ -21,7 +22,8 @@ public record MapNodeResponse(
                 node.getName(),
                 node.getX(),
                 node.getY(),
-                node.isExitTarget()
+                node.isExitTarget(),
+                node.isStartCandidate()
         );
     }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapEdge.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapEdge.java
@@ -60,8 +60,8 @@ public class MapEdge {
 
     private MapEdge(Floor floor, MapNode fromNode, MapNode toNode, double distance,
                     boolean bidirectional) {
-        if (distance <= 0) {
-            throw new IllegalArgumentException("distance는 0보다 커야 합니다.");
+        if (!Double.isFinite(distance) || distance <= 0) {
+            throw new IllegalArgumentException("distance는 0보다 큰 유한값이어야 합니다.");
         }
         this.floor = floor;
         this.fromNode = fromNode;

--- a/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapNode.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapNode.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
@@ -63,6 +64,8 @@ public class MapNode {
 
     // DOOR 타입 노드를 훈련 시작점 후보로도 쓸 수 있게 하는 플래그. DOOR가 아니면 항상 false
     // START 타입과 달리 위치와 별개로 PATCH /nodes/{nodeId}/start-candidate로만 토글
+    // @ColumnDefault: 기존 행도 false로 채워지도록 DB 기본값을 명시
+    @ColumnDefault("false")
     @Column(name = "is_start_candidate", nullable = false)
     private boolean isStartCandidate;
 

--- a/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapNode.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/entity/MapNode.java
@@ -61,6 +61,11 @@ public class MapNode {
     @Column(name = "is_exit_target", nullable = false)
     private boolean isExitTarget;
 
+    // DOOR 타입 노드를 훈련 시작점 후보로도 쓸 수 있게 하는 플래그. DOOR가 아니면 항상 false
+    // START 타입과 달리 위치와 별개로 PATCH /nodes/{nodeId}/start-candidate로만 토글
+    @Column(name = "is_start_candidate", nullable = false)
+    private boolean isStartCandidate;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -117,10 +122,18 @@ public class MapNode {
         this.isExitTarget = isExitTarget;
     }
 
+    // DOOR 타입에서만 유효하다 - DOOR 여부 검증은 Service가 담당한다(resolveExitTarget과 동일 컨벤션).
+    public void changeStartCandidate(boolean isStartCandidate) {
+        this.isStartCandidate = isStartCandidate;
+    }
+
     public void changeType(NodeType type) {
         this.type = type;
         if (type != NodeType.CUSTOM) {
             this.customDeviceType = null;
+        }
+        if (type != NodeType.DOOR) {
+            this.isStartCandidate = false;
         }
     }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapEdgeJpaRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapEdgeJpaRepository.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MapEdgeJpaRepository extends JpaRepository<MapEdge, UUID> {
 
@@ -13,8 +15,12 @@ public interface MapEdgeJpaRepository extends JpaRepository<MapEdge, UUID> {
 
     Optional<MapEdge> findByIdAndFloor_Building_SchoolName(UUID id, String schoolName);
 
-    // 특정 노드에 연결된 엣지 (유도등 좌/우 Edge 검증용, 노드 삭제 시 연결 엣지 조회용으로도 사용)
-    List<MapEdge> findAllByFromNode_IdOrToNode_Id(UUID fromNodeId, UUID toNodeId);
+    // 특정 노드에 연결된 엣지 (유도등 좌/우 Edge 검증용, 노드 삭제/노드 이동 시 연결 엣지의 그리드 셀
+    // 재계산용으로도 사용)
+    @Query("SELECT e FROM MapEdge e JOIN FETCH e.fromNode JOIN FETCH e.toNode "
+            + "WHERE e.fromNode.id = :fromNodeId OR e.toNode.id = :toNodeId")
+    List<MapEdge> findAllByFromNode_IdOrToNode_Id(
+            @Param("fromNodeId") UUID fromNodeId, @Param("toNodeId") UUID toNodeId);
 
     // 노드 삭제 시 연결된 엣지 cascade 삭제용
     void deleteByFromNode_IdOrToNode_Id(UUID fromNodeId, UUID toNodeId);

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepository.java
@@ -38,6 +38,9 @@ public interface MapGraphRepository {
     // 노드 위치 및 EXIT 대상 여부 수정 (드래그 편집)
     MapNode updateNodePosition(MapNode node, double x, double y, boolean isExitTarget);
 
+    // DOOR 노드의 시작 후보 여부만 토글 (위치/타입과 무관)
+    MapNode updateStartCandidate(MapNode node, boolean isStartCandidate);
+
     // 노드 삭제 - 연결된 엣지도 함께 삭제(cascade)
     void deleteNode(MapNode node);
 

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
@@ -28,10 +28,17 @@ public class MapGraphRepositoryImpl implements MapGraphRepository {
 
     @Override
     public MapEdge addEdge(Floor floor, MapNode fromNode, MapNode toNode, double distance, boolean bidirectional) {
+        validateDistance(distance);
         validateConnection(fromNode, toNode);
         validateNotDuplicate(fromNode, toNode);
         MapEdge edge = MapEdge.create(floor, fromNode, toNode, distance, bidirectional);
         return mapEdgeJpaRepository.save(edge);
+    }
+
+    private void validateDistance(double distance) {
+        if (distance <= 0) {
+            throw new ApiException(EvacuationErrorCode.INVALID_MAP_EDGE_DISTANCE);
+        }
     }
 
     // 동일 노드 쌍(A-B, B-A 포함) 사이에는 엣지를 하나만 허용
@@ -90,6 +97,12 @@ public class MapGraphRepositoryImpl implements MapGraphRepository {
     public MapNode updateNodePosition(MapNode node, double x, double y, boolean isExitTarget) {
         node.moveTo(x, y);
         node.changeExitTarget(isExitTarget);
+        return node; // 영속 상태 엔티티라 dirty checking으로 트랜잭션 커밋 시 반영됨
+    }
+
+    @Override
+    public MapNode updateStartCandidate(MapNode node, boolean isStartCandidate) {
+        node.changeStartCandidate(isStartCandidate);
         return node; // 영속 상태 엔티티라 dirty checking으로 트랜잭션 커밋 시 반영됨
     }
 

--- a/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImpl.java
@@ -36,7 +36,7 @@ public class MapGraphRepositoryImpl implements MapGraphRepository {
     }
 
     private void validateDistance(double distance) {
-        if (distance <= 0) {
+        if (!Double.isFinite(distance) || distance <= 0) {
             throw new ApiException(EvacuationErrorCode.INVALID_MAP_EDGE_DISTANCE);
         }
     }

--- a/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/graph/service/MapGraphService.java
@@ -89,6 +89,17 @@ public class MapGraphService {
         return MapNodeResponse.from(updated);
     }
 
+    // DOOR 노드의 시작 후보 여부만 위치/타입과 별개로 토글 (시나리오 대피 설정에서 startNode 후보로 인정됨)
+    @Transactional
+    public MapNodeResponse updateStartCandidate(UUID nodeId, boolean isStartCandidate) {
+        MapNode node = findNodeOrThrow(nodeId);
+        if (node.getType() != NodeType.DOOR) {
+            throw new ApiException(EvacuationErrorCode.START_CANDIDATE_ONLY_FOR_DOOR);
+        }
+        MapNode updated = mapGraphRepository.updateStartCandidate(node, isStartCandidate);
+        return MapNodeResponse.from(updated);
+    }
+
     private boolean resolveExitTarget(NodeType type, boolean requestedExitTarget) {
         if (type == NodeType.START) {
             return false;

--- a/src/main/java/com/saferoute/domain/training/controller/ScenarioEvacuationSetupController.java
+++ b/src/main/java/com/saferoute/domain/training/controller/ScenarioEvacuationSetupController.java
@@ -36,8 +36,9 @@ public class ScenarioEvacuationSetupController {
                     훈련 시작점(startNodeId)을 하나의 요청, 하나의 트랜잭션으로 함께 저장합니다.
 
                     fireOriginGridCellId는 격자 셀 ID이고, startNodeId는 도면 관리에서 미리
-                    등록해 둔 NodeType.START 후보 노드 중 하나의 ID입니다. 이 API는 임의 좌표로
-                    새 노드를 만들지 않으며, 두 값은 반드시 같은 층·같은 건물에 있어야 합니다.
+                    등록해 둔 NodeType.START 후보 노드, 또는 isStartCandidate=true로 지정된
+                    DOOR 노드 중 하나의 ID입니다. 이 API는 임의 좌표로 새 노드를 만들지 않으며,
+                    두 값은 반드시 같은 층·같은 건물에 있어야 합니다.
 
                     시나리오 상태가 READY가 아니거나(작성이 아직 끝나지 않은 DRAFT 포함), 이미
                     발화점·시작점 설정이 완료된 시나리오에 다시 요청하면 실패합니다(409). 설정

--- a/src/main/java/com/saferoute/domain/training/service/ScenarioEvacuationSetupService.java
+++ b/src/main/java/com/saferoute/domain/training/service/ScenarioEvacuationSetupService.java
@@ -64,7 +64,9 @@ public class ScenarioEvacuationSetupService {
         if (!startNode.getFloor().getBuilding().getId().equals(buildingId)) {
             throw new ApiException(TrainingErrorCode.START_NODE_BUILDING_MISMATCH);
         }
-        if (startNode.getType() != NodeType.START) {
+        boolean validStartType = startNode.getType() == NodeType.START
+                || (startNode.getType() == NodeType.DOOR && startNode.isStartCandidate());
+        if (!validStartType) {
             throw new ApiException(TrainingErrorCode.START_NODE_TYPE_INVALID);
         }
         if (!cell.getFloor().getId().equals(startNode.getFloor().getId())) {

--- a/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
+++ b/src/main/java/com/saferoute/domain/training/service/TrainingSessionService.java
@@ -158,7 +158,9 @@ public class TrainingSessionService {
     if (startNode == null) {
       throw new ApiException(TrainingErrorCode.START_NODE_NOT_CONFIGURED);
     }
-    if (startNode.getType() != NodeType.START) {
+    boolean validStartType = startNode.getType() == NodeType.START
+        || (startNode.getType() == NodeType.DOOR && startNode.isStartCandidate());
+    if (!validStartType) {
       throw new ApiException(TrainingErrorCode.START_NODE_TYPE_INVALID);
     }
     List<FireZone> fireOrigins = fireZoneRepository

--- a/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/EvacuationErrorCode.java
@@ -18,7 +18,9 @@ public enum EvacuationErrorCode implements BaseErrorCode {
     EXIT_NODE_NOT_DESIGNATED(HttpStatus.NOT_FOUND, "EVAC007", "지정된 출구 노드가 없습니다."),
     ROUTE_RECALCULATION_NOT_FOUND(HttpStatus.NOT_FOUND, "EVAC008", "재탐색 요청을 찾을 수 없습니다."),
     INVALID_RECALCULATION_STATUS_TRANSITION(HttpStatus.CONFLICT, "EVAC009", "이미 처리된 재탐색 요청입니다."),
-    EXIT_NODE_UNSET_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVAC010", "마지막 출구 노드는 EXIT 대상에서 해제할 수 없습니다.");
+    EXIT_NODE_UNSET_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVAC010", "마지막 출구 노드는 EXIT 대상에서 해제할 수 없습니다."),
+    INVALID_MAP_EDGE_DISTANCE(HttpStatus.BAD_REQUEST, "EVAC011", "distance는 0보다 커야 합니다."),
+    START_CANDIDATE_ONLY_FOR_DOOR(HttpStatus.BAD_REQUEST, "EVAC012", "시작 후보 지정은 DOOR 타입 노드에만 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/saferoute/domain/evacuation/controller/MapGraphEditControllerTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/controller/MapGraphEditControllerTest.java
@@ -92,6 +92,7 @@ class MapGraphEditControllerTest {
                 "방1",
                 0.0,
                 0.0,
+                false,
                 false
         );
 
@@ -201,7 +202,8 @@ class MapGraphEditControllerTest {
                 "방1",
                 10.0,
                 20.0,
-                true
+                true,
+                false
         );
 
         given(

--- a/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
@@ -20,6 +20,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -94,16 +96,17 @@ class MapGraphRepositoryImplTest {
         assertThat(edges).hasSize(1);
     }
 
-    @Test
-    @DisplayName("distance가 0 이하면 400으로 거부된다")
-    void addEdge_nonPositiveDistance_throws() {
+    @ParameterizedTest
+    @ValueSource(doubles = {0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY})
+    @DisplayName("distance가 0 이하이거나 NaN/Infinity면 400으로 거부된다")
+    void addEdge_nonPositiveOrNonFiniteDistance_throws(double distance) {
         // given
         Floor floor = mock(Floor.class);
         MapNode from = mock(MapNode.class);
         MapNode to = mock(MapNode.class);
 
         // when & then
-        assertThatThrownBy(() -> mapGraphRepository.addEdge(floor, from, to, 0.0, true))
+        assertThatThrownBy(() -> mapGraphRepository.addEdge(floor, from, to, distance, true))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(EvacuationErrorCode.INVALID_MAP_EDGE_DISTANCE.getMessage());
         verify(mapEdgeJpaRepository, never()).save(any(MapEdge.class));

--- a/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/repository/MapGraphRepositoryImplTest.java
@@ -95,6 +95,21 @@ class MapGraphRepositoryImplTest {
     }
 
     @Test
+    @DisplayName("distance가 0 이하면 400으로 거부된다")
+    void addEdge_nonPositiveDistance_throws() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode from = mock(MapNode.class);
+        MapNode to = mock(MapNode.class);
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphRepository.addEdge(floor, from, to, 0.0, true))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.INVALID_MAP_EDGE_DISTANCE.getMessage());
+        verify(mapEdgeJpaRepository, never()).save(any(MapEdge.class));
+    }
+
+    @Test
     @DisplayName("ROOM 노드는 DOOR가 아닌 노드와 직접 연결할 수 없다")
     void addEdge_roomWithoutDoor_throws() {
         // given
@@ -163,6 +178,21 @@ class MapGraphRepositoryImplTest {
         assertThat(result.getX()).isEqualTo(10);
         assertThat(result.getY()).isEqualTo(20);
         assertThat(result.isExitTarget()).isTrue();
+        verify(mapNodeJpaRepository, never()).save(any(MapNode.class));
+    }
+
+    @Test
+    @DisplayName("DOOR 노드의 시작 후보 여부를 토글하면 dirty checking으로 반영된다 (save 호출 없음)")
+    void updateStartCandidate_success() {
+        // given
+        Floor floor = mock(Floor.class);
+        MapNode node = MapNode.create(floor, "DOOR1", NodeType.DOOR, "출입문", 0, 0, false);
+
+        // when
+        MapNode result = mapGraphRepository.updateStartCandidate(node, true);
+
+        // then
+        assertThat(result.isStartCandidate()).isTrue();
         verify(mapNodeJpaRepository, never()).save(any(MapNode.class));
     }
 

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceIntegrationTest.java
@@ -1,0 +1,79 @@
+package com.saferoute.domain.evacuation.graph.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.graph.dto.request.CreateMapEdgeRequest;
+import com.saferoute.domain.evacuation.graph.dto.request.UpdateMapNodePositionRequest;
+import com.saferoute.domain.evacuation.graph.dto.response.MapNodeResponse;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.dto.request.CreateOrUpdateFloorGridRequest;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+// 그리드가 생성된 층에서, 이미 엣지가 연결된 노드의 타입/EXIT 대상 여부를 PATCH로 바꿀 때
+// FloorGridService.recomputeEdgeGridCells가 LazyInitializationException 없이 끝나는지 검증한다.
+// Mockito 목으로는 이 버그(영속성 컨텍스트 clear 이후 지연 로딩 프록시 초기화 실패)를 재현할 수
+// 없어 실제 JPA/DB(H2)를 쓰는 통합 테스트로 둔다.
+@SpringBootTest
+class MapGraphServiceIntegrationTest {
+
+    @Autowired
+    private MapGraphService mapGraphService;
+
+    @Autowired
+    private BuildingRepository buildingRepository;
+
+    @Autowired
+    private FloorRepository floorRepository;
+
+    @Autowired
+    private MapNodeJpaRepository mapNodeJpaRepository;
+
+    @Autowired
+    private FloorGridService floorGridService;
+
+    @Test
+    @Transactional
+    @DisplayName("그리드/연결 엣지가 있는 STAIR 노드를 EXIT로 바꾸고 isExitTarget을 켜면 500 없이 성공한다")
+    void updateNodePosition_stairToExitWithGridAndEdge_succeeds() {
+        Building building = buildingRepository.save(
+                Building.create("공학관", "서울특별시 성북구 안전로 1", BuildingType.CLASSROOM, "SafeRoute School"));
+        Floor floor = floorRepository.save(Floor.create(building, 1));
+        floor.updateSegmentationStatus(SegmentationStatus.DONE);
+        floor.upload(10.0, 10.0, "floors/test-map.png");
+        floorRepository.save(floor);
+        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(0.5));
+
+        MapNode stair = mapNodeJpaRepository.save(
+                MapNode.create(floor, "STAIR_A", NodeType.STAIR, "계단A", 0.3, 0.3, false));
+        MapNode hallway = mapNodeJpaRepository.save(
+                MapNode.create(floor, "HALLWAY_A", NodeType.HALLWAY, "복도A", 0.5, 0.5, false));
+        // 엣지 생성 직후의 그리드 셀 재계산(MapEdgeGridCellRepository.deleteAllByMapEdgeId의
+        // clearAutomatically)이 영속성 컨텍스트를 비워, 아래 PATCH에서 다시 조회되는 MapEdge의
+        // fromNode/toNode가 지연 로딩 프록시가 되는 상황을 재현하는 데 필요하다.
+        mapGraphService.createEdge(new CreateMapEdgeRequest(stair.getId(), hallway.getId(), 5.0, true));
+
+        UpdateMapNodePositionRequest request =
+                new UpdateMapNodePositionRequest(0.3, 0.3, true, NodeType.EXIT);
+
+        MapNodeResponse[] response = new MapNodeResponse[1];
+        assertThatCode(() -> response[0] = mapGraphService.updateNodePosition(stair.getId(), request))
+                .doesNotThrowAnyException();
+
+        assertThat(response[0].type()).isEqualTo(NodeType.EXIT);
+        assertThat(response[0].isExitTarget()).isTrue();
+    }
+}

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceTest.java
@@ -322,6 +322,38 @@ class MapGraphServiceTest {
         assertThat(node.getCustomDeviceType()).isNull();
     }
 
+    // === updateStartCandidate ===
+
+    @Test
+    @DisplayName("DOOR 노드는 시작 후보 여부를 토글할 수 있다")
+    void updateStartCandidate_doorNode_success() {
+        // given
+        MapNode node = createNode("DOOR1", NodeType.DOOR);
+        given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
+        given(mapGraphRepository.updateStartCandidate(node, true)).willReturn(node);
+
+        // when
+        MapNodeResponse response = mapGraphService.updateStartCandidate(node.getId(), true);
+
+        // then
+        assertThat(response.id()).isEqualTo(node.getId());
+        verify(mapGraphRepository).updateStartCandidate(node, true);
+    }
+
+    @Test
+    @DisplayName("DOOR가 아닌 노드는 시작 후보로 지정할 수 없다")
+    void updateStartCandidate_notDoorNode_throws() {
+        // given
+        MapNode node = createNode("ROOM1", NodeType.ROOM);
+        given(mapGraphRepository.findNodeById(node.getId())).willReturn(Optional.of(node));
+
+        // when & then
+        assertThatThrownBy(() -> mapGraphService.updateStartCandidate(node.getId(), true))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(EvacuationErrorCode.START_CANDIDATE_ONLY_FOR_DOOR.getMessage());
+        verify(mapGraphRepository, never()).updateStartCandidate(any(), anyBoolean());
+    }
+
     // === deleteNode ===
 
     @Test


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #224 
- Branch:

## 주요 내용

- 계단 노드를 최종 탈출구로 지정시 오류, 관련 내용 수정
- 유도등 노드 삭제 api 오류 수정
- 문 노드 시작지점으로 바로 지정 가능하게 수정

## ✅ Check List

- [ ] 테스트 통과
- [ ] ./gradlew build 성공
- [ ] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * DOOR 유형 노드를 훈련 시작 후보로 지정하고 해제할 수 있습니다.
  * 지도 편집 API를 통해 시작 후보 상태를 변경하고 응답에서 확인할 수 있습니다.
  * 시작 후보로 지정된 DOOR 노드에서 훈련 및 대피 시나리오를 시작할 수 있습니다.

* **버그 수정**
  * 지도 연결선 생성 시 0 이하의 거리가 입력되지 않도록 검증을 추가했습니다.
  * 지도 편집 과정에서 연결선 생성 후에도 노드 정보를 안정적으로 수정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->