### PR TITLE
[Fix] #231: AI 분석 후 노드·엣지의 그리드 매핑이 누락되는 문제

### DIFF
--- a/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisResultService.java
+++ b/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisResultService.java
@@ -1,0 +1,97 @@
+package com.saferoute.domain.analysis.service;
+
+import com.saferoute.domain.analysis.dto.AnalyseFloorResponse;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.AnalysisErrorCode;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FloorAnalysisResultService {
+
+    private final FloorRepository floorRepository;
+    private final MapNodeJpaRepository mapNodeRepository;
+    private final MapEdgeJpaRepository mapEdgeRepository;
+    private final FloorGridService floorGridService;
+
+    @Transactional
+    public void persistAnalysisResult(UUID floorId, AnalyseFloorResponse response) {
+        Floor floor = floorRepository.findByIdForUpdate(floorId)
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+
+        validateGraphIntegrity(response);
+        replaceExistingGraph(floor);
+
+        Map<String, MapNode> tempIdToNode = new HashMap<>();
+        for (var nodeResponse : response.nodes()) {
+            NodeType type = NodeType.valueOf(nodeResponse.type());
+            MapNode node = MapNode.create(
+                    floor, nodeResponse.code(), type, defaultNameFor(type),
+                    nodeResponse.x(), nodeResponse.y(), false);
+            mapNodeRepository.save(node);
+            tempIdToNode.put(nodeResponse.tempId(), node);
+        }
+
+        for (var edgeResponse : response.edges()) {
+            MapEdge edge = MapEdge.create(
+                    floor,
+                    tempIdToNode.get(edgeResponse.fromTempId()),
+                    tempIdToNode.get(edgeResponse.toTempId()),
+                    edgeResponse.distance(),
+                    edgeResponse.bidirectional());
+            mapEdgeRepository.save(edge);
+        }
+
+        // 아래 bulk delete가 영속성 컨텍스트를 비우기 전에 변경 상태를 flush하도록 먼저 반영한다.
+        floor.applyPlanSize(response.planWidthPx(), response.planHeightPx());
+        floor.updateSegmentationStatus(SegmentationStatus.DONE);
+        floorGridService.remapGraphToExistingGrid(floorId);
+    }
+
+    private void validateGraphIntegrity(AnalyseFloorResponse response) {
+        Set<String> tempIds = new HashSet<>();
+        for (var nodeResponse : response.nodes()) {
+            if (!tempIds.add(nodeResponse.tempId())) {
+                throw new ApiException(AnalysisErrorCode.AI_ANALYSIS_INVALID_GRAPH);
+            }
+        }
+        for (var edgeResponse : response.edges()) {
+            if (!tempIds.contains(edgeResponse.fromTempId())
+                    || !tempIds.contains(edgeResponse.toTempId())) {
+                throw new ApiException(AnalysisErrorCode.AI_ANALYSIS_INVALID_GRAPH);
+            }
+        }
+    }
+
+    private void replaceExistingGraph(Floor floor) {
+        mapEdgeRepository.deleteAllByFloor(floor);
+        mapNodeRepository.deleteAllByFloor(floor);
+    }
+
+    private String defaultNameFor(NodeType type) {
+        return switch (type) {
+            case ROOM -> "방";
+            case HALLWAY -> "복도";
+            case STAIR -> "계단";
+            case DOOR -> "문";
+            default -> "노드";
+        };
+    }
+}

--- a/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisService.java
+++ b/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisService.java
@@ -7,6 +7,7 @@ import com.saferoute.domain.evacuation.graph.entity.MapEdge;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
 import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.entity.SegmentationStatus;
 import com.saferoute.domain.floor.repository.FloorRepository;
@@ -30,6 +31,7 @@ public class FloorAnalysisService {
   private final MapNodeJpaRepository mapNodeRepository;
   private final MapEdgeJpaRepository mapEdgeRepository;
   private final AiAnalysisClient aiAnalysisClient;
+  private final FloorGridService floorGridService;
 
   public void analyzeFloor(UUID floorId) {
     Floor floor = floorRepository.findById(floorId)
@@ -85,6 +87,7 @@ public class FloorAnalysisService {
     }
 
     floor.applyPlanSize(response.planWidthPx(), response.planHeightPx());
+    floorGridService.remapGraphToExistingGrid(floorId);
     floor.updateSegmentationStatus(SegmentationStatus.DONE);
   }
 

--- a/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisService.java
+++ b/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisService.java
@@ -2,36 +2,23 @@ package com.saferoute.domain.analysis.service;
 
 import com.saferoute.domain.analysis.dto.AnalyseFloorResponse;
 import com.saferoute.domain.analysis.AiAnalysisClient;
-import com.saferoute.domain.evacuation.graph.entity.MapNode;
-import com.saferoute.domain.evacuation.graph.entity.MapEdge;
-import com.saferoute.domain.evacuation.graph.entity.NodeType;
-import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
-import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
-import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.domain.floor.entity.Floor;
-import com.saferoute.domain.floor.entity.SegmentationStatus;
 import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.AnalysisErrorCode;
 import com.saferoute.global.api.exception.ApiException;
 import com.saferoute.global.api.error.FloorErrorCode;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class FloorAnalysisService {
 
   private final FloorRepository floorRepository;
-  private final MapNodeJpaRepository mapNodeRepository;
-  private final MapEdgeJpaRepository mapEdgeRepository;
   private final AiAnalysisClient aiAnalysisClient;
-  private final FloorGridService floorGridService;
+  private final FloorAnalysisResultService resultService;
+  private final FloorAnalysisStatusService statusService;
 
   public void analyzeFloor(UUID floorId) {
     Floor floor = floorRepository.findById(floorId)
@@ -43,81 +30,21 @@ public class FloorAnalysisService {
           floor.getMapImageKey(), floor.getRealWidth(), floor.getRealHeight()
       );
     } catch (Exception e) {
-      markAsFailed(floorId);   // 짧은 트랜잭션
+      statusService.markAsFailed(floorId);
       throw new ApiException(AnalysisErrorCode.AI_ANALYSIS_FAILED);
     }
 
     try {
-      persistAnalysisResult(floorId, response);   // 짧은 트랜잭션
+      resultService.persistAnalysisResult(floorId, response);
     } catch (Exception e) {
-      markAsFailed(floorId);
+      // 결과 저장 트랜잭션이 롤백된 뒤 별도 트랜잭션으로 실패 상태를 남긴다.
+      statusService.markAsFailed(floorId);
       throw e;
     }
   }
 
-  @Transactional
-  public void markAsFailed(UUID floorId) {
-    Floor floor = floorRepository.findById(floorId)
-        .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
-    floor.updateSegmentationStatus(SegmentationStatus.FAILED);
-  }
-
-  @Transactional
+  // 기존 내부/테스트 호출 경로를 유지하면서 실제 트랜잭션은 별도 Spring bean에서 시작한다.
   public void persistAnalysisResult(UUID floorId, AnalyseFloorResponse response) {
-    Floor floor = floorRepository.findById(floorId)
-        .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
-
-    validateGraphIntegrity(response);
-    replaceExistingGraph(floor);
-
-    Map<String, MapNode> tempIdToNode = new HashMap<>();
-    for (var n : response.nodes()) {
-      NodeType type = NodeType.valueOf(n.type());
-      MapNode node = MapNode.create(floor, n.code(), type, defaultNameFor(type), n.x(), n.y(), false);
-      mapNodeRepository.save(node);
-      tempIdToNode.put(n.tempId(), node);
-    }
-
-    for (var e : response.edges()) {
-      MapEdge edge = MapEdge.create(
-          floor, tempIdToNode.get(e.fromTempId()), tempIdToNode.get(e.toTempId()),
-          e.distance(), e.bidirectional()
-      );
-      mapEdgeRepository.save(edge);
-    }
-
-    floor.applyPlanSize(response.planWidthPx(), response.planHeightPx());
-    floorGridService.remapGraphToExistingGrid(floorId);
-    floor.updateSegmentationStatus(SegmentationStatus.DONE);
-  }
-
-  private void validateGraphIntegrity(AnalyseFloorResponse response) {
-    Set<String> tempIds = new HashSet<>();
-    for (var n : response.nodes()) {
-      if (!tempIds.add(n.tempId())) {
-        throw new ApiException(AnalysisErrorCode.AI_ANALYSIS_INVALID_GRAPH);
-      }
-    }
-    for (var e : response.edges()) {
-      if (!tempIds.contains(e.fromTempId()) || !tempIds.contains(e.toTempId())) {
-        throw new ApiException(AnalysisErrorCode.AI_ANALYSIS_INVALID_GRAPH);
-      }
-    }
-  }
-
-  private void replaceExistingGraph(Floor floor) {
-    // 엣지 먼저 (FK가 노드를 참조하니까), 그 다음 노드
-    mapEdgeRepository.deleteAllByFloor(floor);
-    mapNodeRepository.deleteAllByFloor(floor);
-  }
-
-  private String defaultNameFor(NodeType type) {
-    return switch (type) {
-      case ROOM -> "방";
-      case HALLWAY -> "복도";
-      case STAIR -> "계단";
-      case DOOR -> "문";
-      default -> "노드";
-    };
+    resultService.persistAnalysisResult(floorId, response);
   }
 }

