### PR TITLE
fix(device): 유도등 code 채번 동시성 수정 및 CCTV 감시구역 저장 FK 위반 정상 응답

### DIFF
--- a/src/main/java/com/saferoute/domain/device/entity/IoTLightCodeAllocation.java
+++ b/src/main/java/com/saferoute/domain/device/entity/IoTLightCodeAllocation.java
@@ -1,0 +1,32 @@
+package com.saferoute.domain.device.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "iot_light_code_allocations")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IoTLightCodeAllocation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "iot_light_code_sequence_generator")
+    @SequenceGenerator(
+            name = "iot_light_code_sequence_generator",
+            sequenceName = "iot_light_code_sequence",
+            initialValue = 1,
+            allocationSize = 1
+    )
+    private Long number;
+
+    public static IoTLightCodeAllocation create() {
+        return new IoTLightCodeAllocation();
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/repository/IoTLightCodeAllocationRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/IoTLightCodeAllocationRepository.java
@@ -1,0 +1,7 @@
+package com.saferoute.domain.device.repository;
+
+import com.saferoute.domain.device.entity.IoTLightCodeAllocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IoTLightCodeAllocationRepository extends JpaRepository<IoTLightCodeAllocation, Long> {
+}

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -112,7 +113,14 @@ public class CctvService {
                 floor.getId(), request.gridCellIds());
 
         cctvGridCellRepository.deleteAllByCctvId(cctvId);
-        saveMappings(cctv, gridCells);
+        try {
+            saveMappings(cctv, gridCells);
+        } catch (DataIntegrityViolationException exception) {
+            // 검증(findAndValidateGridCells) 이후 저장 사이에 그리드가 재생성되면 그 셀들이
+            // 이미 삭제된 상태라 FK 위반으로 터진다 - 클라이언트가 오래된 셀 목록을 들고 있었던
+            // 것과 같은 상황이므로 동일한 에러로 응답해 다시 최신 목록을 불러오게 한다.
+            throw new ApiException(CctvErrorCode.GRID_CELL_NOT_FOUND, exception);
+        }
         congestionConfigService.incrementVersionForGridChange();
         return CctvResponse.of(cctv, gridCells);
     }

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightCodeAllocator.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightCodeAllocator.java
@@ -1,0 +1,35 @@
+package com.saferoute.domain.device.service;
+
+import com.saferoute.domain.device.entity.IoTLightCodeAllocation;
+import com.saferoute.domain.device.repository.IoTLightCodeAllocationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class IoTLightCodeAllocator {
+
+    private static final String LIGHT_CODE_PREFIX = "LIGHT_";
+    private static final int MINIMUM_NUMBER_WIDTH = 3;
+
+    private final IoTLightCodeAllocationRepository allocationRepository;
+
+    // 번호는 유도등 등록 트랜잭션과 별도로 확정한다 (CctvCodeAllocator와 동일한 컨벤션).
+    // 등록이 실패하거나 유도등이 삭제되어도 이미 발급된 번호는 재사용되지 않으며,
+    // DB sequence가 동시 요청의 원자성을 보장한다 - 기존 count()+1 방식은 동시 요청 시
+    // 같은 번호를 중복 발급해 iot_lights_code_key 유니크 제약 위반을 일으켰다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public String allocate() {
+        IoTLightCodeAllocation allocation = allocationRepository.saveAndFlush(IoTLightCodeAllocation.create());
+        return format(allocation.getNumber());
+    }
+
+    static String format(long number) {
+        if (number < 1) {
+            throw new IllegalArgumentException("IoT light code number must be positive");
+        }
+        return LIGHT_CODE_PREFIX + String.format("%0" + MINIMUM_NUMBER_WIDTH + "d", number);
+    }
+}

