### PR TITLE
fix(building, evacuation) #237: 길이 단위 변환 및 중복 경로 변경 제안 방지

### DIFF
--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionEventService.java
@@ -118,10 +118,9 @@ public class CongestionEventService {
                                     + "sessionId={}, cctvCode={}, level={}, triggerType={}",
                             session.getId(), cctv.getCode(), savedLevel, triggerType
                     );
-                }
-                for (MapEdge edge : affectedEdges) {
+                } else {
                     routeRecalculationService.trigger(
-                            session, edge, savedLevel, triggerType, cctv.getCode(), density);
+                            session, affectedEdges, savedLevel, triggerType, cctv.getCode(), density);
                 }
             }
             publishAndCompleteAfterCommit(session.getId(), affectedEdges, saveResult.item());

--- a/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
+++ b/src/main/java/com/saferoute/domain/congestion/service/CongestionObservationService.java
@@ -152,10 +152,10 @@ public class CongestionObservationService {
                                     + "sessionId={}, cctvCode={}, level={}",
                             session.getId(), cctv.getCode(), savedLevel
                     );
-                }
-                for (MapEdge edge : affectedEdges) {
+                } else {
                     routeRecalculationService.trigger(
-                            session, edge, savedLevel, RecalculationTriggerType.LEVEL_UP, cctv.getCode(), density);
+                            session, affectedEdges, savedLevel, RecalculationTriggerType.LEVEL_UP,
+                            cctv.getCode(), density);
                 }
             }
             publishAndCompleteAfterCommit(session.getId(), affectedEdges, saveResult.item(), processingOwner);