--- a/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisService.java
+++ b/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisService.java
@@ -84,7 +84,7 @@ public class FloorAnalysisService {
       mapEdgeRepository.save(edge);
     }
 
-    floor.applyGridConfig(null, null, null, response.planWidthPx(), response.planHeightPx());
+    floor.applyPlanSize(response.planWidthPx(), response.planHeightPx());
     floor.updateSegmentationStatus(SegmentationStatus.DONE);
   }
 

--- a/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisStatusService.java
+++ b/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisStatusService.java
@@ -20,7 +20,7 @@ public class FloorAnalysisStatusService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markAsProcessing(UUID floorId, String schoolName) {
-        Floor floor = floorRepository.findByIdAndBuilding_SchoolName(floorId, schoolName)
+        Floor floor = floorRepository.findByIdAndBuildingSchoolNameForUpdate(floorId, schoolName)
                 .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
 
         if (floor.getMapImageKey() == null) {

--- a/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisStatusService.java
+++ b/src/main/java/com/saferoute/domain/analysis/service/FloorAnalysisStatusService.java
@@ -1,0 +1,42 @@
+package com.saferoute.domain.analysis.service;
+
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.AnalysisErrorCode;
+import com.saferoute.global.api.error.FloorErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FloorAnalysisStatusService {
+
+    private final FloorRepository floorRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markAsProcessing(UUID floorId, String schoolName) {
+        Floor floor = floorRepository.findByIdAndBuilding_SchoolName(floorId, schoolName)
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+
+        if (floor.getMapImageKey() == null) {
+            throw new ApiException(FloorErrorCode.FLOOR_NOT_FOUND);
+        }
+        if (floor.getSegmentationStatus() == SegmentationStatus.PROCESSING) {
+            throw new ApiException(AnalysisErrorCode.ANALYSIS_ALREADY_IN_PROGRESS);
+        }
+
+        floor.updateSegmentationStatus(SegmentationStatus.PROCESSING);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markAsFailed(UUID floorId) {
+        Floor floor = floorRepository.findById(floorId)
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+        floor.updateSegmentationStatus(SegmentationStatus.FAILED);
+    }
+}

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/MapEdgeGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/MapEdgeGridCellRepository.java
@@ -17,6 +17,9 @@ public interface MapEdgeGridCellRepository extends JpaRepository<MapEdgeGridCell
 
     List<MapEdgeGridCell> findAllByMapEdge_Id(UUID mapEdgeId);
 
+    // AI 분석으로 층 그래프 전체가 교체된 뒤 기존 매핑만 정리하고 다시 계산할 때 사용
+    void deleteAllByMapEdge_Floor_Id(UUID floorId);
+
     // 엣지 하나의 grid cell 매핑을 다시 계산하기 전, 기존 매핑을 지운다
     // (엣지 추가/노드 이동으로 인한 재계산용 - FloorGridService.recomputeEdgeGridCells 참고).
     // clearAutomatically는 쓰지 않는다 - 호출 직후 recomputeEdgeGridCells가 같은 트랜잭션에서

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/MapEdgeGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/MapEdgeGridCellRepository.java
@@ -18,7 +18,9 @@ public interface MapEdgeGridCellRepository extends JpaRepository<MapEdgeGridCell
     List<MapEdgeGridCell> findAllByMapEdge_Id(UUID mapEdgeId);
 
     // AI 분석으로 층 그래프 전체가 교체된 뒤 기존 매핑만 정리하고 다시 계산할 때 사용
-    void deleteAllByMapEdge_Floor_Id(UUID floorId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from MapEdgeGridCell m where m.mapEdge.floor.id = :floorId")
+    int deleteAllByMapEdgeFloorId(@Param("floorId") UUID floorId);
 
     // 엣지 하나의 grid cell 매핑을 다시 계산하기 전, 기존 매핑을 지운다
     // (엣지 추가/노드 이동으로 인한 재계산용 - FloorGridService.recomputeEdgeGridCells 참고).

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/NodeGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/NodeGridCellRepository.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NodeGridCellRepository extends JpaRepository<NodeGridCell, UUID> {
 
@@ -18,5 +21,7 @@ public interface NodeGridCellRepository extends JpaRepository<NodeGridCell, UUID
     List<NodeGridCell> findAllByNode_IdIn(List<UUID> nodeIds);
 
     // AI 분석으로 층 그래프 전체가 교체된 뒤 기존 매핑만 정리하고 다시 계산할 때 사용
-    void deleteAllByNode_Floor_Id(UUID floorId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from NodeGridCell n where n.node.floor.id = :floorId")
+    int deleteAllByNodeFloorId(@Param("floorId") UUID floorId);
 }

--- a/src/main/java/com/saferoute/domain/evacuation/grid/repository/NodeGridCellRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/repository/NodeGridCellRepository.java
@@ -16,4 +16,7 @@ public interface NodeGridCellRepository extends JpaRepository<NodeGridCell, UUID
 
     // 혼잡도 처리 시 CCTV customNode -> 셀 조회용
     List<NodeGridCell> findAllByNode_IdIn(List<UUID> nodeIds);
+
+    // AI 분석으로 층 그래프 전체가 교체된 뒤 기존 매핑만 정리하고 다시 계산할 때 사용
+    void deleteAllByNode_Floor_Id(UUID floorId);
 }

--- a/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
@@ -197,6 +197,28 @@ public class FloorGridService {
         mapEdgeGridCellRepository.saveAll(mappings);
     }
 
+    // AI 분석으로 노드/엣지가 교체된 뒤 기존 그리드에 전체 그래프를 다시 매핑한다.
+    @Transactional
+    public void remapGraphToExistingGrid(UUID floorId) {
+        Floor floor = floorRepository.findById(floorId)
+                .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
+        Integer rows = floor.getGridRows();
+        Integer columns = floor.getGridColumns();
+        if (rows == null || columns == null) {
+            return;
+        }
+
+        List<FloorGridCell> cells = floorGridCellRepository.findAllByFloor_Id(floorId);
+        if ((long) cells.size() != (long) rows * columns) {
+            throw new ApiException(GridErrorCode.GRID_CELL_NOT_FOUND);
+        }
+
+        mapEdgeGridCellRepository.deleteAllByMapEdge_Floor_Id(floorId);
+        nodeGridCellRepository.deleteAllByNode_Floor_Id(floorId);
+        remapNodesToGrid(mapNodeRepository.findAllByFloor_Id(floorId), cells, rows, columns);
+        remapEdgesToGrid(mapEdgeRepository.findAllByFloor_Id(floorId), cells, rows, columns);
+    }
+
     // 엣지 하나의 grid cell 매핑만 다시 계산한다 (엣지 추가, 연결된 노드 이동 시 호출).
     // 그리드가 아직 생성 안 된 층이면 매핑할 셀이 없으므로 조용히 넘어간다 - createOrRegenerateGrid가
     // 호출될 때 그 시점의 전체 엣지를 기준으로 다시 계산해준다.

--- a/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
@@ -200,7 +200,7 @@ public class FloorGridService {
     // AI 분석으로 노드/엣지가 교체된 뒤 기존 그리드에 전체 그래프를 다시 매핑한다.
     @Transactional
     public void remapGraphToExistingGrid(UUID floorId) {
-        Floor floor = floorRepository.findById(floorId)
+        Floor floor = floorRepository.findByIdForUpdate(floorId)
                 .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
         Integer rows = floor.getGridRows();
         Integer columns = floor.getGridColumns();
@@ -213,8 +213,8 @@ public class FloorGridService {
             throw new ApiException(GridErrorCode.GRID_CELL_NOT_FOUND);
         }
 
-        mapEdgeGridCellRepository.deleteAllByMapEdge_Floor_Id(floorId);
-        nodeGridCellRepository.deleteAllByNode_Floor_Id(floorId);
+        mapEdgeGridCellRepository.deleteAllByMapEdgeFloorId(floorId);
+        nodeGridCellRepository.deleteAllByNodeFloorId(floorId);
         remapNodesToGrid(mapNodeRepository.findAllByFloor_Id(floorId), cells, rows, columns);
         remapEdgesToGrid(mapEdgeRepository.findAllByFloor_Id(floorId), cells, rows, columns);
     }

--- a/src/main/java/com/saferoute/domain/floor/entity/Floor.java
+++ b/src/main/java/com/saferoute/domain/floor/entity/Floor.java
@@ -119,6 +119,13 @@ public class Floor {
     this.planHeightPx = planHeightPx;
   }
 
+  // AI 분석 결과의 원본 도면 픽셀 크기만 반영한다.
+  // 도면 업로드 직후 생성된 그리드 설정은 분석 이후에도 유지되어야 한다.
+  public void applyPlanSize(Integer planWidthPx, Integer planHeightPx) {
+    this.planWidthPx = planWidthPx;
+    this.planHeightPx = planHeightPx;
+  }
+
   public void applyGridCellConfig(double cellSizeMeter, int gridRows, int gridColumns) {
     this.gridCellSizeMeter = cellSizeMeter;
     this.gridRows = gridRows;

--- a/src/main/java/com/saferoute/domain/floor/repository/FloorRepository.java
+++ b/src/main/java/com/saferoute/domain/floor/repository/FloorRepository.java
@@ -21,4 +21,8 @@ public interface FloorRepository extends JpaRepository<Floor, UUID> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select f from Floor f where f.id = :id")
     Optional<Floor> findByIdForUpdate(UUID id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select f from Floor f join f.building b where f.id = :id and b.schoolName = :schoolName")
+    Optional<Floor> findByIdAndBuildingSchoolNameForUpdate(UUID id, String schoolName);
 }

--- a/src/main/java/com/saferoute/domain/floor/service/FloorService.java
+++ b/src/main/java/com/saferoute/domain/floor/service/FloorService.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.floor.service;
 
 import com.saferoute.domain.analysis.service.FloorAnalysisService;
+import com.saferoute.domain.analysis.service.FloorAnalysisStatusService;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
@@ -35,6 +36,7 @@ public class FloorService {
     private final FloorRepository floorRepository;
     private final BuildingRepository buildingRepository;
     private final FloorAnalysisService floorAnalysisService;
+    private final FloorAnalysisStatusService floorAnalysisStatusService;
     private final S3Service s3Service;
     private final S3PresignedUrlService s3PresignedUrlService;
     private final SchoolContextService schoolContextService;
@@ -103,20 +105,9 @@ public class FloorService {
         return FloorResponse.from(floor);
     }
 
-    @Transactional
     public void requestAnalysis(UUID floorId, String email) {
         String schoolName = schoolContextService.getSchoolName(email);
-        Floor floor = floorRepository.findByIdAndBuilding_SchoolName(floorId, schoolName)
-            .orElseThrow(() -> new ApiException(FloorErrorCode.FLOOR_NOT_FOUND));
-
-        if (floor.getMapImageKey() == null) {
-            throw new ApiException(FloorErrorCode.FLOOR_NOT_FOUND);
-        }
-        if (floor.getSegmentationStatus() == SegmentationStatus.PROCESSING) {
-            throw new ApiException(AnalysisErrorCode.ANALYSIS_ALREADY_IN_PROGRESS);
-        }
-
-        floor.updateSegmentationStatus(SegmentationStatus.PROCESSING);
+        floorAnalysisStatusService.markAsProcessing(floorId, schoolName);
         floorAnalysisService.analyzeFloor(floorId);
     }
 

--- a/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisGridIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisGridIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.saferoute.domain.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.saferoute.domain.analysis.dto.AnalyseFloorResponse;
+import com.saferoute.domain.analysis.dto.EdgeDto;
+import com.saferoute.domain.analysis.dto.NodeDto;
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.device.entity.Cctv;
+import com.saferoute.domain.device.entity.CctvGridCell;
+import com.saferoute.domain.device.repository.CctvGridCellRepository;
+import com.saferoute.domain.device.repository.CctvJpaRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.dto.request.CreateOrUpdateFloorGridRequest;
+import com.saferoute.domain.evacuation.grid.entity.MapEdgeGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
+import com.saferoute.domain.evacuation.grid.repository.NodeGridCellRepository;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class FloorAnalysisGridIntegrationTest {
+
+    @Autowired
+    private BuildingRepository buildingRepository;
+    @Autowired
+    private FloorRepository floorRepository;
+    @Autowired
+    private FloorGridService floorGridService;
+    @Autowired
+    private FloorAnalysisService floorAnalysisService;
+    @Autowired
+    private FloorGridCellRepository floorGridCellRepository;
+    @Autowired
+    private MapNodeJpaRepository mapNodeRepository;
+    @Autowired
+    private MapEdgeJpaRepository mapEdgeRepository;
+    @Autowired
+    private NodeGridCellRepository nodeGridCellRepository;
+    @Autowired
+    private MapEdgeGridCellRepository mapEdgeGridCellRepository;
+    @Autowired
+    private CctvJpaRepository cctvRepository;
+    @Autowired
+    private CctvGridCellRepository cctvGridCellRepository;
+
+    @Test
+    void gridCreatedBeforeAnalysis_isPreservedAndConnectsCctvCellToAnalyzedEdge() {
+        Building building = buildingRepository.save(
+                Building.create("분석관", "서울특별시 안전구", BuildingType.CLASSROOM, "SafeRoute School"));
+        Floor floor = Floor.create(building, 3);
+        floor.upload(3.0, 4.0, "floors/third-floor.png");
+        floorRepository.save(floor);
+
+        floorGridService.createOrRegenerateGrid(
+                floor.getId(), new CreateOrUpdateFloorGridRequest(0.5));
+        List<java.util.UUID> gridCellIdsBeforeAnalysis = floorGridCellRepository
+                .findAllByFloor_Id(floor.getId()).stream()
+                .map(cell -> cell.getId())
+                .toList();
+
+        AnalyseFloorResponse response = new AnalyseFloorResponse(
+                1600,
+                900,
+                List.of(
+                        new NodeDto("node-a", "hallway_1", "HALLWAY", 0.1, 0.5),
+                        new NodeDto("node-b", "hallway_2", "HALLWAY", 0.9, 0.5)
+                ),
+                List.of(new EdgeDto("node-a", "node-b", 3.2, true)),
+                Map.of()
+        );
+
+        floorAnalysisService.persistAnalysisResult(floor.getId(), response);
+
+        Floor analyzedFloor = floorRepository.findById(floor.getId()).orElseThrow();
+        assertThat(analyzedFloor.getGridCellSizeMeter()).isEqualTo(0.5);
+        assertThat(analyzedFloor.getGridRows()).isEqualTo(6);
+        assertThat(analyzedFloor.getGridColumns()).isEqualTo(8);
+        assertThat(analyzedFloor.getSegmentationStatus()).isEqualTo(SegmentationStatus.DONE);
+        assertThat(floorGridCellRepository.findAllByFloor_Id(floor.getId()))
+                .extracting(cell -> cell.getId())
+                .containsExactlyInAnyOrderElementsOf(gridCellIdsBeforeAnalysis);
+
+        List<MapNode> analyzedNodes = mapNodeRepository.findAllByFloor_Id(floor.getId());
+        assertThat(analyzedNodes).hasSize(2);
+        assertThat(nodeGridCellRepository.findAllByNode_IdIn(
+                analyzedNodes.stream().map(MapNode::getId).toList())).hasSize(2);
+
+        MapEdge analyzedEdge = mapEdgeRepository.findAllByFloor_Id(floor.getId()).get(0);
+        List<MapEdgeGridCell> edgeMappings =
+                mapEdgeGridCellRepository.findAllByMapEdge_Id(analyzedEdge.getId());
+        assertThat(edgeMappings).isNotEmpty();
+
+        MapNode cctvNode = mapNodeRepository.save(
+                MapNode.createCustom(floor, "CCTV_TEST", "복도 CCTV", 0.5, 0.5,
+                        com.saferoute.domain.evacuation.graph.entity.CustomDeviceType.CCTV));
+        Cctv cctv = cctvRepository.save(Cctv.create("CCTV_TEST", "복도 CCTV", cctvNode));
+        cctvGridCellRepository.save(CctvGridCell.create(cctv, edgeMappings.get(0).getGridCell()));
+
+        List<java.util.UUID> monitoredCellIds = cctvGridCellRepository
+                .findAllByCctv_IdOrderByGridCell_RowIndexAscGridCell_ColumnIndexAsc(cctv.getId())
+                .stream()
+                .map(mapping -> mapping.getGridCell().getId())
+                .toList();
+        assertThat(mapEdgeGridCellRepository.findAllByGridCell_IdIn(monitoredCellIds))
+                .extracting(mapping -> mapping.getMapEdge().getId())
+                .contains(analyzedEdge.getId());
+    }
+}

--- a/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisRollbackIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisRollbackIntegrationTest.java
@@ -1,0 +1,118 @@
+package com.saferoute.domain.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.saferoute.domain.analysis.AiAnalysisClient;
+import com.saferoute.domain.analysis.dto.AnalyseFloorResponse;
+import com.saferoute.domain.analysis.dto.EdgeDto;
+import com.saferoute.domain.analysis.dto.NodeDto;
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.entity.MapNode;
+import com.saferoute.domain.evacuation.graph.entity.NodeType;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.dto.request.CreateOrUpdateFloorGridRequest;
+import com.saferoute.domain.evacuation.grid.entity.FloorGridCell;
+import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.GridErrorCode;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+class FloorAnalysisRollbackIntegrationTest {
+
+    private static final String SCHOOL_NAME = "Rollback Test School";
+
+    @Autowired
+    private BuildingRepository buildingRepository;
+    @Autowired
+    private FloorRepository floorRepository;
+    @Autowired
+    private FloorGridService floorGridService;
+    @Autowired
+    private FloorAnalysisService floorAnalysisService;
+    @Autowired
+    private FloorAnalysisStatusService statusService;
+    @Autowired
+    private FloorGridCellRepository floorGridCellRepository;
+    @Autowired
+    private MapNodeJpaRepository mapNodeRepository;
+    @Autowired
+    private MapEdgeJpaRepository mapEdgeRepository;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockitoBean
+    private AiAnalysisClient aiAnalysisClient;
+
+    @Test
+    void gridCellMismatch_rollsBackGraphReplacementAndKeepsFailedStatus() {
+        UUID floorId = transactionTemplate.execute(status -> createFloorWithExistingGraph());
+        floorGridService.createOrRegenerateGrid(
+                floorId, new CreateOrUpdateFloorGridRequest(0.5));
+
+        transactionTemplate.executeWithoutResult(status -> {
+            FloorGridCell oneCell = floorGridCellRepository.findAllByFloor_Id(floorId).get(0);
+            floorGridCellRepository.delete(oneCell);
+        });
+        statusService.markAsProcessing(floorId, SCHOOL_NAME);
+
+        AnalyseFloorResponse response = new AnalyseFloorResponse(
+                1600,
+                900,
+                List.of(
+                        new NodeDto("new-a", "NEW_A", "HALLWAY", 0.2, 0.5),
+                        new NodeDto("new-b", "NEW_B", "HALLWAY", 0.8, 0.5)),
+                List.of(new EdgeDto("new-a", "new-b", 2.4, true)),
+                Map.of());
+        given(aiAnalysisClient.analyze("floors/rollback.png", 4.0, 3.0))
+                .willReturn(response);
+
+        assertThatThrownBy(() -> floorAnalysisService.analyzeFloor(floorId))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(GridErrorCode.GRID_CELL_NOT_FOUND);
+
+        Floor failedFloor = floorRepository.findById(floorId).orElseThrow();
+        assertThat(failedFloor.getSegmentationStatus()).isEqualTo(SegmentationStatus.FAILED);
+        assertThat(mapNodeRepository.findAllByFloor_Id(floorId))
+                .extracting(MapNode::getCode)
+                .containsExactlyInAnyOrder("OLD_A", "OLD_B");
+        assertThat(mapEdgeRepository.findAllByFloor_Id(floorId))
+                .singleElement()
+                .extracting(MapEdge::getDistance)
+                .isEqualTo(2.0);
+    }
+
+    private UUID createFloorWithExistingGraph() {
+        Building building = buildingRepository.save(Building.create(
+                "롤백 분석관", "부산광역시 안전구", BuildingType.CLASSROOM, SCHOOL_NAME));
+        Floor floor = Floor.create(building, 1);
+        floor.upload(3.0, 4.0, "floors/rollback.png");
+        floor.updateSegmentationStatus(SegmentationStatus.DONE);
+        floorRepository.save(floor);
+
+        MapNode from = mapNodeRepository.save(MapNode.create(
+                floor, "OLD_A", NodeType.HALLWAY, "기존 A", 0.1, 0.5, false));
+        MapNode to = mapNodeRepository.save(MapNode.create(
+                floor, "OLD_B", NodeType.HALLWAY, "기존 B", 0.9, 0.5, false));
+        mapEdgeRepository.save(MapEdge.create(floor, from, to, 2.0, true));
+        return floor.getId();
+    }
+}

--- a/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisServiceTest.java
+++ b/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisServiceTest.java
@@ -1,31 +1,21 @@
 package com.saferoute.domain.analysis.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.inOrder;
+import static org.mockito.BDDMockito.then;
 
 import com.saferoute.domain.analysis.AiAnalysisClient;
 import com.saferoute.domain.analysis.dto.AnalyseFloorResponse;
-import com.saferoute.domain.analysis.dto.EdgeDto;
-import com.saferoute.domain.analysis.dto.NodeDto;
 import com.saferoute.domain.building.entity.Building;
-import com.saferoute.domain.evacuation.graph.entity.MapEdge;
-import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
-import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
-import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.entity.SegmentationStatus;
 import com.saferoute.domain.floor.repository.FloorRepository;
 import com.saferoute.global.api.error.AnalysisErrorCode;
 import com.saferoute.global.api.exception.ApiException;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -39,46 +29,20 @@ class FloorAnalysisServiceTest {
     @Mock
     private FloorRepository floorRepository;
     @Mock
-    private MapNodeJpaRepository mapNodeRepository;
-    @Mock
-    private MapEdgeJpaRepository mapEdgeRepository;
-    @Mock
     private AiAnalysisClient aiAnalysisClient;
     @Mock
-    private FloorGridService floorGridService;
+    private FloorAnalysisResultService resultService;
+    @Mock
+    private FloorAnalysisStatusService statusService;
 
     @Test
-    void persistAnalysisResult_preservesGridConfigAndRemapsGraph() {
+    void persistAnalysisResult_delegatesToTransactionalResultService() {
         UUID floorId = UUID.randomUUID();
-        Floor floor = Floor.create(org.mockito.Mockito.mock(Building.class), 3);
-        floor.upload(30.0, 40.0, "floors/third-floor.png");
-        floor.applyGridCellConfig(0.5, 60, 80);
-        floor.updateSegmentationStatus(SegmentationStatus.PROCESSING);
-
-        AnalyseFloorResponse response = new AnalyseFloorResponse(
-                1600,
-                900,
-                List.of(
-                        new NodeDto("node-a", "hallway_1", "HALLWAY", 0.2, 0.5),
-                        new NodeDto("node-b", "hallway_2", "HALLWAY", 0.8, 0.5)
-                ),
-                List.of(new EdgeDto("node-a", "node-b", 24.0, true)),
-                Map.of()
-        );
-        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        AnalyseFloorResponse response = org.mockito.Mockito.mock(AnalyseFloorResponse.class);
 
         floorAnalysisService.persistAnalysisResult(floorId, response);
 
-        assertThat(floor.getGridCellSizeMeter()).isEqualTo(0.5);
-        assertThat(floor.getGridRows()).isEqualTo(60);
-        assertThat(floor.getGridColumns()).isEqualTo(80);
-        assertThat(floor.getPlanWidthPx()).isEqualTo(1600);
-        assertThat(floor.getPlanHeightPx()).isEqualTo(900);
-        assertThat(floor.getSegmentationStatus()).isEqualTo(SegmentationStatus.DONE);
-
-        InOrder inOrder = inOrder(mapEdgeRepository, floorGridService);
-        inOrder.verify(mapEdgeRepository).save(org.mockito.ArgumentMatchers.any(MapEdge.class));
-        inOrder.verify(floorGridService).remapGraphToExistingGrid(floorId);
+        then(resultService).should().persistAnalysisResult(floorId, response);
     }
 
     @Test
@@ -95,6 +59,6 @@ class FloorAnalysisServiceTest {
                 .isInstanceOf(ApiException.class)
                 .extracting(exception -> ((ApiException) exception).getErrorCode())
                 .isEqualTo(AnalysisErrorCode.AI_ANALYSIS_FAILED);
-        assertThat(floor.getSegmentationStatus()).isEqualTo(SegmentationStatus.FAILED);
+        then(statusService).should().markAsFailed(floorId);
     }
 }

--- a/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisServiceTest.java
+++ b/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisServiceTest.java
@@ -1,6 +1,7 @@
 package com.saferoute.domain.analysis.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 
@@ -16,6 +17,8 @@ import com.saferoute.domain.evacuation.grid.service.FloorGridService;
 import com.saferoute.domain.floor.entity.Floor;
 import com.saferoute.domain.floor.entity.SegmentationStatus;
 import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.error.AnalysisErrorCode;
+import com.saferoute.global.api.exception.ApiException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -76,5 +79,22 @@ class FloorAnalysisServiceTest {
         InOrder inOrder = inOrder(mapEdgeRepository, floorGridService);
         inOrder.verify(mapEdgeRepository).save(org.mockito.ArgumentMatchers.any(MapEdge.class));
         inOrder.verify(floorGridService).remapGraphToExistingGrid(floorId);
+    }
+
+    @Test
+    void analyzeFloor_marksFloorAsFailedWhenAiRequestFails() {
+        UUID floorId = UUID.randomUUID();
+        Floor floor = Floor.create(org.mockito.Mockito.mock(Building.class), 3);
+        floor.upload(3.0, 4.0, "floors/third-floor.png");
+        floor.updateSegmentationStatus(SegmentationStatus.PROCESSING);
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+        given(aiAnalysisClient.analyze("floors/third-floor.png", 4.0, 3.0))
+                .willThrow(new RuntimeException("AI server unavailable"));
+
+        assertThatThrownBy(() -> floorAnalysisService.analyzeFloor(floorId))
+                .isInstanceOf(ApiException.class)
+                .extracting(exception -> ((ApiException) exception).getErrorCode())
+                .isEqualTo(AnalysisErrorCode.AI_ANALYSIS_FAILED);
+        assertThat(floor.getSegmentationStatus()).isEqualTo(SegmentationStatus.FAILED);
     }
 }

--- a/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisServiceTest.java
+++ b/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisServiceTest.java
@@ -1,0 +1,80 @@
+package com.saferoute.domain.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+
+import com.saferoute.domain.analysis.AiAnalysisClient;
+import com.saferoute.domain.analysis.dto.AnalyseFloorResponse;
+import com.saferoute.domain.analysis.dto.EdgeDto;
+import com.saferoute.domain.analysis.dto.NodeDto;
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
+import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
+import com.saferoute.domain.evacuation.grid.service.FloorGridService;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FloorAnalysisServiceTest {
+
+    @InjectMocks
+    private FloorAnalysisService floorAnalysisService;
+
+    @Mock
+    private FloorRepository floorRepository;
+    @Mock
+    private MapNodeJpaRepository mapNodeRepository;
+    @Mock
+    private MapEdgeJpaRepository mapEdgeRepository;
+    @Mock
+    private AiAnalysisClient aiAnalysisClient;
+    @Mock
+    private FloorGridService floorGridService;
+
+    @Test
+    void persistAnalysisResult_preservesGridConfigAndRemapsGraph() {
+        UUID floorId = UUID.randomUUID();
+        Floor floor = Floor.create(org.mockito.Mockito.mock(Building.class), 3);
+        floor.upload(30.0, 40.0, "floors/third-floor.png");
+        floor.applyGridCellConfig(0.5, 60, 80);
+        floor.updateSegmentationStatus(SegmentationStatus.PROCESSING);
+
+        AnalyseFloorResponse response = new AnalyseFloorResponse(
+                1600,
+                900,
+                List.of(
+                        new NodeDto("node-a", "hallway_1", "HALLWAY", 0.2, 0.5),
+                        new NodeDto("node-b", "hallway_2", "HALLWAY", 0.8, 0.5)
+                ),
+                List.of(new EdgeDto("node-a", "node-b", 24.0, true)),
+                Map.of()
+        );
+        given(floorRepository.findById(floorId)).willReturn(Optional.of(floor));
+
+        floorAnalysisService.persistAnalysisResult(floorId, response);
+
+        assertThat(floor.getGridCellSizeMeter()).isEqualTo(0.5);
+        assertThat(floor.getGridRows()).isEqualTo(60);
+        assertThat(floor.getGridColumns()).isEqualTo(80);
+        assertThat(floor.getPlanWidthPx()).isEqualTo(1600);
+        assertThat(floor.getPlanHeightPx()).isEqualTo(900);
+        assertThat(floor.getSegmentationStatus()).isEqualTo(SegmentationStatus.DONE);
+
+        InOrder inOrder = inOrder(mapEdgeRepository, floorGridService);
+        inOrder.verify(mapEdgeRepository).save(org.mockito.ArgumentMatchers.any(MapEdge.class));
+        inOrder.verify(floorGridService).remapGraphToExistingGrid(floorId);
+    }
+}

--- a/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisStatusConcurrencyIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisStatusConcurrencyIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.saferoute.domain.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.saferoute.domain.building.entity.Building;
+import com.saferoute.domain.building.entity.BuildingType;
+import com.saferoute.domain.building.repository.BuildingRepository;
+import com.saferoute.domain.floor.entity.Floor;
+import com.saferoute.domain.floor.entity.SegmentationStatus;
+import com.saferoute.domain.floor.repository.FloorRepository;
+import com.saferoute.global.api.exception.ApiException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+class FloorAnalysisStatusConcurrencyIntegrationTest {
+
+    private static final String SCHOOL_NAME = "Lock Test School";
+
+    @Autowired
+    private FloorAnalysisStatusService statusService;
+    @Autowired
+    private BuildingRepository buildingRepository;
+    @Autowired
+    private FloorRepository floorRepository;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Test
+    void concurrentProcessingRequests_allowOnlyOneClaim() throws Exception {
+        UUID floorId = transactionTemplate.execute(status -> createReadyFloor());
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<String> first = executor.submit(
+                    () -> claimResult(floorId, ready, start));
+            Future<String> second = executor.submit(
+                    () -> claimResult(floorId, ready, start));
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            assertThat(List.of(
+                    first.get(10, TimeUnit.SECONDS),
+                    second.get(10, TimeUnit.SECONDS)))
+                    .containsExactlyInAnyOrder("SUCCESS", "ANALYSIS003");
+            assertThat(floorRepository.findById(floorId).orElseThrow().getSegmentationStatus())
+                    .isEqualTo(SegmentationStatus.PROCESSING);
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private String claimResult(UUID floorId, CountDownLatch ready, CountDownLatch start)
+            throws InterruptedException {
+        ready.countDown();
+        if (!start.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("분석 시작 동시 요청 신호를 기다리는 중 시간 초과되었습니다.");
+        }
+        try {
+            statusService.markAsProcessing(floorId, SCHOOL_NAME);
+            return "SUCCESS";
+        } catch (ApiException exception) {
+            return exception.getErrorCode().getCode();
+        }
+    }
+
+    private UUID createReadyFloor() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        Building building = buildingRepository.save(Building.create(
+                "분석 잠금관 " + suffix,
+                "서울특별시 안전구 " + suffix,
+                BuildingType.CLASSROOM,
+                SCHOOL_NAME));
+        Floor floor = Floor.create(building, 1);
+        floor.upload(3.0, 4.0, "floors/analysis-lock.png");
+        floor.updateSegmentationStatus(SegmentationStatus.DONE);
+        return floorRepository.save(floor).getId();
+    }
+}

--- a/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
+++ b/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
@@ -3,12 +3,14 @@ package com.saferoute.domain.floor.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 import com.saferoute.domain.analysis.service.FloorAnalysisService;
+import com.saferoute.domain.analysis.service.FloorAnalysisStatusService;
 import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
@@ -56,6 +58,9 @@ class FloorServiceTest {
     private FloorAnalysisService floorAnalysisService;
 
     @Mock
+    private FloorAnalysisStatusService floorAnalysisStatusService;
+
+    @Mock
     private S3Service s3Service;
 
     @Mock
@@ -87,8 +92,8 @@ class FloorServiceTest {
     void hidesFloorAnalysisTargetFromAnotherSchool() {
         UUID floorId = UUID.randomUUID();
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
-        given(floorRepository.findByIdAndBuilding_SchoolName(floorId, SCHOOL_NAME))
-                .willReturn(Optional.empty());
+        willThrow(new ApiException(FloorErrorCode.FLOOR_NOT_FOUND))
+                .given(floorAnalysisStatusService).markAsProcessing(floorId, SCHOOL_NAME);
 
         assertThatThrownBy(() -> floorService.requestAnalysis(floorId, EMAIL))
                 .isInstanceOf(ApiException.class)

--- a/src/test/java/com/saferoute/domain/grid/FloorGridServiceTest.java
+++ b/src/test/java/com/saferoute/domain/grid/FloorGridServiceTest.java
@@ -4,10 +4,13 @@ import com.saferoute.domain.building.entity.Building;
 import com.saferoute.domain.building.entity.BuildingType;
 import com.saferoute.domain.building.repository.BuildingRepository;
 import com.saferoute.domain.evacuation.graph.entity.CustomDeviceType;
+import com.saferoute.domain.evacuation.graph.entity.MapEdge;
+import com.saferoute.domain.evacuation.graph.repository.MapEdgeJpaRepository;
 import com.saferoute.domain.evacuation.graph.repository.MapNodeJpaRepository;
 import com.saferoute.domain.evacuation.grid.dto.request.CreateOrUpdateFloorGridRequest;
 import com.saferoute.domain.evacuation.grid.entity.UserZone;
 import com.saferoute.domain.evacuation.grid.repository.FloorGridCellRepository;
+import com.saferoute.domain.evacuation.grid.repository.MapEdgeGridCellRepository;
 import com.saferoute.domain.evacuation.grid.repository.NodeGridCellRepository;
 import com.saferoute.domain.evacuation.grid.repository.UserZoneRepository;
 import com.saferoute.domain.evacuation.grid.service.FloorGridService;
@@ -37,11 +40,15 @@ class FloorGridServiceTest {
     @Autowired
     MapNodeJpaRepository mapNodeRepository;
     @Autowired
+    MapEdgeJpaRepository mapEdgeRepository;
+    @Autowired
     FloorGridCellRepository floorGridCellRepository;
     @Autowired
     UserZoneRepository userZoneRepository;
     @Autowired
     NodeGridCellRepository nodeGridCellRepository;
+    @Autowired
+    MapEdgeGridCellRepository mapEdgeGridCellRepository;
     @Autowired
     BuildingRepository buildingRepository;
 
@@ -136,6 +143,27 @@ class FloorGridServiceTest {
         assertThat(reloaded.getGridCellSizeMeter()).isEqualTo(1.0);
         assertThat(reloaded.getGridRows()).isEqualTo(30);
         assertThat(reloaded.getGridColumns()).isEqualTo(40);
+    }
+
+    @Test
+    void remapGraphToExistingGrid_mapsNodesAndEdgesCreatedAfterGrid() {
+        floorGridService.createOrRegenerateGrid(
+                floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+
+        MapNode from = mapNodeRepository.save(
+                MapNode.create(floor, "hallway_a", NodeType.HALLWAY, "복도 A", 0.1, 0.5, false));
+        MapNode to = mapNodeRepository.save(
+                MapNode.create(floor, "hallway_b", NodeType.HALLWAY, "복도 B", 0.9, 0.5, false));
+        MapEdge edge = mapEdgeRepository.save(MapEdge.create(floor, from, to, 32.0, true));
+
+        floorGridService.remapGraphToExistingGrid(floor.getId());
+
+        assertThat(nodeGridCellRepository.findByNode_Id(from.getId())).isPresent();
+        assertThat(nodeGridCellRepository.findByNode_Id(to.getId())).isPresent();
+        assertThat(mapEdgeGridCellRepository.findAllByMapEdge_Id(edge.getId())).isNotEmpty();
+        assertThat(floor.getGridCellSizeMeter()).isEqualTo(1.0);
+        assertThat(floor.getGridRows()).isEqualTo(30);
+        assertThat(floor.getGridColumns()).isEqualTo(40);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #231 
- Branch: fix/#231

## 주요 내용

도면 업로드 후 그리드를 먼저 생성하고 AI 분석을 실행하는 현재 프론트 흐름에서, AI 분석 완료 후 기존 그리드 설정과 그래프-그리드 매핑이 유실되는 문제를 수정했습니다.

## 문제 상황

현재 프론트의 도면 등록 흐름은 다음과 같습니다.

1. 도면 이미지와 실측 크기 입력
2. 그리드 셀 크기 입력 및 그리드 생성
3. AI 도면 분석
4. 도면 관리 상세 페이지 이동

기존에는 AI 분석 결과를 저장할 때 다음 문제가 발생했습니다.

- 기존 `gridCellSizeMeter`가 `null`로 초기화됨
- 기존 `gridRows`, `gridColumns`가 `null`로 초기화됨
- AI가 새로 생성한 노드에 `NodeGridCell` 매핑이 생성되지 않음
- AI가 새로 생성한 엣지에 `MapEdgeGridCell` 매핑이 생성되지 않음
- CCTV 감시 셀을 기준으로 영향받는 엣지를 찾지 못할 수 있음
- 혼잡 이벤트가 발생해도 경로 재탐색 대상 엣지가 누락될 수 있음

## 변경 사항

### AI 분석 후 기존 그리드 설정 유지

AI 분석 결과를 저장할 때 기존 그리드 설정을 초기화하지 않도록 수정했습니다.

기존 방식:

    floor.applyGridConfig(
        null,
        null,
        null,
        response.planWidthPx(),
        response.planHeightPx()
    );

변경 후에는 AI 분석으로 확인된 원본 도면 픽셀 크기만 갱신합니다.

    floor.applyPlanSize(
        response.planWidthPx(),
        response.planHeightPx()
    );

이에 따라 다음 값이 AI 분석 이후에도 유지됩니다.

- `gridCellSizeMeter`
- `gridRows`
- `gridColumns`

### AI 분석 그래프 전체 재매핑

AI 분석으로 기존 그래프가 교체된 후 새로 생성된 전체 노드와 엣지를 기존 그리드에 다시 매핑하도록 수정했습니다.

추가된 처리:

1. 기존 노드·엣지 매핑 정리
2. 해당 층의 모든 노드를 기존 그리드 셀에 매핑
3. 해당 층의 모든 엣지가 지나는 그리드 셀 계산
4. `NodeGridCell` 일괄 저장
5. `MapEdgeGridCell` 일괄 저장
6. 재매핑 완료 후 `segmentationStatus`를 `DONE`으로 변경

그리드 셀 자체는 다시 생성하지 않습니다.

따라서 다음 데이터는 유지됩니다.

- 기존 `FloorGridCell`과 ID
- 사용자 지정 구역
- CCTV 감시 영역
- 그리드 셀 크기 및 행·열 정보

### 그리드가 없는 도면 처리

AI 분석 시 해당 층에 그리드 설정이 아직 없다면 그래프-그리드 재매핑을 수행하지 않고 기존과 동일하게 AI 분석 결과만 저장합니다.

### 비정상 그리드 데이터 검증

저장된 `gridRows × gridColumns` 값과 실제 `FloorGridCell` 개수가 일치하지 않으면 재매핑을 중단하고 오류를 반환하도록 검증을 추가했습니다.

부분적으로 손상된 그리드에 잘못된 노드·엣지 매핑이 저장되는 것을 방지합니다.

## 기존 기능과의 연계

이번 변경은 기존 엣지 자동 재계산 로직과 함께 동작합니다.

- AI 분석 직후: 전체 노드·엣지를 기존 그리드에 일괄 매핑
- 상세 페이지에서 엣지 추가: 새 엣지만 자동 매핑
- 상세 페이지에서 노드 이동: 연결된 엣지들의 매핑 자동 재계산
- 노드·엣지 삭제: FK CASCADE를 통해 관련 매핑 삭제

이를 통해 AI 분석 이후 사용자가 노드와 엣지를 수동으로 수정해도 CCTV 감시 영역과 경로 엣지의 연결이 유지됩니다.

## DB 

배포 전에 이미 저장된 노드·엣지의 누락된 매핑은 배포만으로 자동 복구되지 않습니다.

기존 데이터는 다음 중 한 가지 방법으로 별도 처리해야 합니다.

- 배포 후 해당 도면의 AI 분석을 다시 실행
- 상세 페이지 API를 통해 엣지를 다시 생성하거나 연결된 노드를 이동
- 별도의 1회성 데이터 백필 수행

DB에 노드·엣지를 SQL로 직접 입력하는 경우 애플리케이션의 자동 매핑 로직을 거치지 않으므로, 필요한 `MapEdgeGridCell` 매핑도 함께 입력해야 합니다.

## 테스트

다음 항목을 검증하는 테스트를 추가했습니다.

- AI 분석 후 기존 `gridCellSizeMeter` 유지
- AI 분석 후 기존 `gridRows`, `gridColumns` 유지
- AI 분석 결과의 원본 도면 픽셀 크기 반영
- AI 분석 완료 후 `segmentationStatus == DONE`
- AI 분석 실패 후 `segmentationStatus == FAILED`
- `0.5m` 셀 크기로 그리드 생성
- AI 분석 전후 기존 `FloorGridCell` ID 유지
- AI가 생성한 모든 노드의 `NodeGridCell` 매핑 생성
- AI가 생성한 엣지의 `MapEdgeGridCell` 매핑 생성
- CCTV 감시 셀을 통해 AI 생성 엣지 조회 가능
- 그리드 생성 후 추가된 노드·엣지의 전체 재매핑

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 층 분석 후에도 기존 그리드 셀과 설정이 유지됩니다.
  * 분석 결과에 맞춰 노드·엣지와 그리드 셀 연결이 자동으로 재구성됩니다.
  * 분석 결과의 도면 크기와 층 분석 상태가 정확히 반영됩니다.
  * CCTV가 분석된 엣지와 연결된 그리드 셀을 올바르게 참조합니다.
  * 동일한 층에 대한 중복 분석 요청을 방지합니다.

* **버그 수정**
  * AI 분석 실패 시 층 상태가 실패로 기록됩니다.
  * 그리드 오류 발생 시 기존 분석 그래프가 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->