### PR TITLE
fix(device): CCTV 등록/감시구역 저장의 지연 flush로 FK 위반이 안 잡히던 문제 수정

### DIFF
--- a/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/device/repository/CctvGridCellRepository.java
@@ -28,7 +28,11 @@ public interface CctvGridCellRepository extends JpaRepository<CctvGridCell, UUID
             """)
     List<CctvGridCell> findAllByCctvIdsWithGridCell(@Param("cctvIds") List<UUID> cctvIds);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    // clearAutomatically는 쓰지 않는다 - 호출 직후 configureGridCells가 같은 트랜잭션에서
+    // cctv/gridCells 엔티티를 계속 참조하는데, clear()가 영속성 컨텍스트를 비우면 그 엔티티들이
+    // detach되어 이후 새 CctvGridCell 저장 시 예기치 않은 동작을 일으킬 수 있다
+    // (MapEdgeGridCellRepository.deleteAllByMapEdgeId와 동일한 이슈, #228 참고).
+    @Modifying(flushAutomatically = true)
     @Query("delete from CctvGridCell mapping where mapping.cctv.id = :cctvId")
     int deleteAllByCctvId(@Param("cctvId") UUID cctvId);
 }

--- a/src/main/java/com/saferoute/domain/device/service/CctvRegistrationService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvRegistrationService.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,11 +65,21 @@ public class CctvRegistrationService {
         Cctv cctv = Cctv.create(code, request.name(), customNode);
         cctv.issueDeviceToken(issuedToken.hash());
         Cctv savedCctv = cctvJpaRepository.save(cctv);
-        cctvGridCellRepository.saveAll(
-                gridCells.stream()
-                        .map(cell -> CctvGridCell.create(savedCctv, cell))
-                        .toList()
-        );
+        try {
+            // saveAll()만으로는 실제 INSERT가 트랜잭션 커밋 시점까지 미뤄져 이 try/catch
+            // 밖(JpaTransactionManager.doCommit)에서 예외가 터진다 - saveAllAndFlush로
+            // 즉시 flush해서 검증(findAndValidateGridCells) 이후 그리드가 재생성돼 그 셀들이
+            // 이미 삭제된 경우의 FK 위반을 여기서 잡는다.
+            cctvGridCellRepository.saveAllAndFlush(
+                    gridCells.stream()
+                            .map(cell -> CctvGridCell.create(savedCctv, cell))
+                            .toList()
+            );
+        } catch (DataIntegrityViolationException exception) {
+            // CctvService.configureGridCells와 동일한 상황이므로 같은 에러로 응답해
+            // 최신 목록을 다시 불러오게 한다.
+            throw new ApiException(CctvErrorCode.GRID_CELL_NOT_FOUND, exception);
+        }
         congestionConfigService.incrementVersionForGridChange();
 
         return new CctvRegistrationResponse(

--- a/src/main/java/com/saferoute/domain/device/service/CctvService.java
+++ b/src/main/java/com/saferoute/domain/device/service/CctvService.java
@@ -188,7 +188,10 @@ public class CctvService {
     }
 
     private void saveMappings(Cctv cctv, List<FloorGridCell> gridCells) {
-        cctvGridCellRepository.saveAll(
+        // saveAll()만으로는 실제 INSERT가 트랜잭션 커밋 시점까지 미뤄져 configureGridCells의
+        // try/catch 밖(JpaTransactionManager.doCommit)에서 예외가 터진다 - saveAllAndFlush로
+        // 즉시 flush해서 검증 이후 그리드 재생성으로 인한 FK 위반을 여기서 잡는다.
+        cctvGridCellRepository.saveAllAndFlush(
                 gridCells.stream()
                         .map(cell -> CctvGridCell.create(cctv, cell))
                         .toList()

--- a/src/test/java/com/saferoute/domain/device/service/CctvRegistrationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvRegistrationServiceTest.java
@@ -88,9 +88,33 @@ class CctvRegistrationServiceTest {
         assertThat(response.cctv().gridCells()).extracting("id").containsExactly(firstId, secondId);
         assertThat(response.deviceToken()).isEqualTo("raw-token");
         ArgumentCaptor<List<CctvGridCell>> mappings = ArgumentCaptor.forClass(List.class);
-        verify(cctvGridCellRepository).saveAll(mappings.capture());
+        verify(cctvGridCellRepository).saveAllAndFlush(mappings.capture());
         assertThat(mappings.getValue()).hasSize(2);
         verify(congestionConfigService).incrementVersionForGridChange();
+    }
+
+    @Test
+    @DisplayName("검증 이후 실제 저장 사이에 그리드가 재생성돼 셀이 사라지면 GRID_CELL_NOT_FOUND로 응답한다")
+    void register_staleGridCellOnSave_throwsGridCellNotFound() {
+        UUID cellId = UUID.randomUUID();
+        FloorGridCell cell = cell(cellId, floor, 0, 0, true);
+        CreateCctvRequest request = request(List.of(cellId));
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(floorGridCellRepository.findAllById(request.gridCellIds())).willReturn(List.of(cell));
+        given(mapNodeJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(cctvJpaRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(deviceTokenService.issue()).willReturn(
+                new DeviceTokenService.IssuedDeviceToken("raw-token", "hashed-token")
+        );
+        given(cctvGridCellRepository.saveAllAndFlush(any()))
+                .willThrow(new org.springframework.dao.DataIntegrityViolationException("FK violation"));
+
+        assertThatThrownBy(() -> service.register(request, "CCTV_001"))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(CctvErrorCode.GRID_CELL_NOT_FOUND);
+
+        verify(congestionConfigService, never()).incrementVersionForGridChange();
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
+++ b/src/test/java/com/saferoute/domain/device/service/CctvServiceTest.java
@@ -178,7 +178,7 @@ class CctvServiceTest {
         );
 
         verify(cctvGridCellRepository).deleteAllByCctvId(cctvId);
-        verify(cctvGridCellRepository).saveAll(any());
+        verify(cctvGridCellRepository).saveAllAndFlush(any());
         verify(congestionConfigService).incrementVersionForGridChange();
     }
 
@@ -201,7 +201,7 @@ class CctvServiceTest {
         given(cctvJpaRepository.findByIdAndCustomNode_Floor_Building_SchoolName(cctvId, SCHOOL_NAME))
                 .willReturn(Optional.of(cctv));
         given(floorGridCellRepository.findAllById(List.of(cellId))).willReturn(List.of(cell));
-        given(cctvGridCellRepository.saveAll(any()))
+        given(cctvGridCellRepository.saveAllAndFlush(any()))
                 .willThrow(new org.springframework.dao.DataIntegrityViolationException("FK violation"));
 
         assertThatThrownBy(() -> cctvService.configureGridCells(


### PR DESCRIPTION
## 요약

#226/#227에서 `CctvService.configureGridCells()`에 grid cell FK 위반을 `GRID_CELL_NOT_FOUND`(404)로 변환하는 try/catch를 추가했지만, 배포 후에도 실제 운영에서 raw `COMMON500`이 재현됐습니다.

**원인**: `saveAll()`은 INSERT를 즉시 실행하지 않고 같은 트랜잭션의 이후 flush(보통 트랜잭션 커밋 시점)로 미룹니다. `configureGridCells()`/`CctvRegistrationService.register()`는 각자 자신의 `@Transactional` 메서드 안에서 `saveAll()`을 호출하므로, 실제 FK 위반은 그 메서드가 끝나고 트랜잭션이 커밋되는 시점(`JpaTransactionManager.doCommit`)에 터집니다 — 이미 try/catch 밖이라 잡히지 않고 그대로 `Unhandled exception`으로 나갔습니다. CCTV **등록**(`CctvRegistrationService.register()`)에는 이 처리 자체가 아예 없어서 처음부터 매번 500이었습니다.

## 변경 사항

- `CctvService.saveMappings()`: `cctvGridCellRepository.saveAll()` → `saveAllAndFlush()`로 교체해 try/catch 안에서 즉시 잡히게 함.
- `CctvRegistrationService.register()`: 동일하게 `saveAllAndFlush()` + try/catch(`GRID_CELL_NOT_FOUND` 변환) 추가.
- `CctvGridCellRepository.deleteAllByCctvId()`: `clearAutomatically` 제거 (`MapEdgeGridCellRepository.deleteAllByMapEdgeId`, #228과 동일한 이유 - delete 직후 같은 트랜잭션에서 계속 참조하는 `cctv`/`gridCells` 엔티티가 detach되는 것을 방지).

## 참고

`saveAll()`의 flush 지연이 "같은 메서드의 try/catch 안에서 잡히는지 여부"를 가르는 핵심이라, 이 타이밍 자체는 Mockito 단위 테스트로는 검증이 안 됩니다 (mock은 flush 타이밍을 흉내내지 않고 호출 즉시 예외를 던지므로, 기존 단위 테스트가 이 회귀를 못 잡았던 이유이기도 합니다). 실제 프로덕션 로그로 원인을 확인했고, 단위 테스트는 "예외를 잡아서 올바른 에러 코드로 변환하는지"까지만 검증합니다.

## Test plan

- [x] `./gradlew compileJava`
- [x] `./gradlew test --tests "*CctvService*" --tests "*CctvRegistrationService*"` (신규 케이스: `CctvRegistrationServiceTest.register_staleGridCellOnSave_throwsGridCellNotFound`)
- [x] `./gradlew test` (전체)

Closes #232