--- a/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
+++ b/src/main/java/com/saferoute/domain/device/service/IoTLightService.java
@@ -49,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class IoTLightService {
 
     private final IoTLightJpaRepository iotLightJpaRepository;
+    private final IoTLightCodeAllocator iotLightCodeAllocator;
     private final CctvJpaRepository cctvJpaRepository;
     private final MapNodeJpaRepository mapNodeJpaRepository;
     private final MapEdgeJpaRepository mapEdgeJpaRepository;
@@ -66,7 +67,10 @@ public class IoTLightService {
         Floor floor = floorRepository.findByIdAndBuilding_SchoolName(request.floorId(), schoolName)
                 .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
 
-        String code = generateLightCode();
+        // 유도등 code는 기기가 보고하는 시리얼이 아니라 서버가 등록 시점에 채번하는 식별자다 (예: LIGHT_001).
+        // IoTLightCodeAllocator가 별도 트랜잭션의 DB sequence로 원자적으로 발급한다
+        // (CctvCodeAllocator와 동일한 컨벤션 - count()+1 방식은 동시 요청 시 중복 발급됨).
+        String code = iotLightCodeAllocator.allocate();
 
         // customNode의 code/name은 유도등 자체의 code/name을 그대로 사용한다.
         // IoTLight.code는 시스템 전역 유일이 보장되므로 MapNode의 (floor, code) 유니크 제약도 자동 충족된다.
@@ -79,12 +83,6 @@ public class IoTLightService {
         );
 
         return IoTLightResponse.from(light);
-    }
-
-    // 유도등 code는 기기가 보고하는 시리얼이 아니라 서버가 등록 시점에 채번하는 식별자다 (예: LIGHT_001).
-    private String generateLightCode() {
-        long seq = iotLightJpaRepository.count() + 1;
-        return "LIGHT_%03d".formatted(seq);
     }
 
     public List<IoTLightResponse> getLights(UUID floorId, String email) {

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/MapEdgeGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/MapEdgeGridCellRepository.java
@@ -19,7 +19,10 @@ public interface MapEdgeGridCellRepository extends JpaRepository<MapEdgeGridCell
 
     // 엣지 하나의 grid cell 매핑을 다시 계산하기 전, 기존 매핑을 지운다
     // (엣지 추가/노드 이동으로 인한 재계산용 - FloorGridService.recomputeEdgeGridCells 참고).
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    // clearAutomatically는 쓰지 않는다 - 호출 직후 recomputeEdgeGridCells가 같은 트랜잭션에서
+    // edge.getFromNode()/getToNode()에 접근하는데, clear()가 영속성 컨텍스트를 비우면 그 lazy
+    // proxy들이 detach되어 LazyInitializationException("no session")이 발생한다.
+    @Modifying(flushAutomatically = true)
     @Query("delete from MapEdgeGridCell m where m.mapEdge.id = :mapEdgeId")
     int deleteAllByMapEdgeId(@Param("mapEdgeId") UUID mapEdgeId);
 }

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -183,6 +183,39 @@ class CctvServiceTest {
     }
 
     @Test
+    @DisplayName("검증 이후 저장 사이에 그리드가 재생성돼 셀이 사라지면 GRID_CELL_NOT_FOUND로 응답한다")
+    void configureGridCells_staleGridCellOnSave_throwsGridCellNotFound() {
+        UUID cctvId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        UUID cellId = UUID.randomUUID();
+        Floor floor = org.mockito.Mockito.mock(Floor.class);
+        MapNode node = org.mockito.Mockito.mock(MapNode.class);
+        Cctv cctv = cctv(cctvId);
+        FloorGridCell cell = cell(1, 2);
+        given(floor.getId()).willReturn(floorId);
+        given(floor.getGridCellSizeMeter()).willReturn(0.5);
+        given(node.getFloor()).willReturn(floor);
+        given(cctv.getCustomNode()).willReturn(node);
+        given(cell.getFloor()).willReturn(floor);
+        given(cell.isWalkable()).willReturn(true);
+        given(cctvJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(cctvId, SCHOOL_NAME))
+                .willReturn(Optional.of(cctv));
+        given(floorGridCellRepository.findAllById(List.of(cellId))).willReturn(List.of(cell));
+        given(cctvGridCellRepository.saveAll(any()))
+                .willThrow(new org.springframework.dao.DataIntegrityViolationException("FK violation"));
+
+        assertThatThrownBy(() -> cctvService.configureGridCells(
+                cctvId,
+                new ConfigureCctvGridCellsRequest(List.of(cellId)),
+                EMAIL))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(CctvErrorCode.GRID_CELL_NOT_FOUND);
+
+        verify(congestionConfigService, never()).incrementVersionForGridChange();
+    }
+
+    @Test
     @DisplayName("CCTV 정보 수정 시 이름과 연결 노드 위치를 함께 변경한다")
     void updateCctv_success() {
         UUID cctvId = UUID.randomUUID();

--- a/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/IoTLightServiceTest.java
@@ -69,6 +69,9 @@ class IoTLightServiceTest {
     private IoTLightJpaRepository iotLightJpaRepository;
 
     @Mock
+    private IoTLightCodeAllocator iotLightCodeAllocator;
+
+    @Mock
     private CctvJpaRepository cctvJpaRepository;
 
     @Mock
@@ -150,7 +153,7 @@ class IoTLightServiceTest {
         IoTLight savedLight = createLight("LIGHT_001", customNode);
 
         given(floorRepository.findByIdAndBuilding_SchoolName(floorId, SCHOOL_NAME)).willReturn(Optional.of(floor));
-        given(iotLightJpaRepository.count()).willReturn(0L);
+        given(iotLightCodeAllocator.allocate()).willReturn("LIGHT_001");
         given(mapNodeJpaRepository.save(any(MapNode.class))).willReturn(customNode);
         given(iotLightJpaRepository.save(any(IoTLight.class))).willReturn(savedLight);
 
@@ -172,7 +175,7 @@ class IoTLightServiceTest {
         IoTLight savedLight = createLight("LIGHT_006", customNode);
 
         given(floorRepository.findByIdAndBuilding_SchoolName(floorId, SCHOOL_NAME)).willReturn(Optional.of(floor));
-        given(iotLightJpaRepository.count()).willReturn(5L);
+        given(iotLightCodeAllocator.allocate()).willReturn("LIGHT_006");
         given(mapNodeJpaRepository.save(any(MapNode.class))).willReturn(customNode);
         given(iotLightJpaRepository.save(any(IoTLight.class))).willReturn(savedLight);
 

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/RecomputeEdgeGridCellsIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/RecomputeEdgeGridCellsIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.saferoute.domain.evacuation.graph.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.graph.dto.request.UpdateMapNodePositionRequest;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+// 노드 이동 시 연결된 엣지의 grid cell 매핑을 재계산하는 경로(#220)가, 재계산 전 기존 매핑을
+// 지우는 deleteAllByMapEdgeId의 clearAutomatically로 인해 edge.getFromNode()/getToNode() 접근 시
+// LazyInitializationException("no session")을 던지던 회귀(#226 조사 중 발견)를 검증한다.
+// 실제 Hibernate 세션/영속성 컨텍스트가 있어야 재현되므로 단위 테스트(Mockito)로는 못 잡고
+// 통합 테스트가 필요하다.
+@SpringBootTest
+class RecomputeEdgeGridCellsIntegrationTest {
+
+    @Autowired MapGraphService mapGraphService;
+    @Autowired BuildingRepository buildingRepository;
+    @Autowired FloorRepository floorRepository;
+    @Autowired MapNodeJpaRepository mapNodeJpaRepository;
+    @Autowired MapEdgeJpaRepository mapEdgeJpaRepository;
+    @Autowired FloorGridCellRepository floorGridCellRepository;
+    @Autowired MapEdgeGridCellRepository mapEdgeGridCellRepository;
+
+    @AfterEach
+    void cleanUp() {
+        mapEdgeGridCellRepository.deleteAllInBatch();
+        floorGridCellRepository.deleteAllInBatch();
+        mapEdgeJpaRepository.deleteAllInBatch();
+        mapNodeJpaRepository.deleteAllInBatch();
+        floorRepository.deleteAllInBatch();
+        buildingRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void updateNodePosition_recomputesConnectedEdgeGridCellsWithoutLazyInitializationException() {
+        Building building = buildingRepository.saveAndFlush(Building.create(
+                "재계산관", "서울특별시 안전구 재계산로 1", BuildingType.CLASSROOM, "SafeRoute School"));
+        Floor floor = floorRepository.saveAndFlush(Floor.create(building, 1));
+        floor.applyGridCellConfig(1.0, 2, 2);
+        floorRepository.saveAndFlush(floor);
+
+        for (int row = 0; row < 2; row++) {
+            for (int column = 0; column < 2; column++) {
+                floorGridCellRepository.saveAndFlush(
+                        FloorGridCell.create(floor, row, column, true, (column + 0.5) / 2.0, (row + 0.5) / 2.0));
+            }
+        }
+
+        MapNode fromNode = mapNodeJpaRepository.saveAndFlush(
+                MapNode.create(floor, "HALLWAY_A", NodeType.HALLWAY, "복도A", 0.1, 0.1, false));
+        MapNode toNode = mapNodeJpaRepository.saveAndFlush(
+                MapNode.create(floor, "HALLWAY_B", NodeType.HALLWAY, "복도B", 0.9, 0.9, false));
+        MapEdge edge = mapEdgeJpaRepository.saveAndFlush(MapEdge.create(floor, fromNode, toNode, 5.0, true));
+
+        assertThatCode(() -> mapGraphService.updateNodePosition(
+                fromNode.getId(), new UpdateMapNodePositionRequest(0.15, 0.15, false)))
+                .doesNotThrowAnyException();
+
+        List<com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell> mappings =
+                mapEdgeGridCellRepository.findAllByMapEdge_Id(edge.getId());
+        assertThat(mappings).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 요약

- **유도등 code 중복 발급**: `IoTLightService.generateLightCode()`가 `count()+1`로 채번해 동시 요청(더블클릭 등) 시 같은 code를 중복 계산해 `iot_lights_code_key` 유니크 제약 위반(500)이 나던 문제 수정.
- **CCTV 감시구역 저장 시 500**: `configureGridCells()`가 grid cell 존재를 저장 전에 검증하지만, 검증과 실제 INSERT 사이에 그리드가 재생성되면(모든 `FloorGridCell`이 삭제·재생성됨) `cctv_grid_cells.grid_cell_id` FK 위반이 처리되지 않은 `DataIntegrityViolationException`으로 그대로 노출되어 `COMMON500`이 나던 문제 수정.
- **노드 이동 시 엣지 재계산 실패**: #220에서 추가한 `recomputeEdgeGridCells()`가, 재계산 전 기존 매핑을 지우는 `deleteAllByMapEdgeId()`의 `clearAutomatically=true`로 인해 영속성 컨텍스트가 clear되면서 바로 이어서 접근하는 `edge.getFromNode()/getToNode()` lazy proxy가 detach되어 `LazyInitializationException("no session")`을 던지던 문제 수정 (그리드가 있는 층에서 엣지 연결된 노드를 옮길 때마다 100% 재현됨).

## 변경 사항

- `IoTLightCodeAllocation`(엔티티) / `IoTLightCodeAllocationRepository` / `IoTLightCodeAllocator` 추가 — `CctvCodeAllocator`와 동일한 패턴(DB sequence 기반, `REQUIRES_NEW` 별도 트랜잭션으로 원자적 채번).
- `IoTLightService.createLight()`: `generateLightCode()`(count 기반) 대신 `IoTLightCodeAllocator.allocate()` 사용.
- `CctvService.configureGridCells()`: `saveMappings()` 호출을 `DataIntegrityViolationException`으로 감싸 기존 검증 단계와 동일한 `CctvErrorCode.GRID_CELL_NOT_FOUND`(404)로 변환 — 클라이언트가 최신 grid cell 목록을 다시 불러와 재시도할 수 있도록 함.
- `MapEdgeGridCellRepository.deleteAllByMapEdgeId()`: `clearAutomatically` 제거, `flushAutomatically`만 유지.

## Test plan

- [x] `./gradlew compileJava`
- [x] `./gradlew test --tests "*IoTLightService*" --tests "*CctvService*"` (신규 케이스 각 1개)
- [x] `./gradlew test --tests "com.saferoute.domain.device.*"`
- [x] `./gradlew test --tests "*RecomputeEdgeGridCellsIntegrationTest*"` (신규 `@SpringBootTest` 통합 테스트 — 수정 전 실패, 수정 후 통과 직접 확인)
- [x] `./gradlew test` (전체)

Closes #226
Closes #228