### PR TITLE
fix(monitoring) #235: 모니터링 이미지 기준 인원 및 밀집도 반환

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/controller/CongestionObservationController.java
+++ b/src/main/java/com/saferoute/domain/congestion/controller/CongestionObservationController.java
@@ -32,11 +32,17 @@ public class CongestionObservationController {
     @Operation(
             summary = "5초 관측값 수신",
             description = """
-                    Pi가 5초 주기로 보내는 혼잡 관측값(평균/최대 인원, 표본 수 등)을 저장합니다.
+                    Pi가 5초 주기로 보내는 혼잡 관측값(평균/최대 인원, 이미지 Snapshot 인원,
+                    표본 수 등)을 저장합니다.
                     Pi가 보낸 avgHeadcount와 해당 CCTV의 감시 면적(GridCell 기반)으로 BE가 직접
                     density를 계산하고, 그 값을 congestionThresholds 기준으로 판정한 congestionLevel을
                     함께 저장합니다. Pi가 보낸 localDensity/localCongestionLevel 같은 값은 없으며,
                     이 응답의 density/congestionLevel이 최종 판정값입니다.
+
+                    frameHeadcount가 있으면 같은 감시 면적으로 frameDensity와 frameCongestionLevel도
+                    계산해 저장합니다. 상세 모니터링 프레임 조회의 기존 headcount/density/congestionLevel은
+                    이 이미지 Snapshot 기준 값을 반환합니다. 구버전 Pi 요청과 기존 DynamoDB 데이터에는
+                    frameHeadcount가 없을 수 있으며, 이 경우 기존 최대 인원/평균 밀집도 값으로 대체합니다.
 
                     eventId 기준으로 멱등 처리됩니다. 같은 eventId로 재전송하면 새로 만들지 않고
                     저장된 기존 관측값을 그대로 반환하며, 최초 저장 시에만 201 Created, 이미

--- a/src/main/java/com/saferoute/domain/congestion/dto/request/ReportObservationRequest.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/request/ReportObservationRequest.java
@@ -7,7 +7,8 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.util.UUID;
 
-// Pi가 5초마다 보내는 관측값. edgeId/density/congestionLevel은 Pi가 보내지 않는다 - BE가 직접 계산한다.
+// Pi가 5초마다 보내는 관측값. frameHeadcount는 이미지 Snapshot의 인원이며,
+// edgeId/density/congestionLevel은 Pi가 보내지 않는다 - BE가 직접 계산한다.
 public record ReportObservationRequest(
         @NotNull UUID eventId,
         @NotNull UUID trainingSessionId,

--- a/src/main/java/com/saferoute/domain/congestion/dto/request/ReportObservationRequest.java
+++ b/src/main/java/com/saferoute/domain/congestion/dto/request/ReportObservationRequest.java
@@ -14,6 +14,7 @@ public record ReportObservationRequest(
         @NotBlank String cctvCode,
         @NotNull @PositiveOrZero Double avgHeadcount,
         @NotNull @PositiveOrZero Integer peakHeadcount,
+        @PositiveOrZero Integer frameHeadcount,
         @NotNull @Positive Integer sampleCount,
         @NotNull @PositiveOrZero Long windowStart,
         @NotNull @PositiveOrZero Long windowEnd,
@@ -27,6 +28,14 @@ public record ReportObservationRequest(
             return true;
         }
         return avgHeadcount <= peakHeadcount.doubleValue();
+    }
+
+    @AssertTrue(message = "frameHeadcount must not exceed peakHeadcount")
+    public boolean isFrameHeadcountValid() {
+        if (frameHeadcount == null || peakHeadcount == null) {
+            return true;
+        }
+        return frameHeadcount <= peakHeadcount;
     }
 
     @AssertTrue(message = "windowEnd must not be before windowStart")

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -94,6 +94,10 @@ public class CongestionObservationService {
 
         double density = request.avgHeadcount() / monitoredAreaM2;
         CongestionLevel level = config.classify(density);
+        Double frameDensity = request.frameHeadcount() == null
+                ? null
+                : request.frameHeadcount() / monitoredAreaM2;
+        CongestionLevel frameLevel = frameDensity == null ? null : config.classify(frameDensity);
 
         ObservationItem item = ObservationItem.create(
                 request.eventId(),
@@ -102,9 +106,12 @@ public class CongestionObservationService {
                 cctv.getCode(),
                 request.avgHeadcount(),
                 request.peakHeadcount(),
+                request.frameHeadcount(),
                 request.sampleCount(),
                 density,
                 level,
+                frameDensity,
+                frameLevel,
                 request.windowStart(),
                 request.windowEnd(),
                 request.capturedAt(),

--- a/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
+++ b/src/main/java/com/saferoute/domain/telemetry/dynamo/entity/ObservationItem.java
@@ -27,9 +27,12 @@ public class ObservationItem {
     private String cctvCode;
     private Double avgHeadcount;
     private Integer peakHeadcount;
+    private Integer frameHeadcount;
     private Integer sampleCount;
     private Double density;
     private CongestionLevel congestionLevel;
+    private Double frameDensity;
+    private CongestionLevel frameCongestionLevel;
     private Long windowStart;
     private Long windowEnd;
     private Long capturedAt;
@@ -47,6 +50,7 @@ public class ObservationItem {
     public ObservationItem() {
     }
 
+    // frame 필드가 저장되기 전의 기존 데이터/테스트 생성 계약을 유지한다.
     public static ObservationItem create(
             UUID eventId,
             UUID trainingSessionId,
@@ -63,6 +67,33 @@ public class ObservationItem {
             String monitoringImageKey,
             long configVersion
     ) {
+        return create(
+                eventId, trainingSessionId, edgeId, cctvCode,
+                avgHeadcount, peakHeadcount, null, sampleCount,
+                density, congestionLevel, null, null,
+                windowStart, windowEnd, capturedAt, monitoringImageKey, configVersion
+        );
+    }
+
+    public static ObservationItem create(
+            UUID eventId,
+            UUID trainingSessionId,
+            UUID edgeId,
+            String cctvCode,
+            Double avgHeadcount,
+            Integer peakHeadcount,
+            Integer frameHeadcount,
+            Integer sampleCount,
+            Double density,
+            CongestionLevel congestionLevel,
+            Double frameDensity,
+            CongestionLevel frameCongestionLevel,
+            long windowStart,
+            long windowEnd,
+            long capturedAt,
+            String monitoringImageKey,
+            long configVersion
+    ) {
         ObservationItem item = new ObservationItem();
         item.eventId = eventId.toString();
         item.trainingSessionId = trainingSessionId.toString();
@@ -72,9 +103,12 @@ public class ObservationItem {
         item.cctvCode = cctvCode;
         item.avgHeadcount = avgHeadcount;
         item.peakHeadcount = peakHeadcount;
+        item.frameHeadcount = frameHeadcount;
         item.sampleCount = sampleCount;
         item.density = density;
         item.congestionLevel = congestionLevel;
+        item.frameDensity = frameDensity;
+        item.frameCongestionLevel = frameCongestionLevel;
         item.windowStart = windowStart;
         item.windowEnd = windowEnd;
         item.capturedAt = capturedAt;
@@ -195,6 +229,14 @@ public class ObservationItem {
         this.peakHeadcount = peakHeadcount;
     }
 
+    public Integer getFrameHeadcount() {
+        return frameHeadcount;
+    }
+
+    public void setFrameHeadcount(Integer frameHeadcount) {
+        this.frameHeadcount = frameHeadcount;
+    }
+
     public Integer getSampleCount() {
         return sampleCount;
     }
@@ -217,6 +259,22 @@ public class ObservationItem {
 
     public void setCongestionLevel(CongestionLevel congestionLevel) {
         this.congestionLevel = congestionLevel;
+    }
+
+    public Double getFrameDensity() {
+        return frameDensity;
+    }
+
+    public void setFrameDensity(Double frameDensity) {
+        this.frameDensity = frameDensity;
+    }
+
+    public CongestionLevel getFrameCongestionLevel() {
+        return frameCongestionLevel;
+    }
+
+    public void setFrameCongestionLevel(CongestionLevel frameCongestionLevel) {
+        this.frameCongestionLevel = frameCongestionLevel;
     }
 
     public Long getWindowStart() {

--- a/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameResponse.java
+++ b/src/main/java/com/saferoute/domain/training/dto/MonitoringFrameResponse.java
@@ -39,13 +39,13 @@ public record MonitoringFrameResponse(
         )
         Long urlExpiresAt,
 
-        @Schema(description = "프레임 시점의 최대 인원수", example = "12", nullable = true)
+        @Schema(description = "이미지 Snapshot의 인원수", example = "12", nullable = true)
         Integer headcount,
 
-        @Schema(description = "프레임 시점의 밀집도", example = "0.42", nullable = true)
+        @Schema(description = "이미지 Snapshot 인원수 기준 밀집도", example = "0.42", nullable = true)
         Double density,
 
-        @Schema(description = "프레임 시점의 혼잡 단계", example = "CROWDED", nullable = true)
+        @Schema(description = "이미지 Snapshot 밀집도 기준 혼잡 단계", example = "CROWDED", nullable = true)
         CongestionLevel congestionLevel
 ) {
 
@@ -57,9 +57,9 @@ public record MonitoringFrameResponse(
                 item.getWindowEnd(),
                 null,
                 null,
-                item.getPeakHeadcount(),
-                item.getDensity(),
-                item.getCongestionLevel()
+                frameHeadcount(item),
+                frameDensity(item),
+                frameCongestionLevel(item)
         );
     }
 
@@ -71,9 +71,23 @@ public record MonitoringFrameResponse(
                 item.getWindowEnd(),
                 presignedGetUrl.viewUrl(),
                 presignedGetUrl.expiresAt().toEpochMilli(),
-                item.getPeakHeadcount(),
-                item.getDensity(),
-                item.getCongestionLevel()
+                frameHeadcount(item),
+                frameDensity(item),
+                frameCongestionLevel(item)
         );
+    }
+
+    private static Integer frameHeadcount(ObservationItem item) {
+        return item.getFrameHeadcount() != null ? item.getFrameHeadcount() : item.getPeakHeadcount();
+    }
+
+    private static Double frameDensity(ObservationItem item) {
+        return item.getFrameDensity() != null ? item.getFrameDensity() : item.getDensity();
+    }
+
+    private static CongestionLevel frameCongestionLevel(ObservationItem item) {
+        return item.getFrameCongestionLevel() != null
+                ? item.getFrameCongestionLevel()
+                : item.getCongestionLevel();
     }
 }

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionObservationControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionObservationControllerTest.java
@@ -62,7 +62,7 @@ class CongestionObservationControllerTest {
     private ReportObservationRequest validRequest() {
         return new ReportObservationRequest(
                 UUID.randomUUID(), UUID.randomUUID(), "CCTV_001",
-                5.0, 8, 25, 1_000L, 2_000L, 2_000L, 1L, null
+                5.0, 8, 7, 25, 1_000L, 2_000L, 2_000L, 1L, null
         );
     }
 
@@ -121,6 +121,34 @@ class CongestionObservationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("구버전 Pi 요청은 frameHeadcount가 없어도 허용한다")
+    void reportObservation_allowsMissingFrameHeadcount() throws Exception {
+        ObjectNode body = objectMapper.valueToTree(validRequest());
+        body.remove("frameHeadcount");
+        given(deviceAuthorizationService.validateCctv(any(), org.mockito.ArgumentMatchers.eq("CCTV_001")))
+                .willReturn(Mockito.mock(Cctv.class));
+        given(congestionObservationService.reportObservation(any(), any()))
+                .willReturn(IdempotentSaveResult.created(observation()));
+
+        mockMvc.perform(post("/api/v1/device/congestion-observations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("frameHeadcount가 peakHeadcount보다 크면 400을 반환한다")
+    void reportObservation_rejectsFrameHeadcountAbovePeak() throws Exception {
+        ObjectNode body = objectMapper.valueToTree(validRequest());
+        body.put("frameHeadcount", 9);
+
+        mockMvc.perform(post("/api/v1/device/congestion-observations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/congestion/controller/CongestionObservationControllerTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/controller/CongestionObservationControllerTest.java
@@ -1,5 +1,6 @@
 package com.saferoute.domain.congestion.controller;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -21,6 +22,7 @@ import com.saferoute.global.security.JwtAuthenticationFilter;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -137,6 +139,11 @@ class CongestionObservationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isCreated());
+
+        ArgumentCaptor<ReportObservationRequest> requestCaptor =
+                ArgumentCaptor.forClass(ReportObservationRequest.class);
+        Mockito.verify(congestionObservationService).reportObservation(any(), requestCaptor.capture());
+        assertNull(requestCaptor.getValue().frameHeadcount());
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -130,7 +130,7 @@ class CongestionObservationServiceTest {
 
     private ReportObservationRequest request(double avgHeadcount, String monitoringImageKey) {
         return new ReportObservationRequest(
-                UUID.randomUUID(), sessionId, "CCTV_001", avgHeadcount, 8, 25,
+                UUID.randomUUID(), sessionId, "CCTV_001", avgHeadcount, 8, 7, 25,
                 1_000L, 2_000L, 2_000L, 1L, monitoringImageKey
         );
     }
@@ -197,7 +197,7 @@ class CongestionObservationServiceTest {
     }
 
     @Test
-    @DisplayName("BE가 직접 density와 congestionLevel을 계산해서 저장한다 (Pi 값을 받지 않음)")
+    @DisplayName("BE가 구간 평균과 이미지 프레임의 밀집도 및 단계를 각각 계산해서 저장한다")
     void reportObservation_computesDensityAndLevelItself() {
         TrainingSession session = mock(TrainingSession.class);
         given(session.getId()).willReturn(sessionId);
@@ -210,7 +210,14 @@ class CongestionObservationServiceTest {
         service.reportObservation(cctv, request(9.0));
 
         verify(observationRepository).saveIfAbsent(argThat(item ->
-                item.getDensity().equals(2.25) && item.getCongestionLevel() == CongestionLevel.CAUTION));
+                item.getDensity().equals(2.25)
+                        && item.getCongestionLevel() == CongestionLevel.CAUTION
+                        && item.getFrameHeadcount().equals(7)
+                        && item.getFrameDensity().equals(1.75)
+                        && item.getFrameCongestionLevel() == CongestionLevel.NORMAL));
+        verify(currentCctvStateRepository).updateIfLatest(argThat(state ->
+                state.getDensity().equals(2.25)
+                        && state.getCongestionLevel() == CongestionLevel.CAUTION));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -129,8 +129,16 @@ class CongestionObservationServiceTest {
     }
 
     private ReportObservationRequest request(double avgHeadcount, String monitoringImageKey) {
+        return request(avgHeadcount, 7, monitoringImageKey);
+    }
+
+    private ReportObservationRequest request(
+            double avgHeadcount,
+            Integer frameHeadcount,
+            String monitoringImageKey
+    ) {
         return new ReportObservationRequest(
-                UUID.randomUUID(), sessionId, "CCTV_001", avgHeadcount, 8, 7, 25,
+                UUID.randomUUID(), sessionId, "CCTV_001", avgHeadcount, 8, frameHeadcount, 25,
                 1_000L, 2_000L, 2_000L, 1L, monitoringImageKey
         );
     }
@@ -218,6 +226,24 @@ class CongestionObservationServiceTest {
         verify(currentCctvStateRepository).updateIfLatest(argThat(state ->
                 state.getDensity().equals(2.25)
                         && state.getCongestionLevel() == CongestionLevel.CAUTION));
+    }
+
+    @Test
+    @DisplayName("구버전 요청의 frameHeadcount가 없으면 프레임 지표도 null로 저장한다")
+    void reportObservation_preservesNullFrameMetricsForLegacyRequest() {
+        TrainingSession session = mock(TrainingSession.class);
+        given(session.getId()).willReturn(sessionId);
+        given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
+                sessionId, TrainingStatus.RUNNING, buildingId)).willReturn(Optional.of(session));
+        givenProcessingClaimed();
+        givenAffectedEdges();
+
+        service.reportObservation(cctv, request(9.0, null, null));
+
+        verify(observationRepository).saveIfAbsent(argThat(item ->
+                item.getFrameHeadcount() == null
+                        && item.getFrameDensity() == null
+                        && item.getFrameCongestionLevel() == null));
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
+++ b/src/test/java/com/saferoute/domain/telemetry/dynamo/entity/TelemetryItemTest.java
@@ -58,8 +58,11 @@ class TelemetryItemTest {
 
         assertThat(attributes.get("avgHeadcount").n()).isEqualTo("5.0");
         assertThat(attributes.get("peakHeadcount").n()).isEqualTo("8");
+        assertThat(attributes.get("frameHeadcount").n()).isEqualTo("7");
         assertThat(attributes.get("sampleCount").n()).isEqualTo("25");
         assertThat(attributes.get("density").n()).isEqualTo("2.5");
+        assertThat(attributes.get("frameDensity").n()).isEqualTo("3.5");
+        assertThat(attributes.get("frameCongestionLevel").s()).isEqualTo("CROWDED");
         assertThat(attributes.get("edgeId").s()).isEqualTo(EDGE_ID.toString());
         assertThat(attributes)
                 .containsEntry("GSI1_PK", AttributeValue.fromS("SESSION#" + SESSION_ID + "#CCTV#CCTV_001"))
@@ -130,8 +133,8 @@ class TelemetryItemTest {
 
     private ObservationItem observation() {
         return ObservationItem.create(
-                OBSERVATION_ID, SESSION_ID, EDGE_ID, "CCTV_001", 5.0, 8, 25,
-                2.5, CongestionLevel.CAUTION, 1_786_500_000_000L,
+                OBSERVATION_ID, SESSION_ID, EDGE_ID, "CCTV_001", 5.0, 8, 7, 25,
+                2.5, CongestionLevel.CAUTION, 3.5, CongestionLevel.CROWDED, 1_786_500_000_000L,
                 1_786_500_005_000L, 1_786_500_005_000L, null, 1L
         );
     }

--- a/src/test/java/com/saferoute/domain/training/dto/MonitoringFrameResponseTest.java
+++ b/src/test/java/com/saferoute/domain/training/dto/MonitoringFrameResponseTest.java
@@ -1,0 +1,42 @@
+package com.saferoute.domain.training.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.saferoute.domain.congestion.entity.CongestionLevel;
+import com.saferoute.domain.telemetry.dynamo.entity.ObservationItem;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class MonitoringFrameResponseTest {
+
+    @Test
+    void 신규_관측은_이미지_Snapshot_기준_인원과_밀집도와_단계를_반환한다() {
+        ObservationItem item = legacyObservation();
+        item.setFrameHeadcount(3);
+        item.setFrameDensity(0.75);
+        item.setFrameCongestionLevel(CongestionLevel.NORMAL);
+
+        MonitoringFrameResponse frame = MonitoringFrameResponse.withoutImage(item);
+
+        assertThat(frame.headcount()).isEqualTo(3);
+        assertThat(frame.density()).isEqualTo(0.75);
+        assertThat(frame.congestionLevel()).isEqualTo(CongestionLevel.NORMAL);
+    }
+
+    @Test
+    void 기존_관측은_구간_최대_인원과_평균_밀집도로_fallback한다() {
+        MonitoringFrameResponse frame = MonitoringFrameResponse.withoutImage(legacyObservation());
+
+        assertThat(frame.headcount()).isEqualTo(5);
+        assertThat(frame.density()).isEqualTo(0.42);
+        assertThat(frame.congestionLevel()).isEqualTo(CongestionLevel.CROWDED);
+    }
+
+    private ObservationItem legacyObservation() {
+        return ObservationItem.create(
+                UUID.randomUUID(), UUID.randomUUID(), null, "CCTV_001",
+                4.0, 5, 10, 0.42, CongestionLevel.CROWDED,
+                500L, 1_000L, 1_000L, null, 1L
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #235
- Branch: fix/#235

## 주요 내용
상세 모니터링 화면에서 이미지에 표시된 인원수와 카드의 감지 인원 및 밀집도가 서로 다른 기준으로 표시되는 문제를 수정합니다.

기존에는 다음 값이 혼합되어 사용됐습니다.

- 이미지 오버레이: 업로드된 단일 Snapshot의 실제 인원수
- 감지 인원: 5초 관측 구간의 `peakHeadcount`
- 밀집도 및 혼잡 단계: 5초 관측 구간의 `avgHeadcount` 기준 계산값

이 때문에 8명일 때 2.2명/㎡, 10명일 때 2.1명/㎡처럼 화면상 인원수가 증가했지만 밀집도가 감소하거나, 이미지와 카드의 인원수가 일치하지 않을 수 있었습니다.

## 변경 사항

### 1. 관측 요청에 프레임 인원수 추가

AI가 전달하는 `frameHeadcount`를 관측 요청에서 수신합니다.

```json
{
  "avgHeadcount": 4.75,
  "peakHeadcount": 8,
  "frameHeadcount": 7,
  "sampleCount": 25
}
```

`frameHeadcount`는 `monitoringImageKey`가 가리키는 이미지 Snapshot의 실제 인원수입니다.

### 2. 프레임 기준 지표 계산 및 저장

BE가 CCTV 감시 면적을 이용해 다음 값을 직접 계산하고 DynamoDB Observation에 저장합니다.

```text
frameDensity = frameHeadcount / monitoredAreaM2
frameCongestionLevel = congestionThresholds.classify(frameDensity)
```

저장 필드:

- `frameHeadcount`
- `frameDensity`
- `frameCongestionLevel`

기존 5초 구간 지표는 그대로 유지합니다.

- `avgHeadcount`
- `peakHeadcount`
- `density`
- `congestionLevel`

### 3. 상세 모니터링 프레임 응답 변경

프론트가 사용하는 기존 응답 필드명과 타입은 변경하지 않고 내부 매핑만 변경합니다.

```text
headcount       ← frameHeadcount
density         ← frameDensity
congestionLevel ← frameCongestionLevel
```

따라서 프론트 수정은 필요하지 않습니다.

### 4. 기존 로직 영향 방지

다음 기능은 기존처럼 5초 평균 밀집도를 사용합니다.

- CCTV 현재 혼잡 상태
- WebSocket 상태 갱신
- 경로 재계산 판단
- 혼잡 단계 판정 및 관련 이벤트

프레임 기준 지표는 상세 모니터링 이미지와 카드의 표시를 일치시키는 용도로만 사용합니다.

### 5. 하위 호환성

구버전 AI 요청에서는 `frameHeadcount`가 없을 수 있으므로 선택 필드로 수신합니다.

기존 DynamoDB Observation에도 프레임 필드가 없을 수 있어 다음 fallback을 적용합니다.

```text
headcount       = frameHeadcount       ?? peakHeadcount
density         = frameDensity         ?? density
congestionLevel = frameCongestionLevel ?? congestionLevel
```
### 6. 요청값 검증

- `frameHeadcount`는 0 이상이어야 합니다.
- `frameHeadcount`는 같은 구간의 `peakHeadcount`를 초과할 수 없습니다.
- `frameHeadcount`가 없는 구버전 요청은 정상 처리합니다.

## 테스트

다음 항목을 검증했습니다.

- 신규 프레임 지표 계산 및 DynamoDB 저장
- 이미지 Snapshot 기준 프레임 응답 매핑
- 기존 Observation fallback
- 구버전 AI 요청 호환
- 잘못된 `frameHeadcount` 요청 거부
- 현재 상태가 기존 평균 밀집도를 계속 사용하는지 검증
- 전체 회귀 테스트 통과

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 이미지 Snapshot 기준 인원수, 밀도, 혼잡 단계 관측값을 저장하고 제공합니다.
  - 프레임 인원수 기반 밀도와 혼잡 단계를 자동 계산합니다.
  - 기존 요청 및 데이터에는 기존 관측값을 사용해 호환성을 유지합니다.

- **버그 수정**
  - 프레임 인원수가 최대 인원수를 초과하는 잘못된 요청을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->