### PR TITLE
chore(config): FloorGridCell 저장에 JDBC 배치 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,13 @@ spring:
       hibernate:
         jdbc:
           time_zone: UTC
+          # 배치 크기 미설정 시 Hibernate가 saveAll()도 INSERT를 한 건씩 보낸다.
+          # 그리드 생성/재생성(FloorGridService)이 셀 크기를 작게 잡을수록(예: 1m 미만)
+          # FloorGridCell을 수만~수십만 건 saveAll()로 저장하는데, 배치가 없으면 이게
+          # 왕복 지연만큼 느려져서 요청이 타임아웃되고 "그리드가 안 불러와짐"으로 보인다.
+          batch_size: 100
+        order_inserts: true
+        order_updates: true
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 요약

도면 업로드 후 그리드 셀 크기를 1m 미만으로 잡으면 그리드가 생성/조회되지 않는다고 보고했습니다. `hibernate.jdbc.batch_size`가 설정되어 있지 않아 `FloorGridService.createOrRegenerateGrid()`의 `floorGridCellRepository.saveAll(cells)`가 INSERT를 한 건씩 보내는 게 원인으로 추정됩니다. `cellSizeMeter`가 작을수록 셀 개수가 제곱으로 늘어나므로(예: 60m×30m 층: 1m→1,800개, 0.5m→7,200개, 실제 대형 층은 수만 개 이상), 배치 없이 반복하면 요청이 오래 걸려 타임아웃될 수 있습니다.

## 변경 사항

`application.yml`에 추가:
```yaml
spring:
  jpa:
    properties:
      hibernate:
        jdbc:
          batch_size: 100
        order_inserts: true
        order_updates: true
```

`FloorGridCell.id`는 `@GeneratedValue`(UUID, 클라이언트 사이드 생성)라 IDENTITY 전략이 아니어서 배치 적용에 문제없습니다.

## 참고

추정 원인에 대한 선제적 개선이라, 배포 후에도 1m 미만에서 문제가 재현되면 프론트엔드 쪽(자동 배율 계산/렌더링) 원인일 가능성이 남아 있습니다.

## Test plan

- [x] `./gradlew compileJava`
- [x] `./gradlew test --tests "*FloorGridService*" --tests "*RecomputeEdgeGridCellsIntegrationTest*"`
- [x] `./gradlew test` (전체)

Closes #229