--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
@@ -53,7 +53,7 @@ public class FloorGridController {
     @Operation(
             summary = "층 그리드 생성/재생성",
             description = """
-                    지정한 층에 cellSizeCm(센티미터 단위 셀 한 변 길이) 기준으로 격자 그리드를
+                    지정한 층에 cellSizeMeter(센티미터 단위 셀 한 변 길이) 기준으로 격자 그리드를
                     새로 생성합니다. 백엔드는 요청 경계에서 미터로 변환합니다. 이미 그리드가
                     존재하는 층에 다시 호출하면 최초 생성과 동일한
                     로직으로 전체를 재생성합니다(부분 수정 불가).
@@ -66,7 +66,7 @@ public class FloorGridController {
 
                     도면 세그멘테이션이 완료(DONE) 상태이고 실측 가로/세로 값(realWidth/
                     realHeight)이 설정되어 있어야 하며, 그렇지 않으면 오류가 발생합니다. 계산된
-                    셀 개수가 너무 많거나(rows × columns 상한 초과) cellSizeCm를 미터로 변환해 계산한
+                    셀 개수가 너무 많거나(rows × columns 상한 초과) cellSizeMeter를 미터로 변환해 계산한
                     행/열 수가 0 이하이면(비정상적으로 큰 셀 크기) 오류가 발생합니다.
                     """
     )

--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
@@ -53,8 +53,9 @@ public class FloorGridController {
     @Operation(
             summary = "층 그리드 생성/재생성",
             description = """
-                    지정한 층에 cellSizeMeter(미터 단위 셀 한 변 길이) 기준으로 격자 그리드를
-                    새로 생성합니다. 이미 그리드가 존재하는 층에 다시 호출하면 최초 생성과 동일한
+                    지정한 층에 cellSizeCm(센티미터 단위 셀 한 변 길이) 기준으로 격자 그리드를
+                    새로 생성합니다. 백엔드는 요청 경계에서 미터로 변환합니다. 이미 그리드가
+                    존재하는 층에 다시 호출하면 최초 생성과 동일한
                     로직으로 전체를 재생성합니다(부분 수정 불가).
 
                     재생성 시 기존 그리드 셀은 모두 삭제되고(연결된 NodeGridCell/MapEdgeGridCell도
@@ -65,7 +66,7 @@ public class FloorGridController {
 
                     도면 세그멘테이션이 완료(DONE) 상태이고 실측 가로/세로 값(realWidth/
                     realHeight)이 설정되어 있어야 하며, 그렇지 않으면 오류가 발생합니다. 계산된
-                    셀 개수가 너무 많거나(rows × columns 상한 초과) cellSizeMeter로 계산한
+                    셀 개수가 너무 많거나(rows × columns 상한 초과) cellSizeCm를 미터로 변환해 계산한
                     행/열 수가 0 이하이면(비정상적으로 큰 셀 크기) 오류가 발생합니다.
                     """
     )

--- a/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/controller/FloorGridController.java
@@ -66,8 +66,9 @@ public class FloorGridController {
 
                     도면 세그멘테이션이 완료(DONE) 상태이고 실측 가로/세로 값(realWidth/
                     realHeight)이 설정되어 있어야 하며, 그렇지 않으면 오류가 발생합니다. 계산된
-                    셀 개수가 너무 많거나(rows × columns 상한 초과) cellSizeMeter를 미터로 변환해 계산한
-                    행/열 수가 0 이하이면(비정상적으로 큰 셀 크기) 오류가 발생합니다.
+                    cellSizeMeter는 유한한 0.1cm 이상의 값이어야 합니다. 미터 변환 또는 행·열 계산
+                    결과가 유한하지 않거나 0 이하인 경우, 혹은 rows × columns가 상한을 초과하면
+                    오류가 발생합니다.
                     """
     )
     @PutMapping

--- a/src/main/java/com/saferoute/domain/evacuation/grid/dto/request/CreateOrUpdateFloorGridRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/dto/request/CreateOrUpdateFloorGridRequest.java
@@ -3,6 +3,12 @@ package com.saferoute.domain.evacuation.grid.dto.request;
 import jakarta.validation.constraints.Positive;
 
 public record CreateOrUpdateFloorGridRequest(
-        @Positive double cellSizeMeter
+        @Positive double cellSizeCm
 ) {
+
+    private static final double CENTIMETERS_PER_METER = 100.0;
+
+    public double cellSizeMeter() {
+        return cellSizeCm / CENTIMETERS_PER_METER;
+    }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/grid/dto/request/CreateOrUpdateFloorGridRequest.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/dto/request/CreateOrUpdateFloorGridRequest.java
@@ -3,12 +3,12 @@ package com.saferoute.domain.evacuation.grid.dto.request;
 import jakarta.validation.constraints.Positive;
 
 public record CreateOrUpdateFloorGridRequest(
-        @Positive double cellSizeCm
+        @Positive double cellSizeMeter
 ) {
 
     private static final double CENTIMETERS_PER_METER = 100.0;
 
-    public double cellSizeMeter() {
-        return cellSizeCm / CENTIMETERS_PER_METER;
+    public double cellSizeInMeters() {
+        return cellSizeMeter / CENTIMETERS_PER_METER;
     }
 }

--- a/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
@@ -91,12 +91,12 @@ public class FloorGridService {
 
         validateFloorReady(floor);
 
-        long columnsLong = (long) Math.ceil(floor.getRealWidth() / request.cellSizeMeter());
-        long rowsLong = (long) Math.ceil(floor.getRealHeight() / request.cellSizeMeter());
+        long columnsLong = (long) Math.ceil(floor.getRealWidth() / request.cellSizeInMeters());
+        long rowsLong = (long) Math.ceil(floor.getRealHeight() / request.cellSizeInMeters());
         validateGridSize(rowsLong, columnsLong);
 
-        int columns = (int) Math.ceil(floor.getRealWidth() / request.cellSizeMeter());
-        int rows = (int) Math.ceil(floor.getRealHeight() / request.cellSizeMeter());
+        int columns = (int) Math.ceil(floor.getRealWidth() / request.cellSizeInMeters());
+        int rows = (int) Math.ceil(floor.getRealHeight() / request.cellSizeInMeters());
         validateGridSize(rows, columns);
 
         // 기존 그리드 셀 삭제 -> DB FK CASCADE로 NodeGridCell, MapEdgeGridCell 함께 삭제
@@ -121,7 +121,7 @@ public class FloorGridService {
         remapEdgesToGrid(edges, cells, rows, columns);
 
         // Floor에 최종 그리드 설정 반영
-        floor.applyGridCellConfig(request.cellSizeMeter(), rows, columns);
+        floor.applyGridCellConfig(request.cellSizeInMeters(), rows, columns);
         Floor savedFloor = floorRepository.save(floor);
 
         return FloorGridResponse.of(savedFloor);
@@ -147,8 +147,8 @@ public class FloorGridService {
     private List<FloorGridCell> buildCells(Floor floor, int rows, int columns,
                                            CreateOrUpdateFloorGridRequest request) {
         List<FloorGridCell> cells = new ArrayList<>(rows * columns);
-        double cellWidthNorm = request.cellSizeMeter() / floor.getRealWidth();
-        double cellHeightNorm = request.cellSizeMeter() / floor.getRealHeight();
+        double cellWidthNorm = request.cellSizeInMeters() / floor.getRealWidth();
+        double cellHeightNorm = request.cellSizeInMeters() / floor.getRealHeight();
 
         for (int row = 0; row < rows; row++) {
             for (int col = 0; col < columns; col++) {

--- a/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/grid/service/FloorGridService.java
@@ -38,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FloorGridService {
 
     private static final long MAX_GRID_CELL_COUNT = 1_000_000L; // 테스트 후 값 수정
+    private static final double MIN_CELL_SIZE_METER = 0.001; // 0.1cm
 
     private final FloorRepository floorRepository;
     private final FloorGridCellRepository floorGridCellRepository;
@@ -91,13 +92,15 @@ public class FloorGridService {
 
         validateFloorReady(floor);
 
-        long columnsLong = (long) Math.ceil(floor.getRealWidth() / request.cellSizeInMeters());
-        long rowsLong = (long) Math.ceil(floor.getRealHeight() / request.cellSizeInMeters());
+        double cellSizeMeter = request.cellSizeInMeters();
+        validateCellSize(cellSizeMeter);
+
+        long columnsLong = calculateGridDimension(floor.getRealWidth(), cellSizeMeter);
+        long rowsLong = calculateGridDimension(floor.getRealHeight(), cellSizeMeter);
         validateGridSize(rowsLong, columnsLong);
 
-        int columns = (int) Math.ceil(floor.getRealWidth() / request.cellSizeInMeters());
-        int rows = (int) Math.ceil(floor.getRealHeight() / request.cellSizeInMeters());
-        validateGridSize(rows, columns);
+        int columns = Math.toIntExact(columnsLong);
+        int rows = Math.toIntExact(rowsLong);
 
         // 기존 그리드 셀 삭제 -> DB FK CASCADE로 NodeGridCell, MapEdgeGridCell 함께 삭제
         floorGridCellRepository.deleteAllByFloorId(floorId);
@@ -109,7 +112,7 @@ public class FloorGridService {
         // (유도등은 CustomDeviceType.GUIDE_LIGHT라 대상에서 제외, 그대로 유지)
         mapNodeRepository.deleteAllByFloorIdAndCustomDeviceType(floorId, CustomDeviceType.CCTV);
 
-        List<FloorGridCell> cells = buildCells(floor, rows, columns, request);
+        List<FloorGridCell> cells = buildCells(floor, rows, columns, cellSizeMeter);
         floorGridCellRepository.saveAll(cells);
 
         // 살아남은 노드(STAIR/ROOM/HALLWAY/DOOR/EXIT, 유도등) 새 그리드에 재매핑
@@ -121,7 +124,7 @@ public class FloorGridService {
         remapEdgesToGrid(edges, cells, rows, columns);
 
         // Floor에 최종 그리드 설정 반영
-        floor.applyGridCellConfig(request.cellSizeInMeters(), rows, columns);
+        floor.applyGridCellConfig(cellSizeMeter, rows, columns);
         Floor savedFloor = floorRepository.save(floor);
 
         return FloorGridResponse.of(savedFloor);
@@ -129,26 +132,44 @@ public class FloorGridService {
 
     private void validateFloorReady(Floor floor) {
         if (floor.getSegmentationStatus() != SegmentationStatus.DONE
-                || floor.getRealWidth() == null || floor.getRealHeight() == null) {
+                || floor.getRealWidth() == null || floor.getRealHeight() == null
+                || !Double.isFinite(floor.getRealWidth()) || !Double.isFinite(floor.getRealHeight())
+                || floor.getRealWidth() <= 0 || floor.getRealHeight() <= 0) {
             throw new ApiException(GridErrorCode.FLOOR_NOT_READY_FOR_GRID);
         }
+    }
+
+    private void validateCellSize(double cellSizeMeter) {
+        if (!Double.isFinite(cellSizeMeter) || cellSizeMeter < MIN_CELL_SIZE_METER) {
+            throw new ApiException(GridErrorCode.INVALID_CELL_SIZE);
+        }
+    }
+
+    private long calculateGridDimension(double realLengthMeter, double cellSizeMeter) {
+        double dimension = Math.ceil(realLengthMeter / cellSizeMeter);
+        if (!Double.isFinite(dimension) || dimension <= 0) {
+            throw new ApiException(GridErrorCode.INVALID_CELL_SIZE);
+        }
+        if (dimension > MAX_GRID_CELL_COUNT) {
+            throw new ApiException(GridErrorCode.TOO_MANY_GRID_CELLS);
+        }
+        return (long) dimension;
     }
 
     private void validateGridSize(long rows, long columns) {
         if (rows <= 0 || columns <= 0) {
             throw new ApiException(GridErrorCode.INVALID_CELL_SIZE);
         }
-        long totalCells = rows * columns;
-        if (totalCells > MAX_GRID_CELL_COUNT) {
+        if (rows > MAX_GRID_CELL_COUNT / columns) {
             throw new ApiException(GridErrorCode.TOO_MANY_GRID_CELLS);
         }
     }
 
     private List<FloorGridCell> buildCells(Floor floor, int rows, int columns,
-                                           CreateOrUpdateFloorGridRequest request) {
+                                           double cellSizeMeter) {
         List<FloorGridCell> cells = new ArrayList<>(rows * columns);
-        double cellWidthNorm = request.cellSizeInMeters() / floor.getRealWidth();
-        double cellHeightNorm = request.cellSizeInMeters() / floor.getRealHeight();
+        double cellWidthNorm = cellSizeMeter / floor.getRealWidth();
+        double cellHeightNorm = cellSizeMeter / floor.getRealHeight();
 
         for (int row = 0; row < rows; row++) {
             for (int col = 0; col < columns; col++) {

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RouteRecalculation.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/entity/RouteRecalculation.java
@@ -29,10 +29,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 // 혼잡 감지로 트리거된 우회 경로 재탐색 결과. 관리자가 승인해야 실제 대피 경로에 반영된다.
 //
-// 같은 세션+엣지라도 혼잡 레벨이 오르내릴 때마다 PENDING -> CANCELLED -> 새 PENDING, 승인 후
-// 다시 레벨이 오르면 그 엣지에 대해 두 번째 APPROVED가 생기는 식으로 이력이 여러 행 쌓일 수 있어
-// (session, edge, status) 유니크 제약은 걸지 않는다 - "같은 세션+엣지에 PENDING 하나만" 규칙은
-// RouteRecalculationService가 트리거 시점에 조회해서 지킨다.
+// 혼잡 레벨이 오르내릴 때마다 PENDING -> CANCELLED -> 새 PENDING 이력이 쌓일 수 있다.
+// 세션 잠금과 RouteRecalculationService의 트리거 로직으로 세션당 유효한 PENDING 하나만 유지한다.
 @Entity
 @Getter
 @Table(name = "route_recalculations")

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
@@ -9,19 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRecalculationRepository extends JpaRepository<RouteRecalculation, UUID> {
 
-    // Pi가 혼잡 이벤트를 짧은 주기로 반복 전송하므로, 같은 세션+엣지에 대해
-    // 이미 PENDING이 있으면 그 요청을 조회해 레벨이 같으면 무시하고, 다르면 취소 후 새로 만든다.
-    Optional<RouteRecalculation> findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-            UUID trainingSessionId, UUID triggerEdgeId, RecalculationStatus status);
-
-    // 같은 세션+엣지에서 가장 최근에 승인된 경로 - "현재 활성 경로"의 대용으로 쓴다
-    // (이 시스템엔 활성 경로를 별도로 저장하는 개념이 없음).
-    Optional<RouteRecalculation> findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
-            UUID trainingSessionId, UUID triggerEdgeId, RecalculationStatus status);
-
-    // 세션 전체에서(트리거 엣지 무관) 가장 최근에 승인된 경로 - "지금 안내 중인 경로" 조회(GET
-    // /api/v1/sessions/{sessionId}/current-route)에서 사용. 없으면 호출부가 시나리오의
-    // startNodeId 기준 최단 경로로 대체한다.
+    // 세션 전체에서 가장 최근에 승인된 경로를 현재 활성 경로로 사용한다.
     Optional<RouteRecalculation> findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
             UUID trainingSessionId, RecalculationStatus status);
 

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/repository/RouteRecalculationRepository.java
@@ -6,8 +6,19 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RouteRecalculationRepository extends JpaRepository<RouteRecalculation, UUID> {
+
+    @Query("""
+            select r.trainingSession.id
+            from RouteRecalculation r
+            where r.id = :id
+              and r.trainingSession.scenario.building.schoolName = :schoolName
+            """)
+    Optional<UUID> findTrainingSessionIdByIdAndSchoolName(
+            @Param("id") UUID id, @Param("schoolName") String schoolName);
 
     // 세션 전체에서 가장 최근에 승인된 경로를 현재 활성 경로로 사용한다.
     Optional<RouteRecalculation> findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -60,51 +60,59 @@ public class RouteRecalculationService {
     private final MapNodeJpaRepository mapNodeJpaRepository;
 
     // 혼잡 감지로 트리거되는 우회 경로 재탐색.
-    // - 같은 세션+엣지에 이미 PENDING이 있고 레벨이 그대로면 반복 트리거를 무시한다.
-    // - 레벨이 바뀌었으면 기존 PENDING을 CANCELLED로 무효화하고 새로 계산한다.
+    // - CCTV 한 대가 감시하는 모든 엣지를 한 번에 반영해 후보 경로 하나만 만든다.
+    // - 같은 세션+CCTV에 이미 PENDING이 있고 레벨이 그대로면 반복 트리거를 무시한다.
+    // - 새 판단이 필요하면 기존 PENDING을 모두 CANCELLED로 무효화하고 새로 계산한다.
     // - triggerType이 ENDED(혼잡 종료)면 우회가 아니라 정상 경로로의 복구 후보를 계산한다.
     @Transactional
-    public void trigger(TrainingSession session, MapEdge triggerEdge, CongestionLevel level,
+    public void trigger(TrainingSession session, List<MapEdge> affectedEdges, CongestionLevel level,
             RecalculationTriggerType triggerType, String cctvCode, double density) {
-        Optional<RouteRecalculation> existingPending = routeRecalculationRepository
-                .findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-                        session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING);
-
-        if (triggerType == RecalculationTriggerType.ENDED) {
-            existingPending.ifPresent(pending -> cancel(pending, "혼잡 종료로 무효화됨"));
-            triggerRecovery(session, triggerEdge, level, cctvCode, density);
+        if (affectedEdges.isEmpty()) {
             return;
         }
 
-        if (existingPending.isPresent()) {
-            RouteRecalculation pending = existingPending.get();
-            if (pending.getCongestionLevel() == level) {
-                return;
-            }
-            cancel(pending, "혼잡 단계 변경으로 무효화됨 (" + pending.getCongestionLevel() + " -> " + level + ")");
+        TrainingSession lockedSession = trainingSessionRepository.findByIdForUpdate(session.getId()).orElse(session);
+        MapEdge representativeEdge = affectedEdges.get(0);
+        List<RouteRecalculation> existingPending = routeRecalculationRepository
+                .findAllByTrainingSession_IdAndStatus(session.getId(), RecalculationStatus.PENDING);
+
+        if (triggerType == RecalculationTriggerType.ENDED) {
+            existingPending.forEach(pending -> cancel(pending, "혼잡 종료로 무효화됨"));
+            triggerRecovery(lockedSession, representativeEdge, level, cctvCode, density);
+            return;
         }
 
-        UUID floorId = triggerEdge.getFloor().getId();
+        boolean samePendingExists = existingPending.stream().anyMatch(pending ->
+                pending.getCctvCode().equals(cctvCode) && pending.getCongestionLevel() == level);
+        if (samePendingExists) {
+            return;
+        }
+        for (RouteRecalculation pending : existingPending) {
+            cancel(pending, "새 혼잡 판단으로 무효화됨");
+        }
+
+        UUID floorId = representativeEdge.getFloor().getId();
         // 현재 유효 경로는 항상 "시나리오 대표 startNode -> EXIT" 완전한 한 경로여야 하므로,
         // 혼잡 엣지의 fromNode가 아니라 시나리오의 대표 startNode에서 다시 계산한다.
-        MapNode representativeStart = session.getScenario().getStartNode();
+        MapNode representativeStart = lockedSession.getScenario().getStartNode();
         if (representativeStart == null) {
             log.warn("시나리오에 대표 startNode가 없어 재탐색 승인 대기 항목을 생성하지 않음: sessionId={}",
-                    session.getId());
+                    lockedSession.getId());
             return;
         }
         UUID startNodeId = representativeStart.getId();
 
-        RouteSnapshot previous = resolveActiveRoute(session, triggerEdge, floorId, startNodeId);
+        RouteSnapshot previous = resolveActiveRoute(lockedSession, floorId, startNodeId);
 
         EvacuationRoute candidate;
         try {
             candidate = evacuationRouteService.findShortestRoute(
-                    floorId, startNodeId, excludedEdgesFor(triggerEdge, level), weightMultipliersFor(triggerEdge, level));
+                    floorId, startNodeId, excludedEdgesFor(affectedEdges, level),
+                    weightMultipliersFor(affectedEdges, level));
         } catch (ApiException exception) {
             if (exception.getErrorCode() == EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND) {
                 log.warn("우회 경로를 찾을 수 없어 재탐색 승인 대기 항목을 생성하지 않음: sessionId={}, edgeId={}",
-                        session.getId(), triggerEdge.getId());
+                        lockedSession.getId(), representativeEdge.getId());
                 return;
             }
             throw exception;
@@ -117,21 +125,29 @@ public class RouteRecalculationService {
             return;
         }
 
-        savePending(session, triggerEdge, cctvCode, triggerType, level, density, previous, candidate, candidateNodeIds);
+        savePending(lockedSession, representativeEdge, cctvCode, triggerType, level, density,
+                previous, candidate, candidateNodeIds);
     }
 
     // VERY_CROWDED만 완전 제외한다 - 배율만으로는 다른 대안이 훨씬 나쁠 때 여전히 그 엣지를
     // 통과하는 경로가 선택될 수 있어, "사실상 통행 불가"를 표현하려면 그래프에서 아예 빼야 한다.
-    private Set<UUID> excludedEdgesFor(MapEdge triggerEdge, CongestionLevel level) {
-        return level == CongestionLevel.VERY_CROWDED ? Set.of(triggerEdge.getId()) : Set.of();
+    private Set<UUID> excludedEdgesFor(List<MapEdge> affectedEdges, CongestionLevel level) {
+        return level == CongestionLevel.VERY_CROWDED
+                ? affectedEdges.stream().map(MapEdge::getId).collect(Collectors.toSet())
+                : Set.of();
     }
 
-    private Map<UUID, Double> weightMultipliersFor(MapEdge triggerEdge, CongestionLevel level) {
-        return switch (level) {
-            case CAUTION -> Map.of(triggerEdge.getId(), CAUTION_WEIGHT_MULTIPLIER);
-            case CROWDED -> Map.of(triggerEdge.getId(), CROWDED_WEIGHT_MULTIPLIER);
-            case NORMAL, VERY_CROWDED -> Map.of();
+    private Map<UUID, Double> weightMultipliersFor(List<MapEdge> affectedEdges, CongestionLevel level) {
+        double multiplier = switch (level) {
+            case CAUTION -> CAUTION_WEIGHT_MULTIPLIER;
+            case CROWDED -> CROWDED_WEIGHT_MULTIPLIER;
+            case NORMAL, VERY_CROWDED -> 1.0;
         };
+        if (multiplier == 1.0) {
+            return Map.of();
+        }
+        return affectedEdges.stream().collect(Collectors.toMap(
+                MapEdge::getId, edge -> multiplier, (left, right) -> left));
     }
 
     // 혼잡 종료 시 정상(트리거 엣지를 포함한 직행) 경로로의 복구 후보를 계산한다.
@@ -139,8 +155,8 @@ public class RouteRecalculationService {
     private void triggerRecovery(TrainingSession session, MapEdge triggerEdge, CongestionLevel level,
             String cctvCode, double density) {
         Optional<RouteRecalculation> latestApproved = routeRecalculationRepository
-                .findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
-                        session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED);
+                .findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                        session.getId(), RecalculationStatus.APPROVED);
         if (latestApproved.isEmpty()) {
             return;
         }
@@ -180,12 +196,12 @@ public class RouteRecalculationService {
         trainingEventPublisher.publishRouteRecalculationRequestedAfterCommit(recalculation);
     }
 
-    // "현재 활성 경로"를 별도로 저장하지 않으므로, 가장 최근 승인된 경로가 있으면 그것을,
-    // 없으면 트리거 엣지를 그대로 포함한 정상(직행) 경로를 활성 경로로 취급한다.
-    private RouteSnapshot resolveActiveRoute(TrainingSession session, MapEdge triggerEdge, UUID floorId, UUID startNodeId) {
+    // "현재 활성 경로"를 별도로 저장하지 않으므로, 세션에서 가장 최근 승인된 경로가 있으면 그것을,
+    // 없으면 대표 시작점 기준 정상(직행) 경로를 활성 경로로 취급한다.
+    private RouteSnapshot resolveActiveRoute(TrainingSession session, UUID floorId, UUID startNodeId) {
         Optional<RouteRecalculation> latestApproved = routeRecalculationRepository
-                .findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
-                        session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED);
+                .findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                        session.getId(), RecalculationStatus.APPROVED);
         if (latestApproved.isPresent()) {
             RouteRecalculation approved = latestApproved.get();
             return new RouteSnapshot(approved.getRecalculatedNodeIds(), approved.getTotalWeight());
@@ -322,8 +338,14 @@ public class RouteRecalculationService {
         RouteRecalculation recalculation = findOrThrow(recalculationId, approverEmail);
         validatePending(recalculation);
         User approver = findUserOrThrow(approverEmail);
+        List<RouteRecalculation> siblingPending = routeRecalculationRepository
+                .findAllByTrainingSession_IdAndStatus(
+                        recalculation.getTrainingSession().getId(), RecalculationStatus.PENDING);
 
         recalculation.approve(Instant.now(), approver);
+        siblingPending.stream()
+                .filter(pending -> !pending.getId().equals(recalculation.getId()))
+                .forEach(pending -> cancel(pending, "다른 경로 승인으로 무효화됨"));
         trainingEventPublisher.publishEvacuationRouteUpdatedAfterCommit(recalculation);
         ioTLightService.applyRouteGuidance(recalculation.getRecalculatedNodeIds());
 

--- a/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
+++ b/src/main/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationService.java
@@ -335,12 +335,21 @@ public class RouteRecalculationService {
 
     @Transactional
     public RouteRecalculationResponse approve(UUID recalculationId, String approverEmail) {
-        RouteRecalculation recalculation = findOrThrow(recalculationId, approverEmail);
+        String schoolName = schoolContextService.getSchoolName(approverEmail);
+        UUID sessionId = routeRecalculationRepository
+                .findTrainingSessionIdByIdAndSchoolName(recalculationId, schoolName)
+                .orElseThrow(() -> new ApiException(EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND));
+        trainingSessionRepository.findByIdForUpdate(sessionId)
+                .orElseThrow(() -> new ApiException(TrainingErrorCode.TRAINING_SESSION_NOT_FOUND));
+
+        RouteRecalculation recalculation = routeRecalculationRepository
+                .findByIdAndTrainingSession_Scenario_Building_SchoolName(recalculationId, schoolName)
+                .orElseThrow(() -> new ApiException(EvacuationErrorCode.ROUTE_RECALCULATION_NOT_FOUND));
         validatePending(recalculation);
         User approver = findUserOrThrow(approverEmail);
         List<RouteRecalculation> siblingPending = routeRecalculationRepository
                 .findAllByTrainingSession_IdAndStatus(
-                        recalculation.getTrainingSession().getId(), RecalculationStatus.PENDING);
+                        sessionId, RecalculationStatus.PENDING);
 
         recalculation.approve(Instant.now(), approver);
         siblingPending.stream()

--- a/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
+++ b/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
@@ -85,8 +85,8 @@ public class FloorController {
     @Operation(
             summary = "도면 이미지 업로드",
             description = """
-                    이미 등록되어 있는 층에 도면 이미지 파일과 실제 크기(realWidthCm,
-                    realHeightCm, 센티미터 단위)를 업로드합니다. 백엔드는 요청 경계에서 미터로
+                    이미 등록되어 있는 층에 도면 이미지 파일과 실제 크기(realWidth,
+                    realHeight, 센티미터 단위)를 업로드합니다. 백엔드는 요청 경계에서 미터로
                     변환해 저장합니다. 대상 층은 floorId가 아니라 floorNum으로 지정하며,
                     해당 buildingId 안에 그 floorNum을 가진 층이 없으면 실패하므로 반드시 층 등록
                     API로 층을 먼저 만든 뒤 호출해야 합니다.
@@ -95,7 +95,7 @@ public class FloorController {
                     segmentationStatus가 DONE으로 바뀝니다. 이미 이미지가 있는 층에 다시
                     호출하면 기존 값을 덮어쓰며, 이전 S3 객체는 별도로 삭제되지 않습니다.
 
-                    realWidthCm/realHeightCm는 도면 픽셀 좌표를 실제 거리로 환산하는 데 쓰이므로
+                    realWidth/realHeight는 도면 픽셀 좌표를 실제 거리로 환산하는 데 쓰이므로
                     반드시 양수여야 합니다.
                     """
     )

--- a/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
+++ b/src/main/java/com/saferoute/domain/floor/controller/FloorController.java
@@ -85,8 +85,9 @@ public class FloorController {
     @Operation(
             summary = "도면 이미지 업로드",
             description = """
-                    이미 등록되어 있는 층에 도면 이미지 파일과 실제 크기(realWidth, realHeight,
-                    미터 단위)를 업로드합니다. 대상 층은 floorId가 아니라 floorNum으로 지정하며,
+                    이미 등록되어 있는 층에 도면 이미지 파일과 실제 크기(realWidthCm,
+                    realHeightCm, 센티미터 단위)를 업로드합니다. 백엔드는 요청 경계에서 미터로
+                    변환해 저장합니다. 대상 층은 floorId가 아니라 floorNum으로 지정하며,
                     해당 buildingId 안에 그 floorNum을 가진 층이 없으면 실패하므로 반드시 층 등록
                     API로 층을 먼저 만든 뒤 호출해야 합니다.
 
@@ -94,7 +95,7 @@ public class FloorController {
                     segmentationStatus가 DONE으로 바뀝니다. 이미 이미지가 있는 층에 다시
                     호출하면 기존 값을 덮어쓰며, 이전 S3 객체는 별도로 삭제되지 않습니다.
 
-                    realWidth/realHeight는 도면 픽셀 좌표를 실제 거리로 환산하는 데 쓰이므로
+                    realWidthCm/realHeightCm는 도면 픽셀 좌표를 실제 거리로 환산하는 데 쓰이므로
                     반드시 양수여야 합니다.
                     """
     )

--- a/src/main/java/com/saferoute/domain/floor/dto/request/UploadFloorRequest.java
+++ b/src/main/java/com/saferoute/domain/floor/dto/request/UploadFloorRequest.java
@@ -6,18 +6,18 @@ import jakarta.validation.constraints.Positive;
 
 public record UploadFloorRequest(
     @NotNull Integer floorNum,
-    @Positive @NotNull Double realWidthCm,
-    @Positive @NotNull Double realHeightCm,
+    @Positive @NotNull Double realWidth,
+    @Positive @NotNull Double realHeight,
     @NotNull MultipartFile file
 ) {
 
     private static final double CENTIMETERS_PER_METER = 100.0;
 
     public double realWidthMeter() {
-        return realWidthCm / CENTIMETERS_PER_METER;
+        return realWidth / CENTIMETERS_PER_METER;
     }
 
     public double realHeightMeter() {
-        return realHeightCm / CENTIMETERS_PER_METER;
+        return realHeight / CENTIMETERS_PER_METER;
     }
 }

--- a/src/main/java/com/saferoute/domain/floor/dto/request/UploadFloorRequest.java
+++ b/src/main/java/com/saferoute/domain/floor/dto/request/UploadFloorRequest.java
@@ -6,9 +6,18 @@ import jakarta.validation.constraints.Positive;
 
 public record UploadFloorRequest(
     @NotNull Integer floorNum,
-    @Positive @NotNull Double realWidth,
-    @Positive @NotNull Double realHeight,
+    @Positive @NotNull Double realWidthCm,
+    @Positive @NotNull Double realHeightCm,
     @NotNull MultipartFile file
 ) {
 
+    private static final double CENTIMETERS_PER_METER = 100.0;
+
+    public double realWidthMeter() {
+        return realWidthCm / CENTIMETERS_PER_METER;
+    }
+
+    public double realHeightMeter() {
+        return realHeightCm / CENTIMETERS_PER_METER;
+    }
 }

--- a/src/main/java/com/saferoute/domain/floor/service/FloorService.java
+++ b/src/main/java/com/saferoute/domain/floor/service/FloorService.java
@@ -84,7 +84,7 @@ public class FloorService {
         S3UploadResponse uploadResult =
             s3Service.upload(request.file());
 
-        floor.upload(request.realHeight(), request.realWidth(), uploadResult.key());
+        floor.upload(request.realHeightMeter(), request.realWidthMeter(), uploadResult.key());
 
         return FloorResponse.from(floor);
     }

--- a/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/saferoute/domain/training/repository/TrainingSessionRepository.java
@@ -2,6 +2,7 @@ package com.saferoute.domain.training.repository;
 
 import com.saferoute.domain.training.entity.TrainingSession;
 import com.saferoute.domain.training.entity.TrainingStatus;
+import jakarta.persistence.LockModeType;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -10,10 +11,15 @@ import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TrainingSessionRepository extends JpaRepository<TrainingSession, UUID> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select s from TrainingSession s where s.id = :sessionId")
+  Optional<TrainingSession> findByIdForUpdate(@Param("sessionId") UUID sessionId);
 
   List<TrainingSession> findByStatusAndStartedAtBefore(TrainingStatus status, Instant threshold);
 

--- a/src/main/java/com/saferoute/global/api/error/GridErrorCode.java
+++ b/src/main/java/com/saferoute/global/api/error/GridErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GridErrorCode implements BaseErrorCode {
     FLOOR_NOT_READY_FOR_GRID(HttpStatus.BAD_REQUEST, "GRID001", "도면 분석(realWidth/realHeight)이 완료되지 않아 그리드를 생성할 수 없습니다."),
-    INVALID_CELL_SIZE(HttpStatus.BAD_REQUEST, "GRID002", "그리드 셀 크기는 0보다 커야 합니다."),
+    INVALID_CELL_SIZE(HttpStatus.BAD_REQUEST, "GRID002", "그리드 셀 크기는 유한한 0.1cm 이상이어야 합니다."),
     CELL_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "GRID003", "셀 크기가 도면 전체 크기보다 큽니다."),
     TOO_MANY_GRID_CELLS(HttpStatus.BAD_REQUEST, "GRID004", "셀 크기가 너무 작아 그리드 셀 개수가 허용 범위를 초과합니다."),
     GRID_CELL_NOT_FOUND(HttpStatus.NOT_FOUND, "GRID005", "그리드 셀을 찾을 수 없습니다."),

--- a/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisGridIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisGridIntegrationTest.java
@@ -68,7 +68,7 @@ class FloorAnalysisGridIntegrationTest {
         floorRepository.save(floor);
 
         floorGridService.createOrRegenerateGrid(
-                floor.getId(), new CreateOrUpdateFloorGridRequest(0.5));
+                floor.getId(), new CreateOrUpdateFloorGridRequest(50.0));
         List<java.util.UUID> gridCellIdsBeforeAnalysis = floorGridCellRepository
                 .findAllByFloor_Id(floor.getId()).stream()
                 .map(cell -> cell.getId())

--- a/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisRollbackIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/analysis/service/FloorAnalysisRollbackIntegrationTest.java
@@ -65,7 +65,7 @@ class FloorAnalysisRollbackIntegrationTest {
     void gridCellMismatch_rollsBackGraphReplacementAndKeepsFailedStatus() {
         UUID floorId = transactionTemplate.execute(status -> createFloorWithExistingGraph());
         floorGridService.createOrRegenerateGrid(
-                floorId, new CreateOrUpdateFloorGridRequest(0.5));
+                floorId, new CreateOrUpdateFloorGridRequest(50.0));
 
         transactionTemplate.executeWithoutResult(status -> {
             FloorGridCell oneCell = floorGridCellRepository.findAllByFloor_Id(floorId).get(0);

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionEventServiceTest.java
@@ -235,8 +235,8 @@ class CongestionEventServiceTest {
     }
 
     @Test
-    @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하되 발행은 이벤트당 한 번만 한다")
-    void reportCongestionEvent_triggersRecalculationForEachAffectedEdgeButPublishesOnce() {
+    @DisplayName("CCTV가 여러 Edge를 감시하면 영향 Edge를 묶어 재탐색을 한 번만 트리거한다")
+    void reportCongestionEvent_triggersOneRecalculationForAffectedEdges() {
         TrainingSession session = mock(TrainingSession.class);
         given(session.getId()).willReturn(sessionId);
         given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
@@ -253,9 +253,8 @@ class CongestionEventServiceTest {
         // headcount=13 -> density=3.25 -> CROWDED
         service.reportCongestionEvent(cctv, request(13));
 
-        verify(routeRecalculationService).trigger(eq(session), eq(edgeA), eq(CongestionLevel.CROWDED),
-                eq(RecalculationTriggerType.STARTED), eq("CCTV_001"), anyDouble());
-        verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED),
+        verify(routeRecalculationService).trigger(eq(session), eq(List.of(edgeA, edgeB)),
+                eq(CongestionLevel.CROWDED),
                 eq(RecalculationTriggerType.STARTED), eq("CCTV_001"), anyDouble());
         verify(trainingEventPublisher, times(1))
                 .publishCongestionEventReceived(eq(sessionId), eq(expectedEdgeIds), any());

--- a/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/congestion/service/CongestionObservationServiceTest.java
@@ -287,8 +287,8 @@ class CongestionObservationServiceTest {
     }
 
     @Test
-    @DisplayName("CCTV가 여러 Edge를 감시하면 CROWDED 이상일 때 Edge마다 재탐색을 트리거하되 발행은 CCTV당 한 번만 한다")
-    void reportObservation_triggersRecalculationForEachAffectedEdgeButPublishesOnce() {
+    @DisplayName("CCTV가 여러 Edge를 감시하면 영향 Edge를 묶어 재탐색을 한 번만 트리거한다")
+    void reportObservation_triggersOneRecalculationForAffectedEdges() {
         TrainingSession session = mock(TrainingSession.class);
         given(session.getId()).willReturn(sessionId);
         given(trainingSessionRepository.findByIdAndStatusAndScenario_Building_Id(
@@ -304,9 +304,8 @@ class CongestionObservationServiceTest {
         // avgHeadcount=13 -> density=3.25 -> CROWDED
         service.reportObservation(cctv, request(13.0));
 
-        verify(routeRecalculationService).trigger(eq(session), eq(edgeA), eq(CongestionLevel.CROWDED),
-                eq(RecalculationTriggerType.LEVEL_UP), eq("CCTV_001"), anyDouble());
-        verify(routeRecalculationService).trigger(eq(session), eq(edgeB), eq(CongestionLevel.CROWDED),
+        verify(routeRecalculationService).trigger(eq(session), eq(List.of(edgeA, edgeB)),
+                eq(CongestionLevel.CROWDED),
                 eq(RecalculationTriggerType.LEVEL_UP), eq("CCTV_001"), anyDouble());
         verify(trainingEventPublisher, times(1)).publishCongestionUpdated(
                 eq(sessionId), eq(expectedEdgeIds), any());

--- a/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceIntegrationTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/graph/service/MapGraphServiceIntegrationTest.java
@@ -55,7 +55,7 @@ class MapGraphServiceIntegrationTest {
         floor.updateSegmentationStatus(SegmentationStatus.DONE);
         floor.upload(10.0, 10.0, "floors/test-map.png");
         floorRepository.save(floor);
-        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(0.5));
+        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(50.0));
 
         MapNode stair = mapNodeJpaRepository.save(
                 MapNode.create(floor, "STAIR_A", NodeType.STAIR, "계단A", 0.3, 0.3, false));

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -48,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -95,9 +97,13 @@ class RouteRecalculationServiceTest {
     @BeforeEach
     void setUp() {
         session = mock(TrainingSession.class);
-        org.mockito.Mockito.lenient().when(session.getId()).thenReturn(UUID.randomUUID());
-        org.mockito.Mockito.lenient().when(trainingSessionRepository.findByIdForUpdate(session.getId()))
+        UUID sessionId = UUID.randomUUID();
+        org.mockito.Mockito.lenient().when(session.getId()).thenReturn(sessionId);
+        org.mockito.Mockito.lenient().when(trainingSessionRepository.findByIdForUpdate(sessionId))
                 .thenReturn(Optional.of(session));
+        org.mockito.Mockito.lenient().when(routeRecalculationRepository
+                .findTrainingSessionIdByIdAndSchoolName(any(), any()))
+                .thenReturn(Optional.of(sessionId));
         org.mockito.Mockito.lenient().when(schoolContextService.getSchoolName(MANAGER_EMAIL))
                 .thenReturn(SCHOOL_NAME);
 
@@ -436,6 +442,12 @@ class RouteRecalculationServiceTest {
         assertThat(recalculation.getResolvedBy()).isEqualTo(manager);
         verify(trainingEventPublisher, times(1)).publishEvacuationRouteUpdatedAfterCommit(recalculation);
         verify(ioTLightService, times(1)).applyRouteGuidance(recalculation.getRecalculatedNodeIds());
+        InOrder approvalOrder = inOrder(routeRecalculationRepository, trainingSessionRepository);
+        approvalOrder.verify(routeRecalculationRepository)
+                .findTrainingSessionIdByIdAndSchoolName(recalculation.getId(), SCHOOL_NAME);
+        approvalOrder.verify(trainingSessionRepository).findByIdForUpdate(session.getId());
+        approvalOrder.verify(routeRecalculationRepository)
+                .findByIdAndTrainingSession_Scenario_Building_SchoolName(recalculation.getId(), SCHOOL_NAME);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
+++ b/src/test/java/com/saferoute/domain/evacuation/recalculation/service/RouteRecalculationServiceTest.java
@@ -96,6 +96,8 @@ class RouteRecalculationServiceTest {
     void setUp() {
         session = mock(TrainingSession.class);
         org.mockito.Mockito.lenient().when(session.getId()).thenReturn(UUID.randomUUID());
+        org.mockito.Mockito.lenient().when(trainingSessionRepository.findByIdForUpdate(session.getId()))
+                .thenReturn(Optional.of(session));
         org.mockito.Mockito.lenient().when(schoolContextService.getSchoolName(MANAGER_EMAIL))
                 .thenReturn(SCHOOL_NAME);
 
@@ -118,8 +120,8 @@ class RouteRecalculationServiceTest {
     }
 
     private void givenNoExistingPending() {
-        given(routeRecalculationRepository.findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-                any(), any(), any())).willReturn(Optional.empty());
+        given(routeRecalculationRepository.findAllByTrainingSession_IdAndStatus(
+                any(), any())).willReturn(List.of());
     }
 
     @Test
@@ -138,8 +140,8 @@ class RouteRecalculationServiceTest {
     }
 
     private void givenNoApprovedHistory() {
-        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
-                any(), any(), any())).willReturn(Optional.empty());
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                any(), any())).willReturn(Optional.empty());
     }
 
     private void givenNoDirectRoute() {
@@ -148,14 +150,13 @@ class RouteRecalculationServiceTest {
     }
 
     @Test
-    @DisplayName("같은 세션+엣지에 이미 같은 레벨의 PENDING이 있으면 새로 트리거하지 않는다")
+    @DisplayName("같은 세션+CCTV에 이미 같은 레벨의 PENDING이 있으면 새로 트리거하지 않는다")
     void trigger_skipsWhenSameLevelPendingExists() {
         RouteRecalculation existing = pendingRecalculation(CongestionLevel.CROWDED);
-        given(routeRecalculationRepository.findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-                session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING))
-                .willReturn(Optional.of(existing));
+        given(routeRecalculationRepository.findAllByTrainingSession_IdAndStatus(
+                session.getId(), RecalculationStatus.PENDING)).willReturn(List.of(existing));
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+        routeRecalculationService.trigger(session, List.of(triggerEdge), CongestionLevel.CROWDED,
                 RecalculationTriggerType.LEVEL_UP, "CCTV_001", 3.5);
 
         verify(evacuationRouteService, never()).findShortestRoute(any(), any(), anySet());
@@ -166,15 +167,14 @@ class RouteRecalculationServiceTest {
     @DisplayName("레벨이 바뀌었으면 기존 PENDING을 CANCELLED로 무효화하고 새로 계산한다")
     void trigger_cancelsAndRecreatesWhenLevelChanges() {
         RouteRecalculation existing = pendingRecalculation(CongestionLevel.CROWDED);
-        given(routeRecalculationRepository.findByTrainingSession_IdAndTriggerEdge_IdAndStatus(
-                session.getId(), triggerEdge.getId(), RecalculationStatus.PENDING))
-                .willReturn(Optional.of(existing));
+        given(routeRecalculationRepository.findAllByTrainingSession_IdAndStatus(
+                session.getId(), RecalculationStatus.PENDING)).willReturn(List.of(existing));
         givenNoApprovedHistory();
         givenNoDirectRoute();
         given(evacuationRouteService.findShortestRoute(any(), any(), anySet(), any()))
                 .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.VERY_CROWDED,
+        routeRecalculationService.trigger(session, List.of(triggerEdge), CongestionLevel.VERY_CROWDED,
                 RecalculationTriggerType.LEVEL_UP, "CCTV_001", 5.5);
 
         assertThat(existing.getStatus()).isEqualTo(RecalculationStatus.CANCELLED);
@@ -190,7 +190,7 @@ class RouteRecalculationServiceTest {
         given(evacuationRouteService.findShortestRoute(any(), any(), anySet(), any()))
                 .willThrow(new ApiException(EvacuationErrorCode.EVACUATION_ROUTE_NOT_FOUND));
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+        routeRecalculationService.trigger(session, List.of(triggerEdge), CongestionLevel.CROWDED,
                 RecalculationTriggerType.STARTED, "CCTV_001", 3.5);
 
         verify(routeRecalculationRepository, never()).save(any());
@@ -198,8 +198,8 @@ class RouteRecalculationServiceTest {
     }
 
     @Test
-    @DisplayName("VERY_CROWDED면 트리거 엣지를 완전히 제외하고 우회 경로를 계산한다")
-    void trigger_veryCrowded_excludesTriggerEdgeEntirely() {
+    @DisplayName("VERY_CROWDED면 CCTV 영향 엣지를 모두 제외하고 우회 경로를 한 번 계산한다")
+    void trigger_veryCrowded_excludesAllAffectedEdges() {
         givenNoExistingPending();
         givenNoApprovedHistory();
         givenNoDirectRoute();
@@ -211,15 +211,17 @@ class RouteRecalculationServiceTest {
 
         RouteRecalculation saved = pendingRecalculation(CongestionLevel.VERY_CROWDED);
         given(routeRecalculationRepository.save(any())).willReturn(saved);
+        MapEdge secondEdge = MapEdge.create(triggerEdge.getFloor(), mock(MapNode.class), mock(MapNode.class), 4.0, true);
+        ReflectionTestUtils.setField(secondEdge, "id", UUID.randomUUID());
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.VERY_CROWDED,
+        routeRecalculationService.trigger(session, List.of(triggerEdge, secondEdge), CongestionLevel.VERY_CROWDED,
                 RecalculationTriggerType.STARTED, "CCTV_001", 5.5);
 
         ArgumentCaptor<Set<UUID>> excludedEdgesCaptor = ArgumentCaptor.forClass(Set.class);
         ArgumentCaptor<Map<UUID, Double>> multipliersCaptor = ArgumentCaptor.forClass(Map.class);
         verify(evacuationRouteService).findShortestRoute(
                 any(), any(), excludedEdgesCaptor.capture(), multipliersCaptor.capture());
-        assertThat(excludedEdgesCaptor.getValue()).containsExactly(triggerEdge.getId());
+        assertThat(excludedEdgesCaptor.getValue()).containsExactlyInAnyOrder(triggerEdge.getId(), secondEdge.getId());
         assertThat(multipliersCaptor.getValue()).isEmpty();
 
         verify(routeRecalculationRepository, times(1)).save(any());
@@ -227,8 +229,8 @@ class RouteRecalculationServiceTest {
     }
 
     @Test
-    @DisplayName("CROWDED면 트리거 엣지를 제외하지 않고 3배 가중치만 줘서 후보에 남긴다")
-    void trigger_crowded_appliesWeightMultiplierInsteadOfExcluding() {
+    @DisplayName("CROWDED면 CCTV 영향 엣지 모두에 3배 가중치를 주고 후보에 남긴다")
+    void trigger_crowded_appliesWeightMultiplierToAllAffectedEdges() {
         givenNoExistingPending();
         givenNoApprovedHistory();
         givenNoDirectRoute();
@@ -240,8 +242,10 @@ class RouteRecalculationServiceTest {
 
         RouteRecalculation saved = pendingRecalculation(CongestionLevel.CROWDED);
         given(routeRecalculationRepository.save(any())).willReturn(saved);
+        MapEdge secondEdge = MapEdge.create(triggerEdge.getFloor(), mock(MapNode.class), mock(MapNode.class), 4.0, true);
+        ReflectionTestUtils.setField(secondEdge, "id", UUID.randomUUID());
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+        routeRecalculationService.trigger(session, List.of(triggerEdge, secondEdge), CongestionLevel.CROWDED,
                 RecalculationTriggerType.STARTED, "CCTV_001", 3.5);
 
         ArgumentCaptor<Set<UUID>> excludedEdgesCaptor = ArgumentCaptor.forClass(Set.class);
@@ -250,6 +254,7 @@ class RouteRecalculationServiceTest {
                 any(), any(), excludedEdgesCaptor.capture(), multipliersCaptor.capture());
         assertThat(excludedEdgesCaptor.getValue()).isEmpty();
         assertThat(multipliersCaptor.getValue()).containsEntry(triggerEdge.getId(), 3.0);
+        assertThat(multipliersCaptor.getValue()).containsEntry(secondEdge.getId(), 3.0);
 
         verify(routeRecalculationRepository, times(1)).save(any());
         verify(trainingEventPublisher, times(1)).publishRouteRecalculationRequestedAfterCommit(saved);
@@ -261,8 +266,8 @@ class RouteRecalculationServiceTest {
         givenNoExistingPending();
         UUID sharedNodeId = UUID.randomUUID();
         RouteRecalculation approvedDetour = approvedRecalculation(List.of(sharedNodeId), 20.0);
-        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
-                session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED))
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                session.getId(), RecalculationStatus.APPROVED))
                 .willReturn(Optional.of(approvedDetour));
 
         MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
@@ -270,7 +275,7 @@ class RouteRecalculationServiceTest {
         EvacuationRoute candidateRoute = new EvacuationRoute(List.of(exitNode), 20.0);
         given(evacuationRouteService.findShortestRoute(any(), any(), anySet(), any())).willReturn(candidateRoute);
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+        routeRecalculationService.trigger(session, List.of(triggerEdge), CongestionLevel.CROWDED,
                 RecalculationTriggerType.LEVEL_UP, "CCTV_001", 3.5);
 
         verify(routeRecalculationRepository, never()).save(any());
@@ -283,7 +288,7 @@ class RouteRecalculationServiceTest {
         givenNoExistingPending();
         givenNoApprovedHistory();
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.NORMAL,
+        routeRecalculationService.trigger(session, List.of(triggerEdge), CongestionLevel.NORMAL,
                 RecalculationTriggerType.ENDED, "CCTV_001", 1.0);
 
         verify(routeRecalculationRepository, never()).save(any());
@@ -295,8 +300,8 @@ class RouteRecalculationServiceTest {
     void trigger_ended_createsRecoveryCandidateWhenApprovedDetourExists() {
         givenNoExistingPending();
         RouteRecalculation approvedDetour = approvedRecalculation(List.of(UUID.randomUUID()), 20.0);
-        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
-                session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED))
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                session.getId(), RecalculationStatus.APPROVED))
                 .willReturn(Optional.of(approvedDetour));
 
         MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
@@ -307,7 +312,7 @@ class RouteRecalculationServiceTest {
         RouteRecalculation saved = pendingRecalculation(CongestionLevel.NORMAL);
         given(routeRecalculationRepository.save(any())).willReturn(saved);
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.NORMAL,
+        routeRecalculationService.trigger(session, List.of(triggerEdge), CongestionLevel.NORMAL,
                 RecalculationTriggerType.ENDED, "CCTV_001", 1.0);
 
         verify(routeRecalculationRepository, times(1)).save(any());
@@ -320,8 +325,8 @@ class RouteRecalculationServiceTest {
         givenNoExistingPending();
         UUID sharedNodeId = UUID.randomUUID();
         RouteRecalculation approvedDetour = approvedRecalculation(List.of(sharedNodeId), 20.0);
-        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndTriggerEdge_IdAndStatusOrderByResolvedAtDesc(
-                session.getId(), triggerEdge.getId(), RecalculationStatus.APPROVED))
+        given(routeRecalculationRepository.findFirstByTrainingSession_IdAndStatusOrderByResolvedAtDesc(
+                session.getId(), RecalculationStatus.APPROVED))
                 .willReturn(Optional.of(approvedDetour));
 
         MapNode exitNode = MapNode.create(mock(Floor.class), "STAIR1", NodeType.STAIR, "STAIR1", 0, 0, true);
@@ -329,7 +334,7 @@ class RouteRecalculationServiceTest {
         EvacuationRoute directRoute = new EvacuationRoute(List.of(exitNode), 20.0);
         given(evacuationRouteService.findShortestRoute(floorId, startNodeId)).willReturn(directRoute);
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.NORMAL,
+        routeRecalculationService.trigger(session, List.of(triggerEdge), CongestionLevel.NORMAL,
                 RecalculationTriggerType.ENDED, "CCTV_001", 1.0);
 
         verify(routeRecalculationRepository, never()).save(any());
@@ -431,6 +436,27 @@ class RouteRecalculationServiceTest {
         assertThat(recalculation.getResolvedBy()).isEqualTo(manager);
         verify(trainingEventPublisher, times(1)).publishEvacuationRouteUpdatedAfterCommit(recalculation);
         verify(ioTLightService, times(1)).applyRouteGuidance(recalculation.getRecalculatedNodeIds());
+    }
+
+    @Test
+    @DisplayName("경로를 승인하면 같은 세션의 다른 PENDING 제안을 취소한다")
+    void approve_cancelsSiblingPendingRecalculations() {
+        RouteRecalculation approved = pendingRecalculation(CongestionLevel.CROWDED);
+        RouteRecalculation sibling = pendingRecalculation(CongestionLevel.CROWDED);
+        given(routeRecalculationRepository
+                .findByIdAndTrainingSession_Scenario_Building_SchoolName(approved.getId(), SCHOOL_NAME))
+                .willReturn(Optional.of(approved));
+        given(routeRecalculationRepository.findAllByTrainingSession_IdAndStatus(
+                session.getId(), RecalculationStatus.PENDING)).willReturn(List.of(approved, sibling));
+        User manager = mock(User.class);
+        given(userRepository.findByEmail(MANAGER_EMAIL)).willReturn(Optional.of(manager));
+
+        routeRecalculationService.approve(approved.getId(), MANAGER_EMAIL);
+
+        assertThat(approved.getStatus()).isEqualTo(RecalculationStatus.APPROVED);
+        assertThat(sibling.getStatus()).isEqualTo(RecalculationStatus.CANCELLED);
+        assertThat(sibling.getCancelReason()).isEqualTo("다른 경로 승인으로 무효화됨");
+        verify(trainingEventPublisher).publishRouteRecalculationCancelledAfterCommit(sibling);
     }
 
     @Test
@@ -603,7 +629,7 @@ class RouteRecalculationServiceTest {
         givenNoExistingPending();
         given(scenario.getStartNode()).willReturn(null);
 
-        routeRecalculationService.trigger(session, triggerEdge, CongestionLevel.CROWDED,
+        routeRecalculationService.trigger(session, List.of(triggerEdge), CongestionLevel.CROWDED,
                 RecalculationTriggerType.STARTED, "CCTV_001", 3.5);
 
         verify(routeRecalculationRepository, never()).save(any());

--- a/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
+++ b/src/test/java/com/saferoute/domain/floor/service/FloorServiceTest.java
@@ -210,7 +210,7 @@ class FloorServiceTest {
         Building building = mock(Building.class);
         Floor floor = Floor.create(building, 1);
         UploadFloorRequest request = new UploadFloorRequest(
-                1, 4.0, 3.0,
+                1, 400.0, 300.0,
                 new MockMultipartFile("file", "plan.png", "image/png", new byte[]{1, 2, 3}));
 
         given(schoolContextService.getSchoolName(EMAIL)).willReturn(SCHOOL_NAME);
@@ -228,5 +228,7 @@ class FloorServiceTest {
         then(mapEdgeRepository).should().deleteAllByFloor(floor);
         then(mapNodeRepository).should().deleteAllByFloor(floor);
         assertThat(floor.getMapImageKey()).isEqualTo("floors/new-plan.png");
+        assertThat(floor.getRealWidth()).isEqualTo(4.0);
+        assertThat(floor.getRealHeight()).isEqualTo(3.0);
     }
 }

--- a/src/test/java/com/saferoute/domain/grid/FloorGridServiceTest.java
+++ b/src/test/java/com/saferoute/domain/grid/FloorGridServiceTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.saferoute.domain.evacuation.graph.entity.MapNode;
 import com.saferoute.domain.evacuation.graph.entity.NodeType;
 import com.saferoute.global.api.exception.ApiException;
+import com.saferoute.global.api.error.GridErrorCode;
 
 @SpringBootTest
 @Transactional // 테스트마다 롤백
@@ -131,8 +132,27 @@ class FloorGridServiceTest {
     void createGrid_throwsWhenCellSizeTooSmall() {
         assertThatThrownBy(() ->
                 floorGridService.createOrRegenerateGrid(floor.getId(),
-                        new CreateOrUpdateFloorGridRequest(0.01))
-        ).isInstanceOf(ApiException.class);
+                        new CreateOrUpdateFloorGridRequest(0.1))
+        ).isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", GridErrorCode.TOO_MANY_GRID_CELLS);
+    }
+
+    @Test
+    void createGrid_rejectsNonFiniteCellSize() {
+        assertThatThrownBy(() ->
+                floorGridService.createOrRegenerateGrid(floor.getId(),
+                        new CreateOrUpdateFloorGridRequest(Double.POSITIVE_INFINITY))
+        ).isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", GridErrorCode.INVALID_CELL_SIZE);
+    }
+
+    @Test
+    void createGrid_rejectsCellSizeBelowMinimum() {
+        assertThatThrownBy(() ->
+                floorGridService.createOrRegenerateGrid(floor.getId(),
+                        new CreateOrUpdateFloorGridRequest(0.09))
+        ).isInstanceOf(ApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", GridErrorCode.INVALID_CELL_SIZE);
     }
 
     @Test

--- a/src/test/java/com/saferoute/domain/grid/FloorGridServiceTest.java
+++ b/src/test/java/com/saferoute/domain/grid/FloorGridServiceTest.java
@@ -68,7 +68,7 @@ class FloorGridServiceTest {
     @Test
     void createGrid_calculatesCorrectRowAndColumnCount() {
         var response = floorGridService.createOrRegenerateGrid(
-                floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+                floor.getId(), new CreateOrUpdateFloorGridRequest(100.0));
 
         assertThat(response.rows()).isEqualTo(30);   // ceil(30 / 1.0)
         assertThat(response.columns()).isEqualTo(40); // ceil(40 / 1.0)
@@ -86,7 +86,7 @@ class FloorGridServiceTest {
         mapNodeRepository.save(cctv);
         mapNodeRepository.save(light);
 
-        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(100.0));
 
         assertThat(mapNodeRepository.findById(cctv.getId())).isEmpty();
         assertThat(mapNodeRepository.findById(light.getId())).isPresent();
@@ -97,7 +97,7 @@ class FloorGridServiceTest {
         UserZone zone = UserZone.create(floor, "3층 앞 복도");
         userZoneRepository.save(zone);
 
-        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(100.0));
 
         assertThat(userZoneRepository.findAllByFloor_Id(floor.getId())).isEmpty();
     }
@@ -107,7 +107,7 @@ class FloorGridServiceTest {
         MapNode stair = MapNode.create(floor, "stair_1", NodeType.STAIR, "계단", 0.1, 0.1, false);
         mapNodeRepository.save(stair);
 
-        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(100.0));
 
         var mapping = nodeGridCellRepository.findByNode_Id(stair.getId());
         assertThat(mapping).isPresent();
@@ -123,7 +123,7 @@ class FloorGridServiceTest {
 
         assertThatThrownBy(() ->
                 floorGridService.createOrRegenerateGrid(pendingFloor.getId(),
-                        new CreateOrUpdateFloorGridRequest(1.0))
+                        new CreateOrUpdateFloorGridRequest(100.0))
         ).isInstanceOf(ApiException.class);
     }
 
@@ -131,13 +131,13 @@ class FloorGridServiceTest {
     void createGrid_throwsWhenCellSizeTooSmall() {
         assertThatThrownBy(() ->
                 floorGridService.createOrRegenerateGrid(floor.getId(),
-                        new CreateOrUpdateFloorGridRequest(0.0001))
+                        new CreateOrUpdateFloorGridRequest(0.01))
         ).isInstanceOf(ApiException.class);
     }
 
     @Test
     void createGrid_persistsGridConfigToDatabase() {
-        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+        floorGridService.createOrRegenerateGrid(floor.getId(), new CreateOrUpdateFloorGridRequest(100.0));
 
         Floor reloaded = floorRepository.findById(floor.getId()).orElseThrow();
         assertThat(reloaded.getGridCellSizeMeter()).isEqualTo(1.0);
@@ -148,7 +148,7 @@ class FloorGridServiceTest {
     @Test
     void remapGraphToExistingGrid_mapsNodesAndEdgesCreatedAfterGrid() {
         floorGridService.createOrRegenerateGrid(
-                floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+                floor.getId(), new CreateOrUpdateFloorGridRequest(100.0));
 
         MapNode from = mapNodeRepository.save(
                 MapNode.create(floor, "hallway_a", NodeType.HALLWAY, "복도 A", 0.1, 0.5, false));
@@ -169,7 +169,7 @@ class FloorGridServiceTest {
     @Test
     void getGridCells_returnsRequestedPageOnly() {
         floorGridService.createOrRegenerateGrid(
-                floor.getId(), new CreateOrUpdateFloorGridRequest(1.0));
+                floor.getId(), new CreateOrUpdateFloorGridRequest(100.0));
 
         var firstPage = floorGridService.getGridCells(floor.getId(), 0, 100);
 


### PR DESCRIPTION
## 관련 이슈 및 작업 브랜치

- Closes #237 
- Branch: fix/#237

## 주요 내용
## 변경 사항

### 1. 센티미터 입력값을 미터로 변환

프론트에서 도면과 그리드 크기를 센티미터 단위로 전달하는 계약에 맞춰 요청 필드를 변경했습니다.

- `realWidth` → `realWidthCm`
- `realHeight` → `realHeightCm`
- `cellSizeMeter` → `cellSizeCm`

백엔드 요청 경계에서 cm 값을 m로 변환하며, DB와 도메인 내부 계산 단위는 기존처럼 미터로 유지합니다.

```java
double realWidthMeter = realWidthCm / 100.0;
double realHeightMeter = realHeightCm / 100.0;
double cellSizeMeter = cellSizeCm / 100.0;
```

이에 따라 다음 값은 계속 기존 단위를 사용합니다.

- `Floor.realWidth`: m
- `Floor.realHeight`: m
- `Floor.gridCellSizeMeter`: m
- `monitoredAreaM2`: ㎡
- `density`: 명/㎡

Swagger 설명과 관련 테스트도 변경된 요청 단위에 맞게 수정했습니다.

### 2. 동일 CCTV의 경로 변경 제안 중복 생성 방지

기존에는 CCTV 감시 영역이 여러 MapEdge와 겹칠 경우 각 Edge마다 독립적인 재탐색 요청을 생성했습니다.

이 때문에 제안 하나를 승인해 경로가 변경된 이후에도 같은 CCTV 이벤트에서 생성된 다른 `PENDING` 제안이 계속 노출될 수 있었습니다.

다음과 같이 변경했습니다.

- CCTV 이벤트의 모든 영향 Edge를 한 번에 전달
- 영향 Edge 전체에 혼잡 가중치 또는 제외 조건 적용
- CCTV 이벤트 한 건당 후보 경로 하나만 생성
- 현재 활성 경로를 트리거 Edge별 경로가 아닌 세션 전체의 최신 승인 경로로 조회
- 후보 경로가 현재 활성 경로와 같으면 제안 미생성
- 경로 승인 시 같은 세션의 다른 `PENDING` 제안을 `CANCELLED` 처리
- 동시 혼잡 이벤트에서도 세션당 대기 제안이 중복되지 않도록 훈련 세션 비관적 잠금 적용

## 변경 전

1. CCTV 한 대가 여러 Edge와 매핑됨
2. Edge마다 별도의 경로 변경 제안 생성
3. 관리자가 제안 하나를 승인
4. 동일 이벤트에서 생성된 나머지 `PENDING` 제안이 계속 노출됨
5. Edge별 과거 승인 경로를 기준으로 새로운 제안이 다시 생성될 수 있음

## 변경 후

1. CCTV 한 대의 모든 영향 Edge를 한 번에 수집
2. 영향 Edge 전체를 반영하여 후보 경로 하나 계산
3. 세션 전체 최신 승인 경로와 후보 경로 비교
4. 실제 경로 변경이 필요한 경우에만 제안 하나 생성
5. 승인 시 기존 대기 제안 일괄 무효화

## API 변경 사항

### 도면 업로드

기존:

```text
realWidth
realHeight
```

변경:

```text
realWidthCm
realHeightCm
```

### 그리드 생성 및 재생성

기존:

```json
{
  "cellSizeMeter": 0.5
}
```

변경:

```json
{
  "cellSizeCm": 50
}
```

프론트 연동 코드에서도 변경된 요청 필드명을 반영해야 합니다.

## 테스트

다음 항목을 검증했습니다.

- cm 입력값이 m로 변환되어 저장되는지 확인
- 그리드 셀 크기 변환 후 행·열 및 셀 개수가 기존과 동일한지 확인
- CCTV의 여러 영향 Edge가 재탐색 요청 하나로 전달되는지 확인
- `VERY_CROWDED`일 때 모든 영향 Edge가 제외되는지 확인
- `CROWDED`일 때 모든 영향 Edge에 가중치가 적용되는지 확인
- 승인된 세션 전체 최신 경로가 현재 경로로 사용되는지 확인
- 경로 승인 시 같은 세션의 다른 `PENDING` 제안이 취소되는지 확인
- 영향 Edge가 없을 때 재탐색을 호출하지 않는지 확인
- 전체 테스트 통과

```text
BUILD SUCCESSFUL
```

## 커밋

- `31eb6ed fix(building) #237: 센티미터 입력을 미터로 변환`
- `486f691 fix(evacuation) #237: 중복 경로 변경 제안 방지`

## 참고

백엔드의 `density` 값은 퍼센트가 아니라 `PERSON_PER_SQUARE_METER`, 즉 명/㎡ 단위입니다.

화면의 `5600% 밀집도 감지` 표시는 프론트에서 `density`에 100을 곱하거나 `%`를 붙이는 로직을 제거하고 다음과 같이 표시해야 합니다.

```text
CCTV_121 · 56명/㎡ 밀집도 감지
```

## ✅ Check List

- [x] 테스트 통과
- [x] ./gradlew build 성공
- [x] Reviewers를 등록했나요?
- [ ] CI가 정상적으로 작동하는지 확인했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 혼잡 상황으로 인한 경로 재계산이 여러 영향 구간을 한 번에 반영하도록 개선되어, 반복 알림과 중복 재계산이 줄어듭니다.
  - 동일 훈련 세션에서 최신 재계산 요청과 승인 상태가 일관되게 관리됩니다.
  - 도면 실제 크기와 그리드 셀 크기 입력 단위가 센티미터로 명확해졌으며, 시스템이 미터 단위로 자동 변환합니다.

- **문서**
  - 도면 업로드 및 그리드 생성 API 설명에 입력 단위와 변환 방식이